### PR TITLE
Bugfix: fix integrity issues on delete

### DIFF
--- a/src/converters/schema/schema_dot_org.py
+++ b/src/converters/schema/schema_dot_org.py
@@ -74,7 +74,7 @@ class SchemaDotOrgDataset(BaseModel):
     description: str = Field(default=None, description="A description of the item.")
     identifier: str = Field(description="The AIoD identifier")
     maintainer: SchemaDotOrgOrganization = Field(
-        description="The platform on which this dataset is " "found."
+        description="The platform on which this dataset is found."
     )
     alternateName: list[str] | str | None = Field(
         default=None,

--- a/src/database/model/ai_asset.py
+++ b/src/database/model/ai_asset.py
@@ -10,8 +10,8 @@ class AIAsset(SQLModel, table=True):  # type: ignore [call-arg]
     identifier: int = Field(
         default=None,
         primary_key=True,
-        description="The identifier of each asset should be the same as this " "identifier",
+        description="The identifier of each asset should be the same as this identifier",
     )
     type: str = Field(
-        description="The name of the table of the asset. E.g. 'dataset' or " "'publication'"
+        description="The name of the table of the asset. E.g. 'dataset' or 'publication'"
     )

--- a/src/database/model/case_study/alternate_name.py
+++ b/src/database/model/case_study/alternate_name.py
@@ -1,6 +1,7 @@
 from typing import List
 from typing import TYPE_CHECKING
 
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field, Relationship
 
 from database.model.named_relation import NamedRelation
@@ -12,7 +13,11 @@ if TYPE_CHECKING:  # avoid circular imports; only import while type checking
 class CaseStudyAlternateNameLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "case_study_alternate_name_link"
 
-    casestudy_identifier: int = Field(foreign_key="case_study.identifier", primary_key=True)
+    casestudy_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("case_study.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
     alternate_name_identifier: int = Field(
         foreign_key="case_study_alternate_name.identifier", primary_key=True
     )

--- a/src/database/model/case_study/business_category_link.py
+++ b/src/database/model/case_study/business_category_link.py
@@ -1,9 +1,14 @@
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field
 
 
 class CaseStudyBusinessCategoryLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "case_study_business_category_link"
-    case_study_identifier: int = Field(foreign_key="case_study.identifier", primary_key=True)
+    casestudy_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("case_study.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
     business_category_identifier: int = Field(
         foreign_key="business_category.identifier", primary_key=True
     )

--- a/src/database/model/case_study/keyword_link.py
+++ b/src/database/model/case_study/keyword_link.py
@@ -1,7 +1,12 @@
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field
 
 
 class CaseStudyKeywordLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "case_study_keyword_link"
-    case_study_identifier: int = Field(foreign_key="case_study.identifier", primary_key=True)
+    casestudy_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("case_study.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
     keyword_identifier: int = Field(foreign_key="keyword.identifier", primary_key=True)

--- a/src/database/model/case_study/technical_category_link.py
+++ b/src/database/model/case_study/technical_category_link.py
@@ -1,9 +1,14 @@
+from sqlalchemy import Integer, Column, ForeignKey
 from sqlmodel import SQLModel, Field
 
 
 class CaseStudyTechnicalCategoryLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "case_study_technical_category_link"
-    case_study_identifier: int = Field(foreign_key="case_study.identifier", primary_key=True)
+    casestudy_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("case_study.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
     technical_category_identifier: int = Field(
         foreign_key="technical_category.identifier", primary_key=True
     )

--- a/src/database/model/dataset/alternate_name.py
+++ b/src/database/model/dataset/alternate_name.py
@@ -1,6 +1,7 @@
 from typing import List
 from typing import TYPE_CHECKING
 
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field, Relationship
 
 from database.model.named_relation import NamedRelation
@@ -12,8 +13,12 @@ if TYPE_CHECKING:  # avoid circular imports; only import while type checking
 class DatasetAlternateNameLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "dataset_alternate_name_link"
 
-    dataset_identifier: int = Field(foreign_key="dataset.identifier", primary_key=True)
-    alternate_name_identifier: int = Field(
+    dataset_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("dataset.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
+    alternate_name_identifier: int | None = Field(
         foreign_key="dataset_alternate_name.identifier", primary_key=True
     )
 

--- a/src/database/model/dataset/checksum.py
+++ b/src/database/model/dataset/checksum.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import Relationship, SQLModel, Field
 
 from database.model.dataset.checksum_algorithm import ChecksumAlgorithm
@@ -24,7 +25,9 @@ class ChecksumORM(ChecksumBase, table=True):  # type: ignore [call-arg]
     identifier: int | None = Field(primary_key=True)
     algorithm_identifier: int | None = Field(foreign_key="checksum_algorithm.identifier")
     algorithm: ChecksumAlgorithm | None = Relationship(back_populates="checksums")
-    distribution_identifier: int | None = Field(foreign_key="data_download.identifier")
+    distribution_identifier: int | None = Field(
+        sa_column=Column(Integer, ForeignKey("data_download.identifier", ondelete="CASCADE"))
+    )
     distribution: "DataDownloadORM" = Relationship(back_populates="checksum")
 
     class RelationshipConfig:

--- a/src/database/model/dataset/data_download.py
+++ b/src/database/model/dataset/data_download.py
@@ -1,24 +1,25 @@
 from typing import List
 from typing import TYPE_CHECKING
 
-from serialization import CastDeserializer
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field, Relationship
+
 from database.model.dataset.checksum import ChecksumORM, Checksum
 from database.model.relationships import ResourceRelationshipList
+from serialization import CastDeserializer
 
 if TYPE_CHECKING:  # avoid circular imports; only import while type checking
-    from database.model.dataset.dataset import Dataset
+    pass
 
 
 class DataDownloadBase(SQLModel):
     content_url: str = Field(
         max_length=250,
-        unique=True,
         schema_extra={"example": "https://www.example.com/dataset/file.csv"},
     )
     content_size_kb: int | None = Field(schema_extra={"example": 10000})
     description: str | None = Field(
-        max_length=5000, schema_extra={"example": "Description of this " "file."}
+        max_length=5000, schema_extra={"example": "Description of this file."}
     )
     encoding_format: str | None = Field(max_length=255, schema_extra={"example": "text/csv"})
     name: str | None = Field(max_length=150, schema_extra={"example": "Name of this file."})
@@ -29,9 +30,12 @@ class DataDownloadORM(DataDownloadBase, table=True):  # type: ignore [call-arg]
 
     identifier: int | None = Field(primary_key=True)
 
-    dataset_identifier: int | None = Field(foreign_key="dataset.identifier")
-    dataset: "Dataset" = Relationship(back_populates="distributions")
-    checksum: List[ChecksumORM] = Relationship(back_populates="distribution")
+    dataset_identifier: int | None = Field(
+        sa_column=Column(Integer, ForeignKey("dataset.identifier", ondelete="CASCADE"))
+    )
+    checksum: List[ChecksumORM] = Relationship(
+        back_populates="distribution", sa_relationship_kwargs={"cascade": "all, delete"}
+    )
 
     class RelationshipConfig:
         checksum: List[Checksum] = ResourceRelationshipList(

--- a/src/database/model/dataset/data_download.py
+++ b/src/database/model/dataset/data_download.py
@@ -1,5 +1,4 @@
 from typing import List
-from typing import TYPE_CHECKING
 
 from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field, Relationship
@@ -7,9 +6,6 @@ from sqlmodel import SQLModel, Field, Relationship
 from database.model.dataset.checksum import ChecksumORM, Checksum
 from database.model.relationships import ResourceRelationshipList
 from serialization import CastDeserializer
-
-if TYPE_CHECKING:  # avoid circular imports; only import while type checking
-    pass
 
 
 class DataDownloadBase(SQLModel):

--- a/src/database/model/dataset/dataset.py
+++ b/src/database/model/dataset/dataset.py
@@ -111,6 +111,7 @@ class Dataset(DatasetBase, table=True):  # type: ignore [call-arg]
         sa_relationship_kwargs=dict(
             primaryjoin="Dataset.identifier==DatasetParentChildLink.parent_identifier",
             secondaryjoin="Dataset.identifier==DatasetParentChildLink.child_identifier",
+            cascade="all, delete",
         ),
     )
     is_part: List["Dataset"] = Relationship(
@@ -119,6 +120,7 @@ class Dataset(DatasetBase, table=True):  # type: ignore [call-arg]
         sa_relationship_kwargs=dict(
             primaryjoin="Dataset.identifier==DatasetParentChildLink.child_identifier",
             secondaryjoin="Dataset.identifier==DatasetParentChildLink.parent_identifier",
+            cascade="all, delete",
         ),
     )
     keywords: List[Keyword] = Relationship(back_populates="datasets", link_model=DatasetKeywordLink)

--- a/src/database/model/dataset/keyword_link.py
+++ b/src/database/model/dataset/keyword_link.py
@@ -1,7 +1,12 @@
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field
 
 
 class DatasetKeywordLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "dataset_keyword_link"
-    dataset_identifier: int = Field(foreign_key="dataset.identifier", primary_key=True)
+    dataset_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("dataset.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
     keyword_identifier: int = Field(foreign_key="keyword.identifier", primary_key=True)

--- a/src/database/model/dataset/measured_value.py
+++ b/src/database/model/dataset/measured_value.py
@@ -1,7 +1,7 @@
 from typing import List
 from typing import TYPE_CHECKING
 
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import UniqueConstraint, Column, ForeignKey, Integer
 from sqlmodel import SQLModel, Field, Relationship
 
 if TYPE_CHECKING:  # avoid circular imports; only import while type checking
@@ -11,7 +11,11 @@ if TYPE_CHECKING:  # avoid circular imports; only import while type checking
 class DatasetMeasuredValueNameLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "dataset_measured_value_link"
 
-    dataset_identifier: int = Field(foreign_key="dataset.identifier", primary_key=True)
+    dataset_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("dataset.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
     measured_value_identifier: int = Field(
         foreign_key="measured_value.identifier", primary_key=True
     )

--- a/src/database/model/dataset/publication_link.py
+++ b/src/database/model/dataset/publication_link.py
@@ -1,7 +1,12 @@
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field
 
 
 class DatasetPublicationLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "dataset_publication_link"
-    dataset_identifier: int = Field(foreign_key="dataset.identifier", primary_key=True)
+    dataset_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("dataset.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
     publication_identifier: int = Field(foreign_key="publication.identifier", primary_key=True)

--- a/src/database/model/dataset/publication_link.py
+++ b/src/database/model/dataset/publication_link.py
@@ -9,4 +9,8 @@ class DatasetPublicationLink(SQLModel, table=True):  # type: ignore [call-arg]
             Integer, ForeignKey("dataset.identifier", ondelete="CASCADE"), primary_key=True
         )
     )
-    publication_identifier: int = Field(foreign_key="publication.identifier", primary_key=True)
+    publication_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("publication.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )

--- a/src/database/model/educational_resource/business_categories_link.py
+++ b/src/database/model/educational_resource/business_categories_link.py
@@ -1,10 +1,15 @@
+from sqlalchemy import Column, ForeignKey, Integer
 from sqlmodel import SQLModel, Field
 
 
 class EducationalResourceBusinessCategoryLink(SQLModel, table=True):  # type: ignore [call-arg]
-    __tablename__ = "educatioanal_resource_business_category_link"
-    case_study_identifier: int = Field(
-        foreign_key="educational_resource.identifier", primary_key=True
+    __tablename__ = "educational_resource_business_category_link"
+    educational_resource_identifier: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("educational_resource.identifier", ondelete="CASCADE"),
+            primary_key=True,
+        )
     )
     business_category_identifier: int = Field(
         foreign_key="business_category.identifier", primary_key=True

--- a/src/database/model/educational_resource/keyword_link.py
+++ b/src/database/model/educational_resource/keyword_link.py
@@ -1,9 +1,14 @@
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field
 
 
 class EducationalResourceKeywordLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "educational_resource_keyword_link"
     educational_resource_identifier: int = Field(
-        foreign_key="educational_resource.identifier", primary_key=True
+        sa_column=Column(
+            Integer,
+            ForeignKey("educational_resource.identifier", ondelete="CASCADE"),
+            primary_key=True,
+        )
     )
     keyword_identifier: int = Field(foreign_key="keyword.identifier", primary_key=True)

--- a/src/database/model/educational_resource/language_link.py
+++ b/src/database/model/educational_resource/language_link.py
@@ -1,9 +1,14 @@
+from sqlalchemy import Column, ForeignKey, Integer
 from sqlmodel import SQLModel, Field
 
 
 class EducationalResourceLanguageLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "educational_resource_language_link"
     educational_resource_identifier: int = Field(
-        foreign_key="educational_resource.identifier", primary_key=True
+        sa_column=Column(
+            Integer,
+            ForeignKey("educational_resource.identifier", ondelete="CASCADE"),
+            primary_key=True,
+        )
     )
     language_identifier: int = Field(foreign_key="language.identifier", primary_key=True)

--- a/src/database/model/educational_resource/target_audience_link.py
+++ b/src/database/model/educational_resource/target_audience_link.py
@@ -1,7 +1,14 @@
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field
 
 
 class EducationalResourceTargetAudienceLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "educational_resource_target_audience_link"
-    dataset_identifier: int = Field(foreign_key="educational_resource.identifier", primary_key=True)
+    educational_resource_identifier: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("educational_resource.identifier", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
     keyword_identifier: int = Field(foreign_key="target_audience.identifier", primary_key=True)

--- a/src/database/model/educational_resource/technical_categories_link.py
+++ b/src/database/model/educational_resource/technical_categories_link.py
@@ -1,10 +1,15 @@
+from sqlalchemy import Column, ForeignKey, Integer
 from sqlmodel import SQLModel, Field
 
 
 class EducationalResourceTechnicalCategoryLink(SQLModel, table=True):  # type: ignore [call-arg]
-    __tablename__ = "educatioanal_resource_technical_category_link"
-    case_study_identifier: int = Field(
-        foreign_key="educational_resource.identifier", primary_key=True
+    __tablename__ = "educational_resource_technical_category_link"
+    educational_resource_identifier: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("educational_resource.identifier", ondelete="CASCADE"),
+            primary_key=True,
+        )
     )
     technical_category_identifier: int = Field(
         foreign_key="technical_category.identifier", primary_key=True

--- a/src/database/model/event/application_area_link.py
+++ b/src/database/model/event/application_area_link.py
@@ -1,9 +1,14 @@
+from sqlalchemy import Column, ForeignKey, Integer
 from sqlmodel import SQLModel, Field
 
 
 class EventApplicationAreaLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "event_application_area_link"
-    event_identifier: int = Field(foreign_key="event.identifier", primary_key=True)
+    event_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("event.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
     application_area_identifier: int = Field(
         foreign_key="application_area.identifier", primary_key=True
     )

--- a/src/database/model/event/business_category_link.py
+++ b/src/database/model/event/business_category_link.py
@@ -1,9 +1,14 @@
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field
 
 
 class EventBusinessCategoriesLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "event_business_category_link"
-    event_identifier: int = Field(foreign_key="event.identifier", primary_key=True)
+    event_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("event.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
     business_category_identifier: int = Field(
         foreign_key="business_category.identifier", primary_key=True
     )

--- a/src/database/model/event/event.py
+++ b/src/database/model/event/event.py
@@ -50,6 +50,7 @@ class EventBase(Resource):
 
 class Event(EventBase, table=True):  # type: ignore [call-arg]
     __tablename__ = "event"
+
     identifier: int = Field(primary_key=True, foreign_key="ai_asset.identifier")
 
     business_categories: List["BusinessCategory"] = Relationship(
@@ -88,11 +89,11 @@ class Event(EventBase, table=True):  # type: ignore [call-arg]
             deserializer=FindByNameDeserializer(BusinessCategory),
         )
         sub_events: List[int] = ResourceRelationshipList(
-            example=[3, 4],
+            example=[],
             serializer=AttributeSerializer("identifier"),
         )
         super_events: List[int] = ResourceRelationshipList(
-            example=[1, 2],
+            example=[],
             serializer=AttributeSerializer("identifier"),
         )
         research_areas: List[str] = ResourceRelationshipList(
@@ -106,12 +107,12 @@ class Event(EventBase, table=True):  # type: ignore [call-arg]
             example=["application_area1", "application_area2"],
         )
         relevant_resources: List[int] = ResourceRelationshipList(
-            example=[1, 2],
+            example=[],
             serializer=AttributeSerializer("identifier"),
             deserializer=FindByIdentifierDeserializer(AIAsset),
         )
         used_resources: List[int] = ResourceRelationshipList(
-            example=[1, 2],
+            example=[],
             serializer=AttributeSerializer("identifier"),
             deserializer=FindByIdentifierDeserializer(AIAsset),
         )

--- a/src/database/model/event/event.py
+++ b/src/database/model/event/event.py
@@ -69,6 +69,7 @@ class Event(EventBase, table=True):  # type: ignore [call-arg]
         sa_relationship_kwargs=dict(
             primaryjoin="Event.identifier==EventParentChildLink.parent_identifier",
             secondaryjoin="Event.identifier==EventParentChildLink.child_identifier",
+            cascade="all, delete",
         ),
     )
     super_events: List["Event"] = Relationship(
@@ -77,6 +78,7 @@ class Event(EventBase, table=True):  # type: ignore [call-arg]
         sa_relationship_kwargs=dict(
             primaryjoin="Event.identifier==EventParentChildLink.child_identifier",
             secondaryjoin="Event.identifier==EventParentChildLink.parent_identifier",
+            cascade="all, delete",
         ),
     )
     relevant_resources: List["AIAsset"] = Relationship(link_model=EventRelevantResourcesLink)

--- a/src/database/model/event/relevant_resources_link.py
+++ b/src/database/model/event/relevant_resources_link.py
@@ -1,7 +1,16 @@
+from sqlalchemy import Integer, ForeignKey, Column
 from sqlmodel import SQLModel, Field
 
 
 class EventRelevantResourcesLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "event_relevant_resources_link"
-    event_identifier: int = Field(foreign_key="event.identifier", primary_key=True)
-    relevant_resources_identifier: int = Field(foreign_key="ai_asset.identifier", primary_key=True)
+    event_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("event.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
+    relevant_resources_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("ai_asset.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )

--- a/src/database/model/event/research_area_link.py
+++ b/src/database/model/event/research_area_link.py
@@ -1,7 +1,12 @@
+from sqlalchemy import Column, ForeignKey, Integer
 from sqlmodel import SQLModel, Field
 
 
 class EventResearchAreaLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "event_research_area_link"
-    event_identifier: int = Field(foreign_key="event.identifier", primary_key=True)
+    event_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("event.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
     research_area_identifier: int = Field(foreign_key="research_area.identifier", primary_key=True)

--- a/src/database/model/event/used_resources_link.py
+++ b/src/database/model/event/used_resources_link.py
@@ -1,7 +1,16 @@
+from sqlalchemy import Column, ForeignKey, Integer
 from sqlmodel import SQLModel, Field
 
 
 class EventUsedResourcesLink(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "event_used_resources_link"
-    event_identifier: int = Field(foreign_key="event.identifier", primary_key=True)
-    used_resources_identifier: int = Field(foreign_key="ai_asset.identifier", primary_key=True)
+    event_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("event.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )
+    used_resources_identifier: int = Field(
+        sa_column=Column(
+            Integer, ForeignKey("ai_asset.identifier", ondelete="CASCADE"), primary_key=True
+        )
+    )

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -425,6 +425,12 @@ class ResourceRouter(abc.ABC):
                     session.commit()
                 return self._wrap_with_headers(None)
             except Exception as e:
+                if "foreign key" in str(e).lower():  # Should work regardless of db technology
+                    return HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="This resource cannot be deleted, because other resources are "
+                        "related to it.",
+                    )
                 raise _wrap_as_http_exception(e)
 
         return delete_resource

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -513,7 +513,7 @@ class ResourceRouter(abc.ABC):
             ) from e
         if "platform_and_platform_identifier" in error:
             error_msg = (
-                "If platform is NULL, platform_identifier should also be NULL, and vice " "versa."
+                "If platform is NULL, platform_identifier should also be NULL, and vice versa."
             )
         else:
             error_msg = error.split("constraint failed: ")[-1]
@@ -523,15 +523,11 @@ class ResourceRouter(abc.ABC):
 def _wrap_as_http_exception(exception: Exception) -> HTTPException:
     if isinstance(exception, HTTPException):
         return exception
-
-    # This is an unexpected error. A mistake on our part. End users should not be informed about
-    # details of problems they are not expected to fix, so we give a generic response and log the
-    # error.
-    traceback.print_exc()
     return HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail=(
-            "Unexpected exception while processing your request. Please contact the maintainers."
+            "Unexpected exception while processing your request. Please contact the maintainers: "
+            f"{exception}"
         ),
     )
 

--- a/src/tests/routers/generic/test_router_delete.py
+++ b/src/tests/routers/generic/test_router_delete.py
@@ -3,6 +3,7 @@ from sqlmodel import Session
 from starlette.testclient import TestClient
 from sqlalchemy.future import Engine
 
+from database.model import AIAsset
 from tests.testutils.test_resource import TestResource
 from authentication import keycloak_openid
 from unittest.mock import Mock
@@ -20,6 +21,8 @@ def test_happy_path(
     with Session(engine_test_resource) as session:
         session.add_all(
             [
+                AIAsset(type="test_resource"),
+                AIAsset(type="test_resource"),
                 TestResource(title="my_test_resource", platform="example", platform_identifier=1),
                 TestResource(
                     title="second_test_resource", platform="example", platform_identifier=2
@@ -49,6 +52,8 @@ def test_non_existent(
     with Session(engine_test_resource) as session:
         session.add_all(
             [
+                AIAsset(type="test_resource"),
+                AIAsset(type="test_resource"),
                 TestResource(title="my_test_resource", platform="example", platform_identifier=1),
                 TestResource(
                     title="second_test_resource", platform="example", platform_identifier=2

--- a/src/tests/routers/generic/test_router_get_all.py
+++ b/src/tests/routers/generic/test_router_get_all.py
@@ -2,6 +2,7 @@ from sqlalchemy.future import Engine
 from sqlmodel import Session
 from starlette.testclient import TestClient
 
+from database.model import AIAsset
 from tests.testutils.test_resource import TestResource
 
 
@@ -9,6 +10,8 @@ def test_get_all_happy_path(client_test_resource: TestClient, engine_test_resour
     with Session(engine_test_resource) as session:
         session.add_all(
             [
+                AIAsset(type="test_resource"),
+                AIAsset(type="test_resource"),
                 TestResource(title="my_test_resource_1"),
                 TestResource(title="My second test resource"),
             ]

--- a/src/tests/routers/generic/test_router_get_count.py
+++ b/src/tests/routers/generic/test_router_get_count.py
@@ -2,6 +2,7 @@ from sqlalchemy.future import Engine
 from sqlmodel import Session
 from starlette.testclient import TestClient
 
+from database.model import AIAsset
 from tests.testutils.test_resource import TestResource
 
 
@@ -9,6 +10,8 @@ def test_get_count_happy_path(client_test_resource: TestClient, engine_test_reso
     with Session(engine_test_resource) as session:
         session.add_all(
             [
+                AIAsset(type="test_resource"),
+                AIAsset(type="test_resource"),
                 TestResource(title="my_test_resource_1"),
                 TestResource(title="My second test resource"),
             ]

--- a/src/tests/routers/generic/test_router_platform_get_all.py
+++ b/src/tests/routers/generic/test_router_platform_get_all.py
@@ -2,6 +2,7 @@ from sqlalchemy.future import Engine
 from sqlmodel import Session
 from starlette.testclient import TestClient
 
+from database.model import AIAsset
 from tests.testutils.test_resource import TestResource
 
 
@@ -9,6 +10,8 @@ def test_get_all_happy_path(client_test_resource: TestClient, engine_test_resour
     with Session(engine_test_resource) as session:
         session.add_all(
             [
+                AIAsset(type="test_resource"),
+                AIAsset(type="test_resource"),
                 TestResource(
                     title="my_test_resource_1", platform="example", platform_identifier="1"
                 ),

--- a/src/tests/routers/generic/test_router_relations.py
+++ b/src/tests/routers/generic/test_router_relations.py
@@ -135,11 +135,6 @@ def client_with_testobject(engine_test_resource) -> TestClient:
                 AIAsset(type="test_object"),
                 AIAsset(type="test_object"),
                 AIAsset(type="test_object"),
-                named1,
-                named2,
-                enum1,
-                enum2,
-                enum3,
                 TestObject(
                     identifier=1,
                     title="object 1",

--- a/src/tests/routers/test_router_case_study.py
+++ b/src/tests/routers/test_router_case_study.py
@@ -47,3 +47,5 @@ def test_happy_path(client: TestClient, mocked_privileged_token: Mock):
         "technical category 1",
         "technical category 2",
     }
+    response = client.delete("/case_studies/v0/1", headers={"Authorization": "Fake token"})
+    assert response.status_code == 200

--- a/src/tests/routers/test_router_dataset.py
+++ b/src/tests/routers/test_router_dataset.py
@@ -175,9 +175,10 @@ def test_delete(client: TestClient, engine: Engine, mocked_privileged_token: Moc
     assert response.status_code == 200
 
     with Session(engine) as session:
+        # TODOs will be fixed in https://github.com/aiondemand/AIOD-rest-api/issues/72
         for n_expected, clz in [
             (1, Dataset),
-            (2, AIAsset),  # TODO: fix deletion of AIAsset, after merge with Taniyas PR
+            (2, AIAsset),  # TODO: delete AIAsset. This should be 1
             (1, DataDownloadORM),
             (1, ChecksumORM),
             (2, ChecksumAlgorithm),

--- a/src/tests/routers/test_router_dataset.py
+++ b/src/tests/routers/test_router_dataset.py
@@ -6,11 +6,17 @@ from unittest.mock import Mock
 
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
+from sqlmodel import select
 from starlette.testclient import TestClient
 
 from authentication import keycloak_openid
 from database.model import AIAsset
+from database.model.dataset.alternate_name import DatasetAlternateName
+from database.model.dataset.checksum import ChecksumORM
+from database.model.dataset.checksum_algorithm import ChecksumAlgorithm
+from database.model.dataset.data_download import DataDownloadORM
 from database.model.dataset.dataset import Dataset
+from database.model.dataset.measured_value import MeasuredValueORM
 from database.model.publication.publication import Publication
 
 
@@ -22,7 +28,7 @@ def test_happy_path(client: TestClient, engine: Engine, mocked_privileged_token:
                 AIAsset(type="dataset"),
                 AIAsset(type="publication"),
                 Dataset(
-                    identifier="1",
+                    identifier=1,
                     name="Parent",
                     platform="example",
                     platform_identifier="1",
@@ -30,7 +36,7 @@ def test_happy_path(client: TestClient, engine: Engine, mocked_privileged_token:
                     same_as="",
                 ),
                 Publication(
-                    identifier="2",
+                    identifier=2,
                     title="A publication",
                     platform="example",
                     platform_identifier="1",
@@ -110,3 +116,75 @@ def test_happy_path(client: TestClient, engine: Engine, mocked_privileged_token:
     assert "identifier" not in response_json["measured_values"][0]
     assert response_json["measured_values"][0]["variable"] == "molecule concentration"
     assert response_json["measured_values"][0]["technique"] == "mass spectrometry"
+
+
+def test_delete(client: TestClient, engine: Engine, mocked_privileged_token: Mock):
+    """Tested separately because of the nested objects such as dataset.distributions"""
+    keycloak_openid.decode_token = mocked_privileged_token
+
+    with Session(engine) as session:
+        md5 = ChecksumAlgorithm(name="md5")
+        alias1 = DatasetAlternateName(name="alias1")
+        session.add_all(
+            [
+                AIAsset(type="dataset"),
+                AIAsset(type="dataset"),
+                Dataset(
+                    identifier="1",
+                    name="1",
+                    platform="example",
+                    platform_identifier="1",
+                    description="description text",
+                    same_as="1",
+                    alternate_names=[alias1, DatasetAlternateName(name="alias2")],
+                    distributions=[
+                        DataDownloadORM(
+                            content_url="url",
+                            checksum=[
+                                ChecksumORM(algorithm=md5, value="checksum"),
+                                ChecksumORM(
+                                    algorithm=ChecksumAlgorithm(name="sha256"), value="checksum"
+                                ),
+                            ],
+                        )
+                    ],
+                    measured_values=[MeasuredValueORM(variable="variable", technique="technique")],
+                ),
+                Dataset(
+                    identifier="2",
+                    name="2",
+                    platform="example",
+                    platform_identifier="2",
+                    description="description text",
+                    same_as="2",
+                    alternate_names=[
+                        # alias1,
+                        DatasetAlternateName(name="alias3")
+                    ],
+                    distributions=[
+                        DataDownloadORM(
+                            content_url="url",
+                            checksum=[ChecksumORM(algorithm=md5, value="other checksum")],
+                        )
+                    ],
+                ),
+            ]
+        )
+        session.commit()
+    response = client.delete("/datasets/v0/1", headers={"Authorization": "Fake token"})
+    assert response.status_code == 200
+
+    with Session(engine) as session:
+        for n_expected, clz in [
+            (1, Dataset),
+            (2, AIAsset),  # TODO: fix deletion of AIAsset, after merge with Taniyas PR
+            (1, DataDownloadORM),
+            (1, ChecksumORM),
+            (2, ChecksumAlgorithm),
+            (3, DatasetAlternateName),  # TODO: fix many-to-many orphans. This should be 2
+            (1, MeasuredValueORM),  # TODO: fix many-to-many orphans. This should be 0
+        ]:
+            instances = session.scalars(select(clz)).all()
+            assert len(instances) == n_expected, (
+                f"Number of {clz.__name__} should have been " f"{n_expected}"
+            )

--- a/src/tests/routers/test_router_educational_resource.py
+++ b/src/tests/routers/test_router_educational_resource.py
@@ -92,3 +92,6 @@ def test_happy_path(client: TestClient, mocked_privileged_token: Mock):
         "technical category 1",
         "technical category 2",
     }
+
+    response = client.delete("/educational_resources/v0/1", headers={"Authorization": "Fake token"})
+    assert response.status_code == 200

--- a/src/tests/routers/test_router_event.py
+++ b/src/tests/routers/test_router_event.py
@@ -99,3 +99,9 @@ def test_happy_path(client: TestClient, engine: Engine, mocked_privileged_token:
         "business category 1",
         "business category 2",
     }
+
+    response = client.delete("/events/v0/3", headers={"Authorization": "Fake token"})
+    assert response.status_code == 200
+
+    response = client.get("/events/v0", headers={"Authorization": "Fake token"})
+    assert response.status_code == 200

--- a/src/tests/routers/test_router_news.py
+++ b/src/tests/routers/test_router_news.py
@@ -49,3 +49,5 @@ def test_happy_path(client: TestClient, mocked_privileged_token: Mock):
         "business category 1",
         "business category 2",
     }
+    response = client.delete("/news/v0/1", headers={"Authorization": "Fake token"})
+    assert response.status_code == 200

--- a/src/tests/routers/test_router_presentation.py
+++ b/src/tests/routers/test_router_presentation.py
@@ -42,3 +42,6 @@ def test_happy_path(client: TestClient, mocked_privileged_token: Mock):
     assert response_json["author"] == "John Doe"
     assert response_json["image"] == "https://example.com/presentation/example/image"
     assert response_json["is_accessible_for_free"]
+
+    response = client.delete("/presentations/v0/1", headers={"Authorization": "Fake token"})
+    assert response.status_code == 200

--- a/src/tests/routers/test_router_project.py
+++ b/src/tests/routers/test_router_project.py
@@ -44,3 +44,6 @@ def test_happy_path(client: TestClient, mocked_privileged_token: Mock):
     assert response_json["url"] == "aiod.eu/project/0"
 
     assert set(response_json["keywords"]) == {"keyword1", "keyword2"}
+
+    response = client.delete("/projects/v0/1", headers={"Authorization": "Fake token"})
+    assert response.status_code == 200

--- a/src/tests/routers/test_router_publication.py
+++ b/src/tests/routers/test_router_publication.py
@@ -53,3 +53,6 @@ def test_happy_path(client: TestClient, engine: Engine, mocked_privileged_token:
     assert response_json["resource_type"] == "journal article"
     assert len(response_json["datasets"]) == 1
     assert response_json["datasets"] == [1]
+
+    response = client.delete("/publications/v0/2", headers={"Authorization": "Fake token"})
+    assert response.status_code == 200

--- a/src/uploader/hugging_face_uploader.py
+++ b/src/uploader/hugging_face_uploader.py
@@ -84,7 +84,7 @@ class HuggingfaceUploader:
 
         resource = query.first()
         if not resource:
-            msg = f"Dataset '{identifier} not found " "in the database."
+            msg = f"Dataset '{identifier} not found in the database."
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)
         return resource
 


### PR DESCRIPTION
1. Enabled foreign key constraints in the tests (was on default disabled for sqlite, while it's enabled in production)
2. Fixed existing testcases
3. Added testcases for deletion of resources
4. Testcases failed because of Integrity Errors: e.g. after deleting a dataset, a keyword might have a foreign key relationship to a now non existent dataset
5. Fixed by using delete cascades

A couple of TODOs were intentionally left out of scope for this PR, because they do not cause Exceptions:

1. Deletion of orphans in many-to-many relationships, and orphan AIAssets: https://github.com/aiondemand/AIOD-rest-api/issues/72
2. Testing updates: https://github.com/aiondemand/AIOD-rest-api/issues/73