### PR TITLE
Feature/elastic search db performance

### DIFF
--- a/src/tests/routers/search_routers/test_search_routers.py
+++ b/src/tests/routers/search_routers/test_search_routers.py
@@ -1,5 +1,4 @@
 import json
-import os
 from unittest.mock import Mock
 
 import pytest
@@ -14,16 +13,8 @@ from tests.testutils.paths import path_test_resources
 
 @pytest.mark.parametrize("search_router", sr.router_list)
 def test_search_happy_path(client: TestClient, search_router):
-    mocked_elasticsearch = Elasticsearch("https://example.com:9200")
-    ElasticsearchSingleton().patch(mocked_elasticsearch)
+    mock_elasticsearch(filename_mock=f"{search_router.es_index}_search.json")
 
-    resources_path = os.path.join(path_test_resources(), "elasticsearch")
-    resource_file = f"{search_router.es_index}_search.json"
-    mocked_file = os.path.join(resources_path, resource_file)
-    with open(mocked_file, "r") as f:
-        mocked_results = json.load(f)
-
-    mocked_elasticsearch.search = Mock(return_value=mocked_results)
     search_service = f"/search/{search_router.resource_name_plural}/v1"
     params = {"search_query": "description", "get_all": False}
     response = client.get(search_service, params=params)
@@ -46,22 +37,13 @@ def test_search_happy_path(client: TestClient, search_router):
 
 def test_search_happy_path_get_all(client: TestClient, mocked_privileged_token: Mock):
     keycloak_openid.userinfo = mocked_privileged_token
+    mock_elasticsearch(filename_mock="event_search.json")
 
-    mocked_elasticsearch = Elasticsearch("https://example.com:9200")
-    ElasticsearchSingleton().patch(mocked_elasticsearch)
-
-    resources_path = os.path.join(path_test_resources(), "elasticsearch")
-    mocked_file = os.path.join(resources_path, "event_search.json")
-    with open(mocked_file, "r") as f:
-        mocked_results = json.load(f)
-
-    es_data = mocked_results["hits"]["hits"][0]["_source"]
-    body = {"name": es_data["name"], "keyword": ["keyword1", "keyword2"]}  # not indexed by ES
+    body = {"name": "A name.", "keyword": ["keyword1", "keyword2"]}  # keywords not indexed by ES
 
     response = client.post("/events/v1", json=body, headers={"Authorization": "Fake token"})
     response.raise_for_status()
 
-    mocked_elasticsearch.search = Mock(return_value=mocked_results)
     search_service = "/search/events/v1"
     params = {"search_query": "description", "get_all": True}
     response = client.get(search_service, params=params)
