### PR TITLE
Resources withouth a platform + better error handling

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -89,13 +89,6 @@ from serialization import (
 
 class Example(ExampleBase, table=True):  # type: ignore [call-arg]
     __tablename__ = "example"
-    __table_args__ = (
-        UniqueConstraint(
-            "string_field",
-            "int_field",
-            name="example_string_int_unique",  # A unique constraint on multiple columns
-        ),
-    )
 
     identifier: int = Field(primary_key=True, foreign_key="ai_asset.identifier")
 

--- a/src/database/model/dataset/dataset.py
+++ b/src/database/model/dataset/dataset.py
@@ -74,13 +74,14 @@ class DatasetBase(Resource):
 
 class Dataset(DatasetBase, table=True):  # type: ignore [call-arg]
     __tablename__ = "dataset"
+
     __table_args__ = Resource.__table_args__ + (
         UniqueConstraint(
             "name",
             "version",
-            name="There already exists an item with the same name and version.",
+            name="same_name_and_version",
         ),
-    )  # type: ignore [assignment]
+    )
 
     identifier: int = Field(primary_key=True, foreign_key="ai_asset.identifier")
 

--- a/src/database/model/dataset/dataset.py
+++ b/src/database/model/dataset/dataset.py
@@ -13,11 +13,11 @@ from database.model.dataset.measured_value import (
     MeasuredValue,
 )
 from database.model.dataset.publication_link import DatasetPublicationLink
-from database.model.general.license import License
 from database.model.general.keyword import Keyword
+from database.model.general.license import License
 from database.model.publication.publication import Publication
-from database.model.resource import Resource
 from database.model.relationships import ResourceRelationshipList, ResourceRelationshipSingle
+from database.model.resource import Resource
 from serialization import (
     AttributeSerializer,
     FindByNameDeserializer,
@@ -74,13 +74,13 @@ class DatasetBase(Resource):
 
 class Dataset(DatasetBase, table=True):  # type: ignore [call-arg]
     __tablename__ = "dataset"
-    __table_args__ = (
+    __table_args__ = Resource.__table_args__ + (
         UniqueConstraint(
             "name",
             "version",
-            name="dataset_name_version_unique",
+            name="There already exists an item with the same name and version.",
         ),
-    )
+    )  # type: ignore [assignment]
 
     identifier: int = Field(primary_key=True, foreign_key="ai_asset.identifier")
 

--- a/src/database/model/dataset/measured_value.py
+++ b/src/database/model/dataset/measured_value.py
@@ -31,7 +31,7 @@ class MeasuredValueORM(MeasuredValue, table=True):  # type: ignore [call-arg]
         UniqueConstraint(
             "variable",
             "technique",
-            name="There already exists an item with the same variable and technique.",
+            name="same_variable_and_technique",
         ),
     )
     identifier: int | None = Field(primary_key=True)

--- a/src/database/model/dataset/measured_value.py
+++ b/src/database/model/dataset/measured_value.py
@@ -31,7 +31,7 @@ class MeasuredValueORM(MeasuredValue, table=True):  # type: ignore [call-arg]
         UniqueConstraint(
             "variable",
             "technique",
-            name="measuredValue_variable_technique",
+            name="There already exists an item with the same variable and technique.",
         ),
     )
     identifier: int | None = Field(primary_key=True)

--- a/src/database/model/resource.py
+++ b/src/database/model/resource.py
@@ -2,6 +2,7 @@ from typing import Type, Tuple
 
 from pydantic import create_model
 from sqlalchemy import CheckConstraint
+from sqlalchemy.util import classproperty
 from sqlmodel import SQLModel, Field, UniqueConstraint
 from sqlmodel.main import FieldInfo
 
@@ -29,17 +30,19 @@ class Resource(SQLModel):
         schema_extra={"example": "1"},
     )
 
-    __table_args__ = (
-        UniqueConstraint(
-            "platform",
-            "platform_identifier",
-            name="There already exists an item with the same platform and platform_identifier.",
-        ),
-        CheckConstraint(
-            "(platform IS NULL) <> (platform_identifier IS NOT NULL)",
-            name="If platform is NULL, platform_identifier should also be NULL, and vice versa.",
-        ),
-    )
+    @classproperty
+    def __table_args__(cls) -> Tuple:
+        return (
+            UniqueConstraint(
+                "platform",
+                "platform_identifier",
+                name="same_platform_and_platform_identifier",
+            ),
+            CheckConstraint(
+                "(platform IS NULL) <> (platform_identifier IS NOT NULL)",
+                name=f"{cls.__name__}_platform_and_platform_identifier",
+            ),
+        )
 
 
 def _get_relationships(resource_class: Type[SQLModel]) -> dict[str, ResourceRelationshipInfo]:

