### PR TITLE
Elastic search: better Swagger documentation

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -8,7 +8,11 @@ DIR_DATA=$DIR_ROOT/data
 DIR_MYSQL=$DIR_DATA/mysql
 DIR_CONNECTORS=$DIR_DATA/connectors
 DIR_DELETION=$DIR_DATA/deletion
+DIR_ELASTIC=$DIR_DATA/elasticsearch
 
-find $DIR_CONNECTORS -type f ! -name .gitkeep -delete
-find $DIR_DELETION -type f ! -name .gitkeep -delete
+sudo find $DIR_CONNECTORS -type f ! -name .gitkeep -delete
+sudo find $DIR_DELETION -type f ! -name .gitkeep -delete
 sudo rm -rf $DIR_MYSQL/*
+touch $DIR_MYSQL/.gitkeep
+sudo rm -rf $DIR_ELASTIC/*
+touch $DIR_ELASTIC/.gitkeep

--- a/src/routers/search_router.py
+++ b/src/routers/search_router.py
@@ -1,9 +1,10 @@
 import abc
-from typing import TypeVar, Generic, Any, Type, Annotated
+from typing import TypeVar, Generic, Any, Type, Annotated, Literal
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
-from sqlmodel import SQLModel, select
+from pydantic.generics import GenericModel
+from sqlmodel import SQLModel, select, Field
 from starlette import status
 
 from database.model.concept.aiod_entry import AIoDEntryRead
@@ -18,13 +19,16 @@ SORT = {"identifier": "asc"}
 LIMIT_MAX = 1000
 
 RESOURCE = TypeVar("RESOURCE", bound=AIoDConcept)
+RESOURCE_READ = TypeVar("RESOURCE_READ", bound=BaseModel)
 
 
-class SearchResult(BaseModel, Generic[RESOURCE]):
-    total_hits: int
-    resources: list
-    limit: int
-    offset: int
+class SearchResult(GenericModel, Generic[RESOURCE_READ]):
+    total_hits: int = Field(description="The total number of results.")
+    resources: list[RESOURCE_READ] = Field(description="The resources matching the search query.")
+    limit: int = Field(
+        description="The maximum number of returned results, as specified in the " "input."
+    )
+    offset: int = Field(description="The offset, as specified in the input.")
 
 
 class SearchRouter(Generic[RESOURCE], abc.ABC):
@@ -63,19 +67,49 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
     def create(self, url_prefix: str) -> APIRouter:
         router = APIRouter()
         read_class = resource_read(self.resource_class)  # type: ignore
+        indexed_fields = Literal[tuple(self.indexed_fields)]  # type: ignore
 
-        @router.get(f"{url_prefix}/search/{self.resource_name_plural}/v1", tags=["search"])
+        @router.get(
+            f"{url_prefix}/search/{self.resource_name_plural}/v1",
+            tags=["search"],
+            description=f"""Search for {self.resource_name_plural}.""",
+            # response_model=SearchResult[read_class],  # This gives errors, so not used.
+        )
         def search(
-            platforms: Annotated[list[str] | None, Query()] = None,
-            search_query: str = "",
-            search_fields: Annotated[list[str] | None, Query()] = None,
+            search_query: Annotated[
+                str,
+                Query(
+                    description="Text you wish to find. It is used in an ElasticSearch match "
+                    "query.",
+                    examples=["Name of the resource"],
+                ),
+            ],
+            search_fields: Annotated[  # type: ignore
+                list[indexed_fields] | None,
+                Query(
+                    description="A list of field names to include in the search. If empty, "
+                    "all fields will be used. Do not use the '--' option in Swagger, "
+                    "it is a Swagger artifact.",
+                ),
+            ] = None,
+            platforms: Annotated[
+                list[str] | None,
+                Query(
+                    description="A list of platform names to include. If empty, results from all "
+                    "platforms will be returned.",
+                    examples=["huggingface", "openml"],
+                ),
+            ] = None,
             limit: Annotated[int | None, Query(ge=1, le=LIMIT_MAX)] = 10,
             offset: Annotated[int | None, Query(ge=0)] = 0,
-            get_all: bool = True,
-        ) -> SearchResult[read_class]:  # type: ignore
-            f"""
-            Search for {self.resource_name_plural}.
-            """
+            get_all: Annotated[
+                bool,
+                Query(
+                    description="If true, a request to the database is made to retrieve all data. "
+                    "If false, only the indexed information is returned."
+                ),
+            ] = False,
+        ):
             try:
                 with DbSession() as session:
                     query = select(Platform)
@@ -90,12 +124,6 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
                     detail=f"The available platforms are: {platform_names}",
                 )
             fields = search_fields if search_fields else self.indexed_fields
-            if not set(fields).issubset(self.indexed_fields):
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"The available search fields for this entity "
-                    f"are: {self.indexed_fields}",
-                )
             query_matches = [{"match": {f: search_query}} for f in fields]
             query = {"bool": {"should": query_matches, "minimum_should_match": 1}}
             if platforms:
@@ -103,6 +131,7 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
                 query["bool"]["must"] = {
                     "bool": {"should": platform_matches, "minimum_should_match": 1}
                 }
+
             result = ElasticsearchSingleton().client.search(
                 index=self.es_index, query=query, from_=offset, size=limit, sort=SORT
             )
@@ -113,11 +142,11 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
                     for hit in result["hits"]["hits"]
                 ]
             else:
-                resources: list[Type[RESOURCE]] = [  # type: ignore
+                resources: list[Type[read_class]] = [  # type: ignore
                     self._cast_resource(read_class, hit["_source"])
                     for hit in result["hits"]["hits"]
                 ]
-            return SearchResult[RESOURCE](  # type: ignore
+            return SearchResult[read_class](  # type: ignore
                 total_hits=total_hits,
                 resources=resources,
                 limit=limit,
@@ -157,5 +186,8 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
         resource.aiod_entry = AIoDEntryRead(
             date_modified=resource_dict["date_modified"], status=None
         )
-        resource.description = {"plain": resource_dict["plain"], "html": resource_dict["html"]}
+        resource.description = {
+            "plain": resource_dict["description_plain"],
+            "html": resource_dict["description_html"],
+        }
         return resource

--- a/src/routers/search_routers/search_router_datasets.py
+++ b/src/routers/search_routers/search_router_datasets.py
@@ -17,4 +17,4 @@ class SearchRouterDatasets(SearchRouter[Dataset]):
 
     @property
     def indexed_fields(self):
-        return {"name", "plain", "html", "issn"}
+        return {"name", "description_plain", "description_html", "issn"}

--- a/src/routers/search_routers/search_router_events.py
+++ b/src/routers/search_routers/search_router_events.py
@@ -17,4 +17,4 @@ class SearchRouterEvents(SearchRouter[Event]):
 
     @property
     def indexed_fields(self):
-        return {"name", "plain", "html"}
+        return {"name", "description_plain", "description_html"}

--- a/src/routers/search_routers/search_router_experiments.py
+++ b/src/routers/search_routers/search_router_experiments.py
@@ -17,4 +17,4 @@ class SearchRouterExperiments(SearchRouter[Experiment]):
 
     @property
     def indexed_fields(self):
-        return {"name", "plain", "html"}
+        return {"name", "description_plain", "description_html"}

--- a/src/routers/search_routers/search_router_ml_models.py
+++ b/src/routers/search_routers/search_router_ml_models.py
@@ -17,4 +17,4 @@ class SearchRouterMLModels(SearchRouter[MLModel]):
 
     @property
     def indexed_fields(self):
-        return {"name", "plain", "html"}
+        return {"name", "description_plain", "description_html"}

--- a/src/routers/search_routers/search_router_news.py
+++ b/src/routers/search_routers/search_router_news.py
@@ -17,4 +17,4 @@ class SearchRouterNews(SearchRouter[News]):
 
     @property
     def indexed_fields(self):
-        return {"name", "plain", "html", "headline", "alternative_headline"}
+        return {"name", "description_plain", "description_html", "headline", "alternative_headline"}

--- a/src/routers/search_routers/search_router_organisations.py
+++ b/src/routers/search_routers/search_router_organisations.py
@@ -17,4 +17,4 @@ class SearchRouterOrganisations(SearchRouter[Organisation]):
 
     @property
     def indexed_fields(self):
-        return {"name", "legal_name", "plain", "html"}
+        return {"name", "legal_name", "description_plain", "description_html"}

--- a/src/routers/search_routers/search_router_projects.py
+++ b/src/routers/search_routers/search_router_projects.py
@@ -17,4 +17,4 @@ class SearchRouterProjects(SearchRouter[Project]):
 
     @property
     def indexed_fields(self):
-        return {"name", "plain", "html"}
+        return {"name", "description_plain", "description_html"}

--- a/src/routers/search_routers/search_router_publications.py
+++ b/src/routers/search_routers/search_router_publications.py
@@ -17,4 +17,4 @@ class SearchRouterPublications(SearchRouter[Publication]):
 
     @property
     def indexed_fields(self):
-        return {"name", "plain", "html", "issn", "isbn"}
+        return {"name", "description_plain", "description_html", "issn", "isbn"}

--- a/src/routers/search_routers/search_router_services.py
+++ b/src/routers/search_routers/search_router_services.py
@@ -17,4 +17,4 @@ class SearchRouterServices(SearchRouter[Service]):
 
     @property
     def indexed_fields(self):
-        return {"name", "plain", "html", "slogan"}
+        return {"name", "description_plain", "description_html", "slogan"}

--- a/src/setup/es_setup/definitions.py
+++ b/src/setup/es_setup/definitions.py
@@ -4,8 +4,8 @@ BASE_MAPPING = {
             "date_modified": {"type": "date"},
             "identifier": {"type": "long"},
             "name": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
-            "plain": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
-            "html": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+            "description_plain": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+            "description_html": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
         }
     }
 }

--- a/src/setup/es_setup/generate_elasticsearch_indices.py
+++ b/src/setup/es_setup/generate_elasticsearch_indices.py
@@ -12,6 +12,7 @@ import logging
 from definitions import BASE_MAPPING
 from routers.search_routers import router_list
 from routers.search_routers.elasticsearch import ElasticsearchSingleton
+from setup.logstash_setup.generate_logstash_config_files import GLOBAL_FIELDS
 from setup_logger import setup_logger
 
 
@@ -28,9 +29,8 @@ def generate_mapping(fields):
 def main():
     setup_logger()
     es_client = ElasticsearchSingleton().client
-    global_fields = {"name", "plain", "html"}
     entities = {
-        router.es_index: list(router.indexed_fields ^ global_fields) for router in router_list
+        router.es_index: list(router.indexed_fields ^ GLOBAL_FIELDS) for router in router_list
     }
     logging.info("Generating indices...")
     for es_index, fields in entities.items():

--- a/src/setup/logstash_setup/generate_logstash_config_files.py
+++ b/src/setup/logstash_setup/generate_logstash_config_files.py
@@ -34,7 +34,7 @@ DB_PASS = os.environ["MYSQL_ROOT_PASSWORD"]
 ES_USER = os.environ["ES_USER"]
 ES_PASS = os.environ["ES_PASSWORD"]
 
-GLOBAL_FIELDS = {"name", "plain", "html"}
+GLOBAL_FIELDS = {"name", "description_plain", "description_html"}
 
 
 def generate_file(file_path, template, file_data):

--- a/src/setup/logstash_setup/templates/sql_init.py
+++ b/src/setup/logstash_setup/templates/sql_init.py
@@ -1,8 +1,8 @@
 TEMPLATE_SQL_INIT = """SELECT
     {{entity_name}}.identifier,
     {{entity_name}}.name,
-    text.plain as 'plain',
-    text.html as 'html',
+    text.plain as 'description_plain',
+    text.html as 'description_html',
     aiod_entry.date_modified{{extra_fields}}
 FROM aiod.{{entity_name}}
 INNER JOIN aiod.aiod_entry ON aiod.{{entity_name}}.aiod_entry_identifier=aiod.aiod_entry.identifier

--- a/src/setup/logstash_setup/templates/sql_sync.py
+++ b/src/setup/logstash_setup/templates/sql_sync.py
@@ -1,8 +1,8 @@
 TEMPLATE_SQL_SYNC = """SELECT
     {{entity_name}}.identifier,
     {{entity_name}}.name,
-    text.plain as 'plain',
-    text.html as 'html',
+    text.plain as 'description_plain',
+    text.html as 'description_html',
     aiod_entry.date_modified{{extra_fields}}
 FROM aiod.{{entity_name}}
 INNER JOIN aiod.aiod_entry ON aiod.{{entity_name}}.aiod_entry_identifier=aiod.aiod_entry.identifier

--- a/src/tests/resources/elasticsearch/dataset_search.json
+++ b/src/tests/resources/elasticsearch/dataset_search.json
@@ -22,10 +22,10 @@
           "identifier" : 1,
           "date_modified" : "2023-09-01T00:00:00.000Z",
           "name" : "A name.",
-          "plain" : "A plain text description.",
+          "description_plain" : "A plain text description.",
           "issn" : "20493630",
           "type" : "dataset",
-          "html" : "An html description."
+          "description_html" : "An html description."
         },
         "sort" : [
           1

--- a/src/tests/resources/elasticsearch/event_search.json
+++ b/src/tests/resources/elasticsearch/event_search.json
@@ -22,9 +22,9 @@
           "identifier" : 1,
           "date_modified" : "2023-09-01T00:00:00.000Z",
           "name" : "A name.",
-          "plain" : "A plain text description.",
+          "description_plain" : "A plain text description.",
           "type" : "event",
-          "html" : "An html description."
+          "description_html" : "An html description."
         },
         "sort" : [
           1

--- a/src/tests/resources/elasticsearch/experiment_search.json
+++ b/src/tests/resources/elasticsearch/experiment_search.json
@@ -22,9 +22,9 @@
           "identifier" : 1,
           "date_modified" : "2023-09-01T00:00:00.000Z",
           "name" : "A name.",
-          "plain" : "A plain text description.",
+          "description_plain" : "A plain text description.",
           "type" : "experiment",
-          "html" : "An html description."
+          "description_html" : "An html description."
         },
         "sort" : [
           1

--- a/src/tests/resources/elasticsearch/ml_model_search.json
+++ b/src/tests/resources/elasticsearch/ml_model_search.json
@@ -22,9 +22,9 @@
           "identifier" : 1,
           "date_modified" : "2023-09-01T00:00:00.000Z",
           "name" : "A name.",
-          "plain" : "A plain text description.",
+          "description_plain" : "A plain text description.",
           "type" : "ml_model",
-          "html" : "An html description."
+          "description_html" : "An html description."
         },
         "sort" : [
           1

--- a/src/tests/resources/elasticsearch/news_search.json
+++ b/src/tests/resources/elasticsearch/news_search.json
@@ -23,9 +23,9 @@
           "headline" : "A headline.",
           "date_modified" : "2023-09-01T00:00:00.000Z",
           "name" : "A name.",
-          "plain" : "A plain text description.",
+          "description_plain" : "A plain text description.",
           "type" : "news",
-          "html" : "An html description.",
+          "description_html" : "An html description.",
           "alternative_headline" : "An alternative headline."
         },
         "sort" : [

--- a/src/tests/resources/elasticsearch/organisation_search.json
+++ b/src/tests/resources/elasticsearch/organisation_search.json
@@ -22,9 +22,9 @@
           "identifier" : 1,
           "date_modified" : "2023-09-01T00:00:00.000Z",
           "name" : "A name.",
-          "plain" : "A plain text description.",
+          "description_plain" : "A plain text description.",
           "type" : "organisation",
-          "html" : "An html description.",
+          "description_html" : "An html description.",
           "legal_name" : "A legal name."
         },
         "sort" : [

--- a/src/tests/resources/elasticsearch/project_search.json
+++ b/src/tests/resources/elasticsearch/project_search.json
@@ -22,9 +22,9 @@
           "identifier" : 1,
           "date_modified" : "2023-09-01T00:00:00.000Z",
           "name" : "A name.",
-          "plain" : "A plain text description.",
+          "description_plain" : "A plain text description.",
           "type" : "project",
-          "html" : "An html description."
+          "description_html" : "An html description."
         },
         "sort" : [
           1

--- a/src/tests/resources/elasticsearch/publication_search.json
+++ b/src/tests/resources/elasticsearch/publication_search.json
@@ -22,11 +22,11 @@
           "identifier" : 1,
           "date_modified" : "2023-09-01T00:00:00.000Z",
           "name" : "A name.",
-          "plain" : "A plain text description.",
+          "description_plain" : "A plain text description.",
           "issn" : "20493630",
           "type" : "publication",
           "isbn" : "9783161484100",
-          "html" : "An html description."
+          "description_html" : "An html description."
         },
         "sort" : [
           1

--- a/src/tests/resources/elasticsearch/service_search.json
+++ b/src/tests/resources/elasticsearch/service_search.json
@@ -23,9 +23,9 @@
           "slogan" : "A slogan.",
           "date_modified" : "2023-09-01T00:00:00.000Z",
           "name" : "A name.",
-          "plain" : "A plain text description.",
+          "description_plain" : "A plain text description.",
           "type" : "service",
-          "html" : "An html description."
+          "description_html" : "An html description."
         },
         "sort" : [
           1

--- a/src/tests/routers/search_routers/test_search_routers.py
+++ b/src/tests/routers/search_routers/test_search_routers.py
@@ -39,7 +39,7 @@ def test_search_happy_path(client: TestClient, search_router):
     assert resource["aiod_entry"]["date_modified"] == "2023-09-01T00:00:00+00:00"
     assert resource["aiod_entry"]["status"] is None
 
-    global_fields = {"name", "plain", "html"}
+    global_fields = {"name", "description_plain", "description_html"}
     extra_fields = list(search_router.indexed_fields ^ global_fields)
     for field in extra_fields:
         assert resource[field]
@@ -84,9 +84,9 @@ def test_search_bad_fields(client: TestClient, search_router):
     params = {"search_query": "description", "search_fields": ["bad_field"]}
     response = client.get(search_service, params=params)
 
-    assert response.status_code == 400, response.json()
-    err_msg = "The available search fields for this entity are"
-    assert response.json()["detail"][: len(err_msg)] == err_msg
+    assert response.status_code == 422, response.json()
+
+    assert response.json()["detail"][0]["msg"].startswith("unexpected value; permitted: ")
 
 
 @pytest.mark.parametrize("search_router", sr.router_list)


### PR DESCRIPTION
1. Added descriptions (for Swagger) to the search router fields
2. Added enums for search_fields
3. Rrenamed plain and html to `description_plain` and `description_html`
4. Made sure the clean script cleans `data/elasticsearch`