@@ -76,15 +58,8 @@ def test_search_happy_path_get_all(client: TestClient, mocked_privileged_token: 
 
 
 def test_search_get_all_not_found_in_db(client: TestClient):
-    mocked_elasticsearch = Elasticsearch("https://example.com:9200")
-    ElasticsearchSingleton().patch(mocked_elasticsearch)
+    mock_elasticsearch(filename_mock="event_search.json")
 
-    resources_path = os.path.join(path_test_resources(), "elasticsearch")
-    mocked_file = os.path.join(resources_path, "event_search.json")
-    with open(mocked_file, "r") as f:
-        mocked_results = json.load(f)
-
-    mocked_elasticsearch.search = Mock(return_value=mocked_results)
     search_service = "/search/events/v1"
     params = {"search_query": "description", "get_all": True}
     response = client.get(search_service, params=params)
@@ -99,16 +74,8 @@ def test_search_get_all_not_found_in_db(client: TestClient):
 @pytest.mark.parametrize("search_router", sr.router_list)
 def test_search_bad_platform(client: TestClient, search_router):
     """Tests the search router bad platform error"""
-    mocked_elasticsearch = Elasticsearch("https://example.com:9200")
-    ElasticsearchSingleton().patch(mocked_elasticsearch)
+    mock_elasticsearch(filename_mock=f"{search_router.es_index}_search.json")
 
-    resources_path = os.path.join(path_test_resources(), "elasticsearch")
-    resource_file = f"{search_router.es_index}_search.json"
-    mocked_file = os.path.join(resources_path, resource_file)
-    with open(mocked_file, "r") as f:
-        mocked_results = json.load(f)
-
-    mocked_elasticsearch.search = Mock(return_value=mocked_results)
     search_service = f"/search/{search_router.resource_name_plural}/v1"
     params = {"search_query": "description", "platforms": ["bad_platform"]}
     response = client.get(search_service, params=params)
@@ -121,16 +88,8 @@ def test_search_bad_platform(client: TestClient, search_router):
 @pytest.mark.parametrize("search_router", sr.router_list)
 def test_search_bad_fields(client: TestClient, search_router):
     """Tests the search router bad fields error"""
-    mocked_elasticsearch = Elasticsearch("https://example.com:9200")
-    ElasticsearchSingleton().patch(mocked_elasticsearch)
+    mock_elasticsearch(filename_mock=f"{search_router.es_index}_search.json")
 
-    resources_path = os.path.join(path_test_resources(), "elasticsearch")
-    resource_file = f"{search_router.es_index}_search.json"
-    mocked_file = os.path.join(resources_path, resource_file)
-    with open(mocked_file, "r") as f:
-        mocked_results = json.load(f)
-
-    mocked_elasticsearch.search = Mock(return_value=mocked_results)
     search_service = f"/search/{search_router.resource_name_plural}/v1"
     params = {"search_query": "description", "search_fields": ["bad_field"]}
     response = client.get(search_service, params=params)
@@ -143,16 +102,8 @@ def test_search_bad_fields(client: TestClient, search_router):
 @pytest.mark.parametrize("search_router", sr.router_list)
 def test_search_bad_limit(client: TestClient, search_router):
     """Tests the search router bad fields error"""
-    mocked_elasticsearch = Elasticsearch("https://example.com:9200")
-    ElasticsearchSingleton().patch(mocked_elasticsearch)
+    mock_elasticsearch(filename_mock=f"{search_router.es_index}_search.json")
 
-    resources_path = os.path.join(path_test_resources(), "elasticsearch")
-    resource_file = f"{search_router.es_index}_search.json"
-    mocked_file = os.path.join(resources_path, resource_file)
-    with open(mocked_file, "r") as f:
-        mocked_results = json.load(f)
-
-    mocked_elasticsearch.search = Mock(return_value=mocked_results)
     search_service = f"/search/{search_router.resource_name_plural}/v1"
     params = {"search_query": "description", "limit": 1001}
     response = client.get(search_service, params=params)
@@ -171,16 +122,8 @@ def test_search_bad_limit(client: TestClient, search_router):
 @pytest.mark.parametrize("search_router", sr.router_list)
 def test_search_bad_offset(client: TestClient, search_router):
     """Tests the search router bad fields error"""
-    mocked_elasticsearch = Elasticsearch("https://example.com:9200")
-    ElasticsearchSingleton().patch(mocked_elasticsearch)
+    mock_elasticsearch(filename_mock=f"{search_router.es_index}_search.json")
 
-    resources_path = os.path.join(path_test_resources(), "elasticsearch")
-    resource_file = f"{search_router.es_index}_search.json"
-    mocked_file = os.path.join(resources_path, resource_file)
-    with open(mocked_file, "r") as f:
-        mocked_results = json.load(f)
-
-    mocked_elasticsearch.search = Mock(return_value=mocked_results)
     search_service = f"/search/{search_router.resource_name_plural}/v1"
     params = {"search_query": "description", "offset": -1}
     response = client.get(search_service, params=params)
@@ -194,3 +137,12 @@ def test_search_bad_offset(client: TestClient, search_router):
             "type": "value_error.number.not_ge",
         }
     ]