--- a/src/tests/routers/generic/test_router_post.py
+++ b/src/tests/routers/generic/test_router_post.py
@@ -25,23 +25,6 @@ def test_unicode(client_test_resource: TestClient, title: str, mocked_privileged
     assert response_json["title"] == title
 
 
-def test_duplicated_resource(client_test_resource: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.decode_token = mocked_privileged_token
-    body = {"title": "title", "platform": "example", "platform_identifier": "1"}
-    response = client_test_resource.post(
-        "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
-    )
-    assert response.status_code == 200
-    response = client_test_resource.post(
-        "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
-    )
-    assert response.status_code == 409
-    assert (
-        response.json()["detail"] == "There already exists a test_resource with the same platform "
-        "and name, with identifier=1."
-    )
-
-
 def test_missing_value(client_test_resource: TestClient, mocked_privileged_token: Mock):
     keycloak_openid.decode_token = mocked_privileged_token
     body = {"platform": "example", "platform_identifier": "1"}
@@ -68,3 +51,75 @@ def test_null_value(client_test_resource: TestClient, mocked_privileged_token: M
             "type": "type_error.none.not_allowed",
         }
     ]
+
+
+def test_posting_same_item_twice(client_test_resource: TestClient, mocked_privileged_token: Mock):
+    keycloak_openid.decode_token = mocked_privileged_token
+    headers = {"Authorization": "Fake token"}
+    body = {"title": "title1", "platform": "example", "platform_identifier": "1"}
+    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    assert response.status_code == 200
+    body = {"title": "title2", "platform": "example", "platform_identifier": "1"}
+    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    assert response.status_code == 409
+    assert (
+        response.json()["detail"] == "There already exists a test_resource with the same "
+        "platform and platform_identifier, with identifier=1."
+    )
+
+
+def test_no_platform_no_platform_identifier(
+    client_test_resource: TestClient, mocked_privileged_token: Mock
+):
+    keycloak_openid.decode_token = mocked_privileged_token
+    headers = {"Authorization": "Fake token"}
+    body = {"title": "title1", "platform": None, "platform_identifier": None}
+    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    assert response.status_code == 200
+    body = {"title": "title2", "platform": None, "platform_identifier": None}
+    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    assert response.status_code == 200
+
+
+def test_no_platform_with_platform_identifier(
+    client_test_resource: TestClient, mocked_privileged_token: Mock
+):
+    keycloak_openid.decode_token = mocked_privileged_token
+    headers = {"Authorization": "Fake token"}
+    body = {"title": "title1", "platform": None, "platform_identifier": "1"}
+    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"] == "If platform is NULL, platform_identifier should also be "
+        "NULL, and vice versa."
+    )
+
+
+def test_platform_with_no_platform_identifier(
+    client_test_resource: TestClient, mocked_privileged_token: Mock
+):
+    keycloak_openid.decode_token = mocked_privileged_token
+    headers = {"Authorization": "Fake token"}
+    body = {"title": "title1", "platform": "example", "platform_identifier": None}
+    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"] == "If platform is NULL, platform_identifier should also be "
+        "NULL, and vice versa."
+    )
+
+
+def test_same_title_twice(client_test_resource: TestClient, mocked_privileged_token: Mock):
+    keycloak_openid.decode_token = mocked_privileged_token
+    keycloak_openid.public_key = Mock(return_value="")
+    headers = {"Authorization": "Fake token"}
+    body = {"title": "title1", "platform": None, "platform_identifier": None}
+    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    assert response.status_code == 200
+    body = {"title": "title1", "platform": None, "platform_identifier": None}
+    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    assert response.status_code == 409
+    assert (
+        response.json()["detail"] == "There already exists a test_resource with the same title, "
+        "with identifier=1."
+    )

--- a/src/tests/routers/generic/test_router_put.py
+++ b/src/tests/routers/generic/test_router_put.py
@@ -68,3 +68,25 @@ def test_too_long_name(
             "type": "value_error.any_str.max_length",
         }
     ]
+
+
+def test_no_platform_with_platform_identifier(
+    client_test_resource: TestClient,
+    engine_test_resource_filled: Engine,
+    mocked_privileged_token: Mock,
+):
+    """
+    The error handling should be the same as with the POST endpoints, so we're not testing all
+    the possible UNIQUE / CHECK constraints here, just this one.
+    """
+    keycloak_openid.decode_token = mocked_privileged_token
+    response = client_test_resource.put(
+        "/test_resources/v0/1",
+        json={"title": "title", "platform": "other", "platform_identifier": None},
+        headers={"Authorization": "Fake token"},
+    )
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"] == "If platform is NULL, platform_identifier should also be "
+        "NULL, and vice versa."
+    )

--- a/src/tests/testutils/test_resource.py
+++ b/src/tests/testutils/test_resource.py
@@ -11,7 +11,7 @@ from routers import ResourceRouter
 
 
 class TestResourceBase(Resource):
-    title: str = Field(max_length=250, nullable=False)
+    title: str = Field(max_length=250, nullable=False, unique=True)
 
 
 class TestResource(TestResourceBase, table=True):  # type: ignore [call-arg]


### PR DESCRIPTION
Testcases to make sure that it's possible to add resources without a platform. This will be interesting for some resources such as the events that are migrated from the CMS, for which no platform is known.

As a bonus, making sure that the error handling is a bit better.