### PR TITLE
Improve swagger documentation

### DIFF
--- a/src/database/model/concept/concept.py
+++ b/src/database/model/concept/concept.py
@@ -19,7 +19,6 @@ CONSTRAINT_LOWERCASE = f"{'platform' if IS_SQLITE else 'BINARY(platform)'} = LOW
 
 
 class AIoDConceptBase(SQLModel):
-    """The AIoDConcept is the top-level (abstract) class in AIoD."""
 
     platform: str | None = Field(
         max_length=SHORT,

--- a/src/database/model/relationships.py
+++ b/src/database/model/relationships.py
@@ -56,7 +56,7 @@ class _ResourceRelationship(abc.ABC, Representation):
     def field(self):
         return Field(
             description=self.description,
-            schema_extra={"example": self.example} if self.example is not None else None,
+            schema_extra={"example": self.example},
             default_factory=self.default_factory_pydantic,
         )
 
@@ -111,7 +111,12 @@ class _ResourceRelationshipList(_ResourceRelationship):
         example(Any): an example value to be shown in Swagger
     """
 
-    example: list[Any] | None = None
+    example: dataclasses.InitVar[list[Any] | None] = None
+
+    def __post_init__(self, example: list[Any] | None):
+        """Make sure the example is an empty list. If the example is None, Swagger will show it
+        as [0] for a list[int], and [""] for a list[str]."""
+        self.example = example if example is not None else []  # type: ignore
 
 
 @dataclasses.dataclass

--- a/src/routers/resource_ai_asset_router.py
+++ b/src/routers/resource_ai_asset_router.py
@@ -1,5 +1,3 @@
-from typing import Annotated
-
 import requests
 from fastapi import APIRouter, HTTPException, status, Path
 from fastapi.responses import Response
@@ -50,16 +48,10 @@ class ResourceAIAssetRouter(ResourceRouter):
         """
 
         def get_resource_content(
-            identifier: Annotated[
-                str, Path(description=f"The identifier of the {self.resource_name}")  # type: ignore
-            ],
-            distribution_idx: Annotated[
-                int,
-                Path(
-                    description=f"The index of the distribution within the " f"{self.resource_name}"
-                ),  # type: ignore
-            ],
-            default: bool = False,
+            identifier: str = Path(description=f"The identifier of the {self.resource_name}"),
+            distribution_idx: int = Path(
+                description=f"The index of the distribution within the {self.resource_name}"
+            ),
         ):
             metadata: AIAsset = self.get_resource(
                 identifier=identifier, schema="aiod", platform=None
@@ -106,11 +98,9 @@ class ResourceAIAssetRouter(ResourceRouter):
                 raise _wrap_as_http_exception(exc)
 
         def get_resource_content_default(
-            identifier: Annotated[
-                str, Path(description=f"The identifier of the {self.resource_name}")  # type: ignore
-            ]
+            identifier: str = Path(description=f"The identifier of the {self.resource_name}"),
         ):
-            return get_resource_content(identifier=identifier, distribution_idx=0, default=True)
+            return get_resource_content(identifier=identifier, distribution_idx=0)
 
         if default:
             return get_resource_content_default

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -517,6 +517,7 @@ class ResourceRouter(abc.ABC):
             Literal[tuple(self._possible_schemas)],  # type: ignore
             Query(
                 description="Return the resource(s) in this schema.",
+                include_in_schema=len(self._possible_schemas) > 1,
             ),
         ]
 

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -269,9 +269,9 @@ class ResourceRouter(abc.ABC):
         """
 
         def get_resource_count(
-            detailed: Annotated[
-                bool, Query(description="If true, a more detailed output is returned.")
-            ] = False
+            detailed: bool = Query(
+                description="If true, a more detailed output is returned.", default=False
+            )
         ):
             try:
                 with DbSession() as session:
@@ -308,13 +308,10 @@ class ResourceRouter(abc.ABC):
         """
 
         def get_resources(
-            platform: Annotated[
-                str,
-                Path(
-                    description="Return resources of this platform",
-                    example="huggingface",
-                ),
-            ],
+            platform: str = Path(
+                description="Return resources of this platform",
+                example="huggingface",
+            ),
             pagination: Pagination = Depends(Pagination),
             schema: self._possible_schemas_type = "aiod",  # type:ignore
         ):
@@ -348,13 +345,10 @@ class ResourceRouter(abc.ABC):
 
         def get_resource(
             identifier: str,
-            platform: Annotated[
-                str,
-                Path(
-                    description="Return resources of this platform",
-                    example="huggingface",
-                ),
-            ],
+            platform: str = Path(
+                description="Return resources of this platform",
+                example="huggingface",
+            ),
             schema: self._possible_schemas_type = "aiod",  # type:ignore
         ):
             return self.get_resource(identifier=identifier, schema=schema, platform=platform)

--- a/src/routers/search_router.py
+++ b/src/routers/search_router.py
@@ -1,5 +1,5 @@
 import abc
-from typing import TypeVar, Generic, Any, Type, Annotated, Literal
+from typing import TypeVar, Generic, Any, Type, Literal
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
@@ -76,39 +76,32 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
             # response_model=SearchResult[read_class],  # This gives errors, so not used.
         )
         def search(
-            search_query: Annotated[
-                str,
-                Query(
-                    description="Text you wish to find. It is used in an ElasticSearch match "
-                    "query.",
-                    examples=["Name of the resource"],
-                ),
-            ],
-            search_fields: Annotated[  # type: ignore
-                list[indexed_fields] | None,
-                Query(
-                    description="Search in these fields. If empty, the query will be matched "
-                    "against all fields. Do not use the '--' option in Swagger, it is a Swagger "
-                    "artifact.",
-                ),
-            ] = None,
-            platforms: Annotated[
-                list[str] | None,
-                Query(
-                    description="Search for resources of these platforms. If empty, results from "
-                    "all platforms will be returned.",
-                    examples=["huggingface", "openml"],
-                ),
-            ] = None,
-            limit: Annotated[int | None, Query(ge=1, le=LIMIT_MAX)] = 10,
-            offset: Annotated[int | None, Query(ge=0)] = 0,
-            get_all: Annotated[
-                bool,
-                Query(
-                    description="If true, a request to the database is made to retrieve all data. "
-                    "If false, only the indexed information is returned."
-                ),
-            ] = False,
+            search_query: str = Query(
+                ...,
+                description="Text you wish to find. It is used in an ElasticSearch match " "query.",
+                examples=["Name of the resource"],
+            ),
+            search_fields: list[indexed_fields]  # type: ignore
+            | None = Query(
+                description="Search in these fields. If empty, the query will be matched "
+                "against all fields. Do not use the '--' option in Swagger, it is a Swagger "
+                "artifact.",
+                default=None,
+            ),
+            platforms: list[str]
+            | None = Query(
+                description="Search for resources of these platforms. If empty, results from "
+                "all platforms will be returned.",
+                examples=["huggingface", "openml"],
+                default=None,
+            ),
+            limit: int | None = Query(ge=1, le=LIMIT_MAX, default=10),
+            offset: int | None = Query(ge=0, default=0),
+            get_all: bool = Query(
+                description="If true, a request to the database is made to retrieve all data. "
+                "If false, only the indexed information is returned.",
+                default=False,
+            ),
         ):
             try:
                 with DbSession() as session:

--- a/src/routers/search_router.py
+++ b/src/routers/search_router.py
@@ -95,8 +95,8 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
                 examples=["huggingface", "openml"],
                 default=None,
             ),
-            limit: int | None = Query(ge=1, le=LIMIT_MAX, default=10),
-            offset: int | None = Query(ge=0, default=0),
+            limit: int = Query(ge=1, le=LIMIT_MAX, default=10),
+            offset: int = Query(ge=0, default=0),
             get_all: bool = Query(
                 description="If true, a request to the database is made to retrieve all data. "
                 "If false, only the indexed information is returned.",

--- a/src/routers/upload_router_huggingface.py
+++ b/src/routers/upload_router_huggingface.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Path
 from fastapi import File, Query, UploadFile
 
 from uploader.hugging_face_uploader import handle_upload
@@ -10,7 +10,10 @@ class UploadRouterHuggingface:
 
         @router.post(url_prefix + "/upload/datasets/{identifier}/huggingface", tags=["upload"])
         def huggingFaceUpload(
-            identifier: int,
+            identifier: int = Path(
+                ...,
+                description="The AIoD dataset identifier",
+            ),
             file: UploadFile = File(
                 ..., title="File", description="This file will be uploaded to HuggingFace"
             ),

--- a/src/routers/upload_router_huggingface.py
+++ b/src/routers/upload_router_huggingface.py
@@ -11,7 +11,6 @@ class UploadRouterHuggingface:
         @router.post(url_prefix + "/upload/datasets/{identifier}/huggingface", tags=["upload"])
         def huggingFaceUpload(
             identifier: int = Path(
-                ...,
                 description="The AIoD dataset identifier",
             ),
             file: UploadFile = File(


### PR DESCRIPTION
1.  Adding descriptions to Path and Query parameters, which is shown in Swagger
2.  Change the default Swagger example for list from a list with a single element, to an empty list. This is for instance convenient for `has_part`, which was on default `[0]` beforehand. That's a bit irritating if you're just trying out the POST without changing any values: it might raise an exception that the instance with identifier=0 does not exist
3. Remove `schema` query parameter if there is only a single option (this parameter is only used for DatasetRouter)