+
+
+def mock_elasticsearch(filename_mock: str):
+    with open(path_test_resources() / "elasticsearch" / filename_mock, "r") as f:
+        mocked_results = json.load(f)
+
+    mocked_elasticsearch = Elasticsearch("https://example.com:9200")
+    mocked_elasticsearch.search = Mock(return_value=mocked_results)
+    ElasticsearchSingleton().patch(mocked_elasticsearch)

--- a/src/tests/routers/search_routers/test_search_routers.py
+++ b/src/tests/routers/search_routers/test_search_routers.py
@@ -1,20 +1,19 @@
-import os
 import json
-import pytest
-
+import os
 from unittest.mock import Mock
 
+import pytest
 from elasticsearch import Elasticsearch
 from starlette.testclient import TestClient
 
+import routers.search_routers as sr
+from authentication import keycloak_openid
 from routers.search_routers.elasticsearch import ElasticsearchSingleton
 from tests.testutils.paths import path_test_resources
-import routers.search_routers as sr
 
 
 @pytest.mark.parametrize("search_router", sr.router_list)
 def test_search_happy_path(client: TestClient, search_router):
-    """Tests the search router"""
     mocked_elasticsearch = Elasticsearch("https://example.com:9200")
     ElasticsearchSingleton().patch(mocked_elasticsearch)
 
@@ -43,6 +42,58 @@ def test_search_happy_path(client: TestClient, search_router):
     extra_fields = list(search_router.indexed_fields ^ global_fields)
     for field in extra_fields:
         assert resource[field]
+
+
+def test_search_happy_path_get_all(client: TestClient, mocked_privileged_token: Mock):
+    keycloak_openid.userinfo = mocked_privileged_token
+
+    mocked_elasticsearch = Elasticsearch("https://example.com:9200")
+    ElasticsearchSingleton().patch(mocked_elasticsearch)
+
+    resources_path = os.path.join(path_test_resources(), "elasticsearch")
+    mocked_file = os.path.join(resources_path, "event_search.json")
+    with open(mocked_file, "r") as f:
+        mocked_results = json.load(f)
+
+    es_data = mocked_results["hits"]["hits"][0]["_source"]
+    body = {"name": es_data["name"], "keyword": ["keyword1", "keyword2"]}  # not indexed by ES
+
+    response = client.post("/events/v1", json=body, headers={"Authorization": "Fake token"})
+    response.raise_for_status()
+
+    mocked_elasticsearch.search = Mock(return_value=mocked_results)
+    search_service = "/search/events/v1"
+    params = {"search_query": "description", "get_all": True}
+    response = client.get(search_service, params=params)
+
+    assert response.status_code == 200, response.json()
+    resource = response.json()["resources"][0]
+
+    assert resource["identifier"] == 1
+    assert resource["name"] == "A name."
+    assert resource["aiod_entry"]["status"] == "draft"
+    assert set(resource["keyword"]) == {"keyword1", "keyword2"}
+
+
+def test_search_get_all_not_found_in_db(client: TestClient):
+    mocked_elasticsearch = Elasticsearch("https://example.com:9200")
+    ElasticsearchSingleton().patch(mocked_elasticsearch)
+
+    resources_path = os.path.join(path_test_resources(), "elasticsearch")
+    mocked_file = os.path.join(resources_path, "event_search.json")
+    with open(mocked_file, "r") as f:
+        mocked_results = json.load(f)
+
+    mocked_elasticsearch.search = Mock(return_value=mocked_results)
+    search_service = "/search/events/v1"
+    params = {"search_query": "description", "get_all": True}
+    response = client.get(search_service, params=params)
+
+    assert response.status_code == 404, response.json()
+    assert (
+        response.json()["detail"]
+        == "Some resources, with identifiers 1, could not be found in the database."
+    )
 
 
 @pytest.mark.parametrize("search_router", sr.router_list)


### PR DESCRIPTION
The elasticsearch endpoint retrieved the resources sequentially from the database. That was quite slow. Now it performs only a single db-query.

Also, 2 extra unittests, and reduced the code-duplication in the unittests.