### PR TITLE
Bugfixes for platform delete

### DIFF
--- a/src/database/deletion/hard_delete.py
+++ b/src/database/deletion/hard_delete.py
@@ -2,9 +2,9 @@
 """
 Actual (hard) deletion of soft-deleted items.
 
-We use soft-deletion, meaning that the .date_deleted attribute is set on a delete request,
-rather than actual deletion. This module hard deletes those items that have been soft deleted
-some time ago.
+We use soft-deletion for most resources, meaning that the .date_deleted attribute is set on a
+delete request, rather than actual deletion. This module hard deletes those items that have been
+soft deleted some time ago.
 """
 import argparse
 import datetime

--- a/src/database/model/concept/concept.py
+++ b/src/database/model/concept/concept.py
@@ -3,8 +3,8 @@ import datetime
 from typing import Optional, Tuple
 
 from sqlalchemy import CheckConstraint, Index
+from sqlalchemy.orm import declared_attr
 from sqlalchemy.sql.functions import coalesce
-from sqlalchemy.util import classproperty
 from sqlmodel import SQLModel, Field, Relationship
 
 from database.model.concept.aiod_entry import AIoDEntryORM, AIoDEntryRead, AIoDEntryCreate
@@ -58,7 +58,7 @@ class AIoDConcept(AIoDConceptBase):
             on_delete_trigger_deletion_by="aiod_entry_identifier",
         )
 
-    @classproperty
+    @declared_attr
     def __table_args__(cls) -> Tuple:
         # Note to developer: this will give problems if we'll add another child which has extra
         # constraints, because this might lead to a duplicate check constraint name.

--- a/src/database/model/platform/platform.py
+++ b/src/database/model/platform/platform.py
@@ -1,3 +1,8 @@
+"""
+The external platform (e.g. openml).
+"""
+
+
 import datetime
 
 from sqlmodel import Field, SQLModel
@@ -5,13 +10,12 @@ from sqlmodel import Field, SQLModel
 
 class PlatformBase(SQLModel):
     name: str = Field(
-        unique=True,
         description="The name of the platform, such as huggingface, "
         "openml or zenodo. Preferably using snake_case.",
         schema_extra={"example": "example_platform"},
         index=True,
+        unique=True,
     )
-    date_deleted: datetime.datetime | None = Field()
 
 
 class Platform(PlatformBase, table=True):  # type: ignore [call-arg]
@@ -19,5 +23,8 @@ class Platform(PlatformBase, table=True):  # type: ignore [call-arg]
     AIoD. This table is partly filled with the enum PlatformName"""
 
     __tablename__ = "platform"
+    __deletion_config__ = {"soft_delete": False}  # hard_deletion, otherwise name cannot be unique,
+    # which is difficult for foreign key constraints
 
     identifier: int = Field(primary_key=True, default=None)
+    date_deleted: datetime.datetime | None = Field()

--- a/src/tests/routers/generic/test_router_delete.py
+++ b/src/tests/routers/generic/test_router_delete.py
@@ -80,3 +80,25 @@ def test_non_existent(
     )
     assert response.status_code == 404, response.json()
     assert response.json()["detail"] == f"Test_resource '{identifier}' not found in the database."
+
+
+def test_add_after_deletion(
+    client_test_resource: TestClient,
+    engine_test_resource: Engine,
+    mocked_privileged_token: Mock,
+):
+    keycloak_openid.userinfo = mocked_privileged_token
+    body = {"title": "my_favourite_resource"}
+    response = client_test_resource.post(
+        "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == 200, response.json()
+    id_ = response.json()["identifier"]
+    response = client_test_resource.delete(
+        f"/test_resources/v0/{id_}", headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == 200, response.json()
+    response = client_test_resource.post(
+        "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == 200, response.json()

--- a/src/tests/routers/resource_routers/test_router_platform.py
+++ b/src/tests/routers/resource_routers/test_router_platform.py
@@ -18,7 +18,6 @@ def test_happy_path(client: TestClient, mocked_privileged_token: Mock):
     assert platforms == {p.name for p in PlatformName}.union(["my_favourite_platform"])
 
 
-@pytest.mark.skip(reason="TODO: while going to Metadata model v2")
 @pytest.mark.parametrize(
     "url", ["/platforms/example/platforms/v1", "/platforms/example/platforms/v1/1"]
 )
@@ -26,3 +25,25 @@ def test_get_platform_of_platform(client: TestClient, url: str):
     response = client.get(url)
     assert response.status_code == 404, response.json()
     assert response.json()["detail"] == "Not Found"
+
+
+def test_delete_platform(client: TestClient, mocked_privileged_token: Mock):
+    keycloak_openid.userinfo = mocked_privileged_token
+    body = {"name": "my_favourite_platform"}
+    response = client.post("/platforms/v1", json=body, headers={"Authorization": "Fake token"})
+    assert response.status_code == 200, response.json()
+    id_ = response.json()["identifier"]
+    response = client.delete(f"/platforms/v1/{id_}", headers={"Authorization": "Fake token"})
+    assert response.status_code == 200, response.json()
+    response = client.post("/platforms/v1", json=body, headers={"Authorization": "Fake token"})
+    assert response.status_code == 200, response.json()
+
+
+def test_platform_same_name(client: TestClient, mocked_privileged_token: Mock):
+    keycloak_openid.userinfo = mocked_privileged_token
+    body = {"name": "my_favourite_platform"}
+    response = client.post("/platforms/v1", json=body, headers={"Authorization": "Fake token"})
+    assert response.status_code == 200, response.json()
+    response = client.post("/platforms/v1", json=body, headers={"Authorization": "Fake token"})
+    assert response.status_code == 409, response.json()
+    assert response.json()["detail"] == "There already exists a platform with the same name."


### PR DESCRIPTION
Making sure platform deletion works as planned.

Decided to use hard-delete for platforms. That should not be problematic (platforms are not indexed by ES anyway), and this makes it easier to keep the unique index platform.name, easy for foreign key constraints.