### PR TITLE
Longer timeout for API

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,8 +23,8 @@ services:
       start_interval: 1s
       start_period: 30s
       interval: 5s
-      timeout: 30s
-      retries: 5
+      timeout: 120s
+      retries: 24
     depends_on:
       sqlserver:
         condition: service_healthy


### PR DESCRIPTION
Some machines were throwing errors because it took too long for the API to go up (e.g. the Zaragoza Rinjani server, and Sonia also had these problems)