### PR TITLE
Bugfix/Authentication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ readme = "README.md"
 dev = [
     "types-python-dateutil==2.8.19.14",
     "pytest==7.4.3",
+    "pytest-asyncio==0.23.0b0",
     "pytest-dotenv==0.5.2",
     "pytest-xdist==3.5.0",
     "pre-commit==3.5.0",

--- a/src/authentication.py
+++ b/src/authentication.py
@@ -13,7 +13,7 @@ should not be responsible for keeping the permissions up to date. Explanation: i
 obtaining the permissions from the decoded token, the backend could also take the permissions.
 This is perfectly safe (the token cannot be changed without knowing the private key of keycloak).
 But then the frontend needs to make sure that the permissions are up-to-date. Every front-end
-should therefor request a new token every X minutes. This is not needed when the back-end
+should therefore request a new token every X minutes. This is not needed when the back-end
 performs a separate authorization request. The only downside is the overhead of the additional
 keycloak requests - if that becomes prohibitive in the future, we should reevaluate this design.
 """

--- a/src/main.py
+++ b/src/main.py
@@ -10,11 +10,10 @@ import pkg_resources
 import uvicorn
 from fastapi import Depends, FastAPI
 from fastapi.responses import HTMLResponse
-from pydantic import Json
 from sqlmodel import select
 
 import routers
-from authentication import get_current_user
+from authentication import get_current_user, User
 from config import KEYCLOAK_CONFIG
 from database.deletion.triggers import add_delete_triggers
 from database.model.concept.concept import AIoDConcept
@@ -64,7 +63,7 @@ def add_routes(app: FastAPI, url_prefix=""):
         """
 
     @app.get(url_prefix + "/authorization_test")
-    def test_authorization(user: Json = Depends(get_current_user)) -> dict:
+    def test_authorization(user: User = Depends(get_current_user)) -> dict:
         """
         Returns the user, if authenticated correctly.
         """

--- a/src/main.py
+++ b/src/main.py
@@ -63,11 +63,11 @@ def add_routes(app: FastAPI, url_prefix=""):
         """
 
     @app.get(url_prefix + "/authorization_test")
-    def test_authorization(user: User = Depends(get_current_user)) -> dict:
+    def test_authorization(user: User = Depends(get_current_user)) -> User:
         """
         Returns the user, if authenticated correctly.
         """
-        return {"msg": "success", "user": user}
+        return user
 
     @app.get(url_prefix + "/counts/v1")
     def counts() -> dict:

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -14,7 +14,7 @@ from sqlalchemy.sql.operators import is_
 from sqlmodel import SQLModel, Session, select, Field
 from starlette.responses import JSONResponse
 
-from authentication import get_current_user
+from authentication import get_current_user, User
 from config import KEYCLOAK_CONFIG
 from converters.schema_converters.schema_converter import SchemaConverter
 from database.model.ai_resource.resource import AbstractAIResource
@@ -365,9 +365,9 @@ class ResourceRouter(abc.ABC):
 
         def register_resource(
             resource_create: clz_create,  # type: ignore
-            user: dict = Depends(get_current_user),
+            user: User = Depends(get_current_user),
         ):
-            if "groups" in user and KEYCLOAK_CONFIG.get("role") not in user["groups"]:
+            if KEYCLOAK_CONFIG.get("role") not in user.roles:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="You do not have permission to edit Aiod resources.",
@@ -405,9 +405,9 @@ class ResourceRouter(abc.ABC):
         def put_resource(
             identifier: int,
             resource_create_instance: clz_create,  # type: ignore
-            user: dict = Depends(get_current_user),
+            user: User = Depends(get_current_user),
         ):
-            if "groups" in user and KEYCLOAK_CONFIG.get("role") not in user["groups"]:
+            if KEYCLOAK_CONFIG.get("role") not in user.roles:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="You do not have permission to edit Aiod resources.",
@@ -445,10 +445,10 @@ class ResourceRouter(abc.ABC):
 
         def delete_resource(
             identifier: str,
-            user: dict = Depends(get_current_user),
+            user: User = Depends(get_current_user),
         ):
             with DbSession() as session:
-                if "groups" in user and KEYCLOAK_CONFIG.get("role") not in user["groups"]:
+                if KEYCLOAK_CONFIG.get("role") not in user.roles:
                     raise HTTPException(
                         status_code=status.HTTP_403_FORBIDDEN,
                         detail="You do not have permission to delete Aiod resources.",

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -367,7 +367,7 @@ class ResourceRouter(abc.ABC):
             resource_create: clz_create,  # type: ignore
             user: User = Depends(get_current_user),
         ):
-            if KEYCLOAK_CONFIG.get("role") not in user.roles:
+            if not user.has_role(KEYCLOAK_CONFIG.get("role")):
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="You do not have permission to edit Aiod resources.",
@@ -407,7 +407,7 @@ class ResourceRouter(abc.ABC):
             resource_create_instance: clz_create,  # type: ignore
             user: User = Depends(get_current_user),
         ):
-            if KEYCLOAK_CONFIG.get("role") not in user.roles:
+            if not user.has_role(KEYCLOAK_CONFIG.get("role")):
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="You do not have permission to edit Aiod resources.",
@@ -448,7 +448,7 @@ class ResourceRouter(abc.ABC):
             user: User = Depends(get_current_user),
         ):
             with DbSession() as session:
-                if KEYCLOAK_CONFIG.get("role") not in user.roles:
+                if not user.has_role(KEYCLOAK_CONFIG.get("role")):
                     raise HTTPException(
                         status_code=status.HTTP_403_FORBIDDEN,
                         detail="You do not have permission to delete Aiod resources.",

--- a/src/tests/database/deletion/test_hard_delete.py
+++ b/src/tests/database/deletion/test_hard_delete.py
@@ -15,7 +15,7 @@ def test_hard_delete(
     mocked_privileged_token: Mock,
     draft: Status,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     now = datetime.datetime.now()
     deletion_time = now - datetime.timedelta(seconds=10)

--- a/src/tests/resources/authentication/user.json
+++ b/src/tests/resources/authentication/user.json
@@ -1,0 +1,42 @@
+{
+    "exp": 1701350361,
+    "iat": 1701350061,
+    "auth_time": 1701349686,
+    "jti": "0bce0fb9-3580-4a20-a0cb-5b9bffe60aa6",
+    "iss": "http://localhost/aiod-auth/realms/aiod",
+    "aud": "account",
+    "sub": "4a80f256-3928-4cfa-ba66-5e22bb36fc01",
+    "typ": "Bearer",
+    "azp": "aiod-api-swagger",
+    "session_state": "f64e4c2f-de29-4f8e-8812-e27e9932d837",
+    "acr": "0",
+    "allowed-origins": [
+      "http://localhost:8000"
+    ],
+    "realm_access": {
+      "roles": [
+        "offline_access",
+        "uma_authorization",
+        "default-roles-aiod"
+      ]
+    },
+    "resource_access": {
+      "account": {
+        "roles": [
+          "manage-account",
+          "manage-account-links",
+          "view-profile"
+        ]
+      }
+    },
+    "scope": "openid profile email",
+    "sid": "f64e4c2f-de29-4f8e-8812-e27e9932d837",
+    "email_verified": false,
+    "preferred_username": "user",
+    "given_name": "",
+    "family_name": "",
+    "client_id": "aiod-api-swagger",
+    "username": "user",
+    "token_type": "Bearer",
+    "active": true
+}

--- a/src/tests/resources/authentication/user_inactive.json
+++ b/src/tests/resources/authentication/user_inactive.json
@@ -1,0 +1,43 @@
+{
+    "exp": 1701350361,
+    "iat": 1701350061,
+    "auth_time": 1701349686,
+    "jti": "0bce0fb9-3580-4a20-a0cb-5b9bffe60aa6",
+    "iss": "http://localhost/aiod-auth/realms/aiod",
+    "aud": "account",
+    "sub": "4a80f256-3928-4cfa-ba66-5e22bb36fc01",
+    "typ": "Bearer",
+    "azp": "aiod-api-swagger",
+    "session_state": "f64e4c2f-de29-4f8e-8812-e27e9932d837",
+    "acr": "0",
+    "allowed-origins": [
+      "http://localhost:8000"
+    ],
+    "realm_access": {
+      "roles": [
+        "offline_access",
+        "uma_authorization",
+        "default-roles-aiod",
+        "edit_aiod_resources"
+      ]
+    },
+    "resource_access": {
+      "account": {
+        "roles": [
+          "manage-account",
+          "manage-account-links",
+          "view-profile"
+        ]
+      }
+    },
+    "scope": "openid profile email",
+    "sid": "f64e4c2f-de29-4f8e-8812-e27e9932d837",
+    "email_verified": false,
+    "preferred_username": "user",
+    "given_name": "",
+    "family_name": "",
+    "client_id": "aiod-api-swagger",
+    "username": "user",
+    "token_type": "Bearer",
+    "active": false
+}

--- a/src/tests/resources/authentication/user_privileged.json
+++ b/src/tests/resources/authentication/user_privileged.json
@@ -1,0 +1,43 @@
+{
+    "exp": 1701350361,
+    "iat": 1701350061,
+    "auth_time": 1701349686,
+    "jti": "0bce0fb9-3580-4a20-a0cb-5b9bffe60aa6",
+    "iss": "http://localhost/aiod-auth/realms/aiod",
+    "aud": "account",
+    "sub": "4a80f256-3928-4cfa-ba66-5e22bb36fc01",
+    "typ": "Bearer",
+    "azp": "aiod-api-swagger",
+    "session_state": "f64e4c2f-de29-4f8e-8812-e27e9932d837",
+    "acr": "0",
+    "allowed-origins": [
+      "http://localhost:8000"
+    ],
+    "realm_access": {
+      "roles": [
+        "offline_access",
+        "uma_authorization",
+        "default-roles-aiod",
+        "edit_aiod_resources"
+      ]
+    },
+    "resource_access": {
+      "account": {
+        "roles": [
+          "manage-account",
+          "manage-account-links",
+          "view-profile"
+        ]
+      }
+    },
+    "scope": "openid profile email",
+    "sid": "f64e4c2f-de29-4f8e-8812-e27e9932d837",
+    "email_verified": false,
+    "preferred_username": "user",
+    "given_name": "",
+    "family_name": "",
+    "client_id": "aiod-api-swagger",
+    "username": "user",
+    "token_type": "Bearer",
+    "active": true
+}

--- a/src/tests/routers/ai_asset_routers/test_router_aiassets_retrieve_content.py
+++ b/src/tests/routers/ai_asset_routers/test_router_aiassets_retrieve_content.py
@@ -61,7 +61,7 @@ def set_up(
     adding a person to the database, and sending a POST request to the
     specified endpoint for the given resource.
     """
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     with DbSession() as session:
         session.add(person)
         session.commit()

--- a/src/tests/routers/generic/test_authentication.py
+++ b/src/tests/routers/generic/test_authentication.py
@@ -47,7 +47,7 @@ def test_delete_unauthenticated(
 
 
 def test_delete_unauthorized(client_test_resource: TestClient, mocked_token: Mock):
-    keycloak_openid.userinfo = mocked_token
+    keycloak_openid.introspect = mocked_token
     response = client_test_resource.delete(
         "/test_resources/v0/1",
         headers={"Authorization": "fake-token"},
@@ -58,7 +58,7 @@ def test_delete_unauthorized(client_test_resource: TestClient, mocked_token: Moc
 
 
 def test_post_unauthorized(client_test_resource: TestClient, mocked_token: Mock):
-    keycloak_openid.userinfo = mocked_token
+    keycloak_openid.introspect = mocked_token
     response = client_test_resource.post(
         "/test_resources/v0",
         json={"title": "example"},
@@ -79,7 +79,7 @@ def test_post_unauthenticated(client_test_resource: TestClient):
 
 
 def test_put_unauthorized(client_test_resource: TestClient, mocked_token: Mock):
-    keycloak_openid.userinfo = mocked_token
+    keycloak_openid.introspect = mocked_token
     response = client_test_resource.put(
         "/test_resources/v0/1",
         json={"title": "example"},

--- a/src/tests/routers/generic/test_router_delete.py
+++ b/src/tests/routers/generic/test_router_delete.py
@@ -16,7 +16,7 @@ def test_happy_path(
     mocked_privileged_token: Mock,
     draft: Status,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     with DbSession() as session:
         session.add_all(
@@ -54,7 +54,7 @@ def test_non_existent(
     mocked_privileged_token: Mock,
     draft: Status,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     with DbSession() as session:
         session.add_all(
             [
@@ -84,7 +84,7 @@ def test_add_after_deletion(
     client_test_resource: TestClient,
     mocked_privileged_token: Mock,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = {"title": "my_favourite_resource"}
     response = client_test_resource.post(
         "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}

--- a/src/tests/routers/generic/test_router_deprecation.py
+++ b/src/tests/routers/generic/test_router_deprecation.py
@@ -37,7 +37,7 @@ class DeprecatedRouter(RouterTestResource):
 def test_deprecated_router(
     engine_test_resource_filled: Engine, verb: str, url: str, mocked_privileged_token: Mock
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     app = FastAPI()
     app.include_router(DeprecatedRouter().create(""))
     client = TestClient(app)

--- a/src/tests/routers/generic/test_router_post.py
+++ b/src/tests/routers/generic/test_router_post.py
@@ -11,7 +11,7 @@ from authentication import keycloak_openid
     ["\"'é:?", "!@#$%^&*()`~", "Ω≈ç√∫˜µ≤≥÷", "田中さんにあげて下さい", " أي بعد, ", "𝑻𝒉𝒆 𝐪𝐮𝐢𝐜𝐤", "گچپژ"],
 )
 def test_unicode(client_test_resource: TestClient, title: str, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     response = client_test_resource.post(
         "/test_resources/v0",
         json={"title": title, "platform": "example", "platform_resource_identifier": "1"},
@@ -26,7 +26,7 @@ def test_unicode(client_test_resource: TestClient, title: str, mocked_privileged
 
 
 def test_missing_value(client_test_resource: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = {"platform": "example", "platform_resource_identifier": "1"}
     response = client_test_resource.post(
         "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
@@ -38,7 +38,7 @@ def test_missing_value(client_test_resource: TestClient, mocked_privileged_token
 
 
 def test_null_value(client_test_resource: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = {"title": None, "platform": "example", "platform_resource_identifier": "1"}
     response = client_test_resource.post(
         "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
@@ -54,7 +54,7 @@ def test_null_value(client_test_resource: TestClient, mocked_privileged_token: M
 
 
 def test_posting_same_item_twice(client_test_resource: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "example", "platform_resource_identifier": "1"}
     response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
@@ -71,7 +71,7 @@ def test_posting_same_item_twice(client_test_resource: TestClient, mocked_privil
 def test_posting_same_item_twice_but_deleted(
     client_test_resource: TestClient, mocked_privileged_token: Mock
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "example", "platform_resource_identifier": "1"}
     response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
@@ -88,7 +88,7 @@ def test_posting_same_item_twice_but_deleted(
 def test_no_platform_no_platform_resource_identifier(
     client_test_resource: TestClient, mocked_privileged_token: Mock
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": None, "platform_resource_identifier": None}
     response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
@@ -101,7 +101,7 @@ def test_no_platform_no_platform_resource_identifier(
 def test_no_platform_with_platform_resource_identifier(
     client_test_resource: TestClient, mocked_privileged_token: Mock
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": None, "platform_resource_identifier": "1"}
     response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
@@ -116,7 +116,7 @@ def test_no_platform_with_platform_resource_identifier(
 def test_platform_with_no_platform_resource_identifier(
     client_test_resource: TestClient, mocked_privileged_token: Mock
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "example", "platform_resource_identifier": None}
     response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
@@ -129,7 +129,7 @@ def test_platform_with_no_platform_resource_identifier(
 
 
 def test_non_existent_platform(client_test_resource: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     keycloak_openid.public_key = Mock(return_value="")
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "this_does_not_exist", "platform_resource_identifier": 1}

--- a/src/tests/routers/generic/test_router_put.py
+++ b/src/tests/routers/generic/test_router_put.py
@@ -17,7 +17,7 @@ def test_unicode(
     title: str,
     mocked_privileged_token: Mock,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     response = client_test_resource.put(
         "/test_resources/v0/1",
         json={"title": title, "platform": "openml", "platform_resource_identifier": "2"},
@@ -37,7 +37,7 @@ def test_non_existent(
     engine_test_resource_filled: Engine,
     mocked_privileged_token: Mock,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     response = client_test_resource.put(
         "/test_resources/v0/2",
         json={"title": "new_title", "platform": "other", "platform_resource_identifier": "2"},
@@ -53,7 +53,7 @@ def test_too_long_name(
     engine_test_resource_filled: Engine,
     mocked_privileged_token: Mock,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     name = "a" * 251
     response = client_test_resource.put(
         "/test_resources/v0/1", json={"title": name}, headers={"Authorization": "Fake token"}
@@ -79,7 +79,7 @@ def test_no_platform_with_platform_resource_identifier(
     The error handling should be the same as with the POST endpoints, so we're not testing all
     the possible UNIQUE / CHECK constraints here, just this one.
     """
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     response = client_test_resource.put(
         "/test_resources/v0/1",
         json={"title": "title", "platform": "other", "platform_resource_identifier": None},

--- a/src/tests/routers/generic/test_router_relations.py
+++ b/src/tests/routers/generic/test_router_relations.py
@@ -198,7 +198,7 @@ def test_get_all_happy_path(client_with_testobject: TestClient):
 
 
 def test_post_happy_path(client_with_testobject: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     response = client_with_testobject.post(
         "/test_resources/v0",
         json={
@@ -229,7 +229,7 @@ def test_post_happy_path(client_with_testobject: TestClient, mocked_privileged_t
 
 
 def test_put_happy_path(client_with_testobject: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     response = client_with_testobject.put(
         "/test_resources/v0/4",
         json={

--- a/src/tests/routers/resource_routers/test_router_case_study.py
+++ b/src/tests/routers/resource_routers/test_router_case_study.py
@@ -11,7 +11,7 @@ def test_happy_path(
     mocked_privileged_token: Mock,
     body_asset: dict,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = copy.copy(body_asset)
     body["name"] = "Case Study"
 

--- a/src/tests/routers/resource_routers/test_router_computational_asset.py
+++ b/src/tests/routers/resource_routers/test_router_computational_asset.py
@@ -7,7 +7,7 @@ from authentication import keycloak_openid
 
 
 def test_happy_path(client: TestClient, mocked_privileged_token: Mock, body_asset: dict):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     body = copy.deepcopy(body_asset)
     body["status_info"] = "https://www.example.com/cluster-status"

--- a/src/tests/routers/resource_routers/test_router_contact.py
+++ b/src/tests/routers/resource_routers/test_router_contact.py
@@ -7,7 +7,7 @@ from authentication import keycloak_openid
 
 
 def test_happy_path(client: TestClient, mocked_privileged_token: Mock, body_asset: dict):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     client.post(
         "/persons/v1", json={"name": "test person"}, headers={"Authorization": "Fake token"}
     )
@@ -50,7 +50,7 @@ def test_post_duplicate_email(
     """
     It should be possible to add same email in different contacts, to enable
     """
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     body1 = {"email": ["a@example.com", "b@example.com"]}
     body2 = {"email": ["c@example.com", "b@example.com"]}

--- a/src/tests/routers/resource_routers/test_router_dataset.py
+++ b/src/tests/routers/resource_routers/test_router_dataset.py
@@ -14,7 +14,7 @@ def test_happy_path(
     body_asset: dict,
     person: Person,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     with DbSession() as session:
         session.add(person)

--- a/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
+++ b/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
@@ -30,7 +30,7 @@ def test_happy_path(
     publication: Publication,
     contact: Contact,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     with DbSession() as session:
         session.add(person)
         session.merge(publication)
@@ -156,7 +156,7 @@ def test_post_duplicate_named_relations(
     """
     Unittest mirroring situation reported during the data migration of AI4EU news.
     """
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     def create_body(i: int, *keywords):
         return {"name": f"dataset{i}", "keyword": keywords}
@@ -222,7 +222,7 @@ def test_post_duplicate_named_relations_with_different_capitals(
     client: TestClient,
     mocked_privileged_token: Mock,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     def create_body(i: int, *keywords):
         return {"name": f"dataset{i}", "keyword": keywords}
@@ -241,7 +241,7 @@ def test_post_editors(
     """
     Unittest mirroring situation reported during the data migration of AI4EU events.
     """
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     headers = {"Authorization": "Fake token"}
     client.post("/persons/v1", json={"name": "1"}, headers=headers)
     client.post("/persons/v1", json={"name": "2"}, headers=headers)
@@ -267,7 +267,7 @@ def test_post_editors(
 
 
 def test_create_aiod_entry(client: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = {"name": "news"}
     start = datetime.now(pytz.utc)
     response = client.post("/news/v1", json=body, headers={"Authorization": "Fake token"})
@@ -286,7 +286,7 @@ def test_create_aiod_entry(client: TestClient, mocked_privileged_token: Mock):
 
 
 def test_update_aiod_entry(client: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = {"name": "news"}
     start = datetime.now(pytz.utc)
     response = client.post("/news/v1", json=body, headers={"Authorization": "Fake token"})
@@ -324,7 +324,7 @@ def assert_distributions(client: TestClient, *content_urls: str):
 
 
 def test_update_distribution(client: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = {"name": "dataset", "distribution": [{"content_url": "url"}]}
     response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
@@ -366,7 +366,7 @@ def test_relations_between_resources(
     publication: Publication,
     organisation: Organisation,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     with DbSession() as session:
         session.add(dataset)

--- a/src/tests/routers/resource_routers/test_router_educational_resource.py
+++ b/src/tests/routers/resource_routers/test_router_educational_resource.py
@@ -11,7 +11,7 @@ def test_happy_path(
     mocked_privileged_token: Mock,
     body_asset: dict,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     body = copy.deepcopy(body_asset)
     body["time_required"] = "3 weeks"

--- a/src/tests/routers/resource_routers/test_router_event.py
+++ b/src/tests/routers/resource_routers/test_router_event.py
@@ -19,7 +19,7 @@ def test_happy_path(
         session.add(person)
         session.commit()
 
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = copy.copy(body_resource)
     body["start_date"] = "2021-02-03T15:15:00"
     body["end_date"] = "2022-02-03T15:15:00"

--- a/src/tests/routers/resource_routers/test_router_experiment.py
+++ b/src/tests/routers/resource_routers/test_router_experiment.py
@@ -11,7 +11,7 @@ def test_happy_path(
     mocked_privileged_token: Mock,
     body_asset: dict,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     body = copy.copy(body_asset)
     body["pid"] = "https://doi.org/10.1000/182"

--- a/src/tests/routers/resource_routers/test_router_ml_model.py
+++ b/src/tests/routers/resource_routers/test_router_ml_model.py
@@ -14,7 +14,7 @@ def test_happy_path(
     experiment: Experiment,
     body_asset: dict,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     with DbSession() as session:
         session.add(experiment)

--- a/src/tests/routers/resource_routers/test_router_news.py
+++ b/src/tests/routers/resource_routers/test_router_news.py
@@ -11,7 +11,7 @@ def test_happy_path(
     mocked_privileged_token: Mock,
     body_resource: dict,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = copy.deepcopy(body_resource)
     body["headline"] = "A headline to show on top of the page."
     body["alternative_headline"] = "An alternative headline."

--- a/src/tests/routers/resource_routers/test_router_organisation.py
+++ b/src/tests/routers/resource_routers/test_router_organisation.py
@@ -16,7 +16,7 @@ def test_happy_path(
     contact: Contact,
     body_agent: dict,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     with DbSession() as session:
         session.add(organisation)  # The new organisation will be a member of this organisation

--- a/src/tests/routers/resource_routers/test_router_person.py
+++ b/src/tests/routers/resource_routers/test_router_person.py
@@ -16,7 +16,7 @@ def test_happy_path(
     person: Person,
     contact: Contact,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     with DbSession() as session:
         person.platform_resource_identifier = "2"

--- a/src/tests/routers/resource_routers/test_router_platform.py
+++ b/src/tests/routers/resource_routers/test_router_platform.py
@@ -8,7 +8,7 @@ from database.model.platform.platform_names import PlatformName
 
 
 def test_happy_path(client: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = {"name": "my_favourite_platform"}
     response = client.post("/platforms/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
@@ -28,7 +28,7 @@ def test_get_platform_of_platform(client: TestClient, url: str):
 
 
 def test_delete_platform(client: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = {"name": "my_favourite_platform"}
     response = client.post("/platforms/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
@@ -40,7 +40,7 @@ def test_delete_platform(client: TestClient, mocked_privileged_token: Mock):
 
 
 def test_platform_same_name(client: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     body = {"name": "my_favourite_platform"}
     response = client.post("/platforms/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()

--- a/src/tests/routers/resource_routers/test_router_project.py
+++ b/src/tests/routers/resource_routers/test_router_project.py
@@ -20,7 +20,7 @@ def test_happy_path(
     publication: Publication,
     dataset: Dataset,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     with DbSession() as session:
         session.add(person)

--- a/src/tests/routers/resource_routers/test_router_publication.py
+++ b/src/tests/routers/resource_routers/test_router_publication.py
@@ -13,7 +13,7 @@ def test_happy_path(
     body_asset: dict,
     dataset: Dataset,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     body = copy.copy(body_asset)
     body["permanent_identifier"] = "http://dx.doi.org/10.1093/ajae/aaq063"

--- a/src/tests/routers/resource_routers/test_router_service.py
+++ b/src/tests/routers/resource_routers/test_router_service.py
@@ -11,7 +11,7 @@ def test_happy_path(
     mocked_privileged_token: Mock,
     body_resource: dict,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     body = copy.copy(body_resource)
     body["slogan"] = "Smart Blockchains for everyone!"

--- a/src/tests/routers/resource_routers/test_router_team.py
+++ b/src/tests/routers/resource_routers/test_router_team.py
@@ -16,7 +16,7 @@ def test_happy_path(
     person: Person,
     organisation: Organisation,
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
 
     with DbSession() as session:
         session.add(person)

--- a/src/tests/routers/search_routers/test_search_routers.py
+++ b/src/tests/routers/search_routers/test_search_routers.py
@@ -36,7 +36,7 @@ def test_search_happy_path(client: TestClient, search_router):
 
 
 def test_search_happy_path_get_all(client: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     mock_elasticsearch(filename_mock="event_search.json")
 
     body = {"name": "A name.", "keyword": ["keyword1", "keyword2"]}  # keywords not indexed by ES

--- a/src/tests/test_authentication.py
+++ b/src/tests/test_authentication.py
@@ -1,6 +1,5 @@
 """Unittests for the behaviour of get_current_user()."""
-
-
+import inspect
 from unittest.mock import Mock
 
 import pytest
@@ -9,7 +8,7 @@ from keycloak import KeycloakError
 from starlette import status
 
 
-from authentication import get_current_user, keycloak_openid
+from authentication import get_current_user, keycloak_openid, User
 from tests.testutils.mock_keycloak import MockedKeycloak, TestUserType
 
 
@@ -32,6 +31,17 @@ async def test_happy_path_privileged():
         "default-roles-aiod",
         "edit_aiod_resources",
     }
+
+
+def test_get_current_user_leaks_no_information():
+    """
+    Make sure an error is thrown if you change the fields on User. There may be good reasons to
+    make a change, but please be very careful: we don't want to expose sensitive information to
+    our application if it is not necessary. Moreover, the User class is returned by the
+    authorization_test endpoint.
+    """
+    assert inspect.signature(get_current_user).return_annotation == User
+    assert set(inspect.get_annotations(User)) == {"name", "roles"}
 
 
 @pytest.mark.asyncio

--- a/src/tests/test_authentication.py
+++ b/src/tests/test_authentication.py
@@ -1,0 +1,68 @@
+from contextlib import contextmanager
+from unittest.mock import Mock
+
+import pytest
+import responses
+from fastapi import HTTPException
+from keycloak import KeycloakError
+from starlette import status
+
+from authentication import get_current_user, keycloak_openid
+from tests.testutils.authentication import MockedKeycloak, TestUserType
+
+
+@contextmanager
+def Jos() -> responses.RequestsMock:
+    request_mock = responses.RequestsMock()
+    try:
+        yield request_mock
+    finally:
+        request_mock.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_happy_path():
+    with MockedKeycloak() as _:
+        user = await get_current_user(token="Bearer mocked")
+    assert user.name == "user"
+    assert set(user.roles) == {"offline_access", "uma_authorization", "default-roles-aiod"}
+
+
+@pytest.mark.asyncio
+async def test_inactive_user():
+    with MockedKeycloak(type_=TestUserType.inactive) as _:
+        with pytest.raises(HTTPException) as exception_info:
+            await get_current_user(token="Bearer mocked")
+
+        assert exception_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exception_info.value.detail == "Invalid authentication token"
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated():
+    with pytest.raises(HTTPException) as exception_info:
+        await get_current_user(token=None)
+    assert exception_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert (
+        exception_info.value.detail
+        == "This endpoint requires authorization. You need to be logged in."
+    )
+
+
+@pytest.mark.asyncio
+async def test_keycloak_error():
+    """
+    On any problem, keycloak_openid.introspect raises an error.
+
+    Refer to https://connect2id.com/products/server/docs/api/token-introspection for a list of
+    possible errors. Only created a single testcase because we handle all errors the same way.
+    """
+    keycloak_openid.introspect = Mock(
+        side_effect=KeycloakError(
+            error_message="unused message", response_code=status.HTTP_403_FORBIDDEN
+        )
+    )
+    with pytest.raises(HTTPException) as exception_info:
+        await get_current_user(token="Bearer mocked")
+    assert exception_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert exception_info.value.detail == "Invalid authentication token"

--- a/src/tests/testutils/authentication.py
+++ b/src/tests/testutils/authentication.py
@@ -1,0 +1,43 @@
+import enum
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+import responses
+
+from tests.testutils.paths import path_test_resources
+
+
+class TestUserType(enum.Enum):
+    user = "user.json"
+    privileged = "user_privileged.json"
+    inactive = "user_inactive.json"
+
+
+@contextmanager
+def MockedKeycloak(type_: TestUserType = TestUserType.user) -> responses.RequestsMock:
+    """
+    Returning a SQLModel session bound to the (configured) database engine.
+
+    Alternatively, we could have used FastAPI Depends, but that only works for FastAPI - while
+    the synchronization, for instance, also needs a Session, but doesn't use FastAPI.
+    """
+    path_user = path_test_resources() / "authentication" / type_.value
+    return _mocked_user(path_user)
+
+
+def _mocked_user(path_user_json: Path) -> responses.RequestsMock:
+    with path_user_json.open("r") as f:
+        response = json.load(f)
+
+    request_mock = responses.RequestsMock()
+    request_mock.start()
+    request_mock.add(
+        responses.POST,
+        "http://keycloak:8080/aiod-auth/realms/aiod/protocol/openid-connect/token/introspect",
+        json=response,
+    )
+    try:
+        yield request_mock
+    finally:
+        request_mock.__exit__(None, None, None)

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -110,12 +110,19 @@ def client_test_resource(engine: Engine) -> TestClient:
 @pytest.fixture()
 def mocked_token() -> Mock:
     default_user = {
-        "name": "test-user",
-        "groups": [
-            "default-roles-dev",
-            "offline_access",
-            "uma_authorization",
-        ],
+        "msg": "success",
+        "user": {
+            "realm_access": {
+                "roles": ["offline_access", "uma_authorization", "default-roles-aiod"]
+            },
+            "resource_access": {
+                "account": {"roles": ["manage-account", "manage-account-links", "view-profile"]}
+            },
+            "scope": "openid profile email",
+            "username": "user",
+            "token_type": "Bearer",
+            "active": True,
+        },
     }
     return Mock(return_value=default_user)
 
@@ -123,12 +130,23 @@ def mocked_token() -> Mock:
 @pytest.fixture()
 def mocked_privileged_token() -> Mock:
     default_user = {
-        "name": "test-user",
-        "groups": [
-            "default-roles-dev",
-            "offline_access",
-            "uma_authorization",
-            "edit_aiod_resources",
-        ],
+        "msg": "success",
+        "user": {
+            "realm_access": {
+                "roles": [
+                    "offline_access",
+                    "uma_authorization",
+                    "default-roles-aiod",
+                    "edit_aiod_resources",
+                ]
+            },
+            "resource_access": {
+                "account": {"roles": ["manage-account", "manage-account-links", "view-profile"]}
+            },
+            "scope": "openid profile email",
+            "username": "user",
+            "token_type": "Bearer",
+            "active": True,
+        },
     }
     return Mock(return_value=default_user)

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -110,19 +110,14 @@ def client_test_resource(engine: Engine) -> TestClient:
 @pytest.fixture()
 def mocked_token() -> Mock:
     default_user = {
-        "msg": "success",
-        "user": {
-            "realm_access": {
-                "roles": ["offline_access", "uma_authorization", "default-roles-aiod"]
-            },
-            "resource_access": {
-                "account": {"roles": ["manage-account", "manage-account-links", "view-profile"]}
-            },
-            "scope": "openid profile email",
-            "username": "user",
-            "token_type": "Bearer",
-            "active": True,
+        "realm_access": {"roles": ["offline_access", "uma_authorization", "default-roles-aiod"]},
+        "resource_access": {
+            "account": {"roles": ["manage-account", "manage-account-links", "view-profile"]}
         },
+        "scope": "openid profile email",
+        "username": "user",
+        "token_type": "Bearer",
+        "active": True,
     }
     return Mock(return_value=default_user)
 
@@ -130,23 +125,20 @@ def mocked_token() -> Mock:
 @pytest.fixture()
 def mocked_privileged_token() -> Mock:
     default_user = {
-        "msg": "success",
-        "user": {
-            "realm_access": {
-                "roles": [
-                    "offline_access",
-                    "uma_authorization",
-                    "default-roles-aiod",
-                    "edit_aiod_resources",
-                ]
-            },
-            "resource_access": {
-                "account": {"roles": ["manage-account", "manage-account-links", "view-profile"]}
-            },
-            "scope": "openid profile email",
-            "username": "user",
-            "token_type": "Bearer",
-            "active": True,
+        "realm_access": {
+            "roles": [
+                "offline_access",
+                "uma_authorization",
+                "default-roles-aiod",
+                "edit_aiod_resources",
+            ]
         },
+        "resource_access": {
+            "account": {"roles": ["manage-account", "manage-account-links", "view-profile"]}
+        },
+        "scope": "openid profile email",
+        "username": "user",
+        "token_type": "Bearer",
+        "active": True,
     }
     return Mock(return_value=default_user)

--- a/src/tests/testutils/mock_keycloak.py
+++ b/src/tests/testutils/mock_keycloak.py
@@ -1,3 +1,5 @@
+"""Mocking the Keycloak instance."""
+
 import enum
 import json
 from contextlib import contextmanager
@@ -17,10 +19,7 @@ class TestUserType(enum.Enum):
 @contextmanager
 def MockedKeycloak(type_: TestUserType = TestUserType.user) -> responses.RequestsMock:
     """
-    Returning a SQLModel session bound to the (configured) database engine.
-
-    Alternatively, we could have used FastAPI Depends, but that only works for FastAPI - while
-    the synchronization, for instance, also needs a Session, but doesn't use FastAPI.
+    Mock the keycloak instance.
     """
     path_user = path_test_resources() / "authentication" / type_.value
     return _mocked_user(path_user)

--- a/src/tests/uploader/huggingface/test_dataset_uploader.py
+++ b/src/tests/uploader/huggingface/test_dataset_uploader.py
@@ -14,7 +14,7 @@ from tests.testutils.paths import path_test_resources
 def test_happy_path_new_repository(
     client: TestClient, mocked_privileged_token: Mock, dataset: Dataset
 ):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     with DbSession() as session:
         session.add(dataset)
         session.commit()
@@ -48,7 +48,7 @@ def test_happy_path_new_repository(
 
 
 def test_repo_already_exists(client: TestClient, mocked_privileged_token: Mock):
-    keycloak_openid.userinfo = mocked_privileged_token
+    keycloak_openid.introspect = mocked_privileged_token
     dataset_id = 1
     with DbSession() as session:
         session.add_all(


### PR DESCRIPTION
Use `keycloak_openid.introspect(token)` instead of `keycloak_openid.userinfo(token)`.

The previous code used the bearer token to authenticate to Keycloak. In other words, it authenticated with Keycloak in the name of the user. (http://openid.net/specs/openid-connect-core-1_0.html#UserInfo) This meant that the `client_id` and `client_secret` were ignored. This is not directly unsafe, but it removes a layer of defense.

Instead, we want to authenticate as the AIoD API using the `client_id` and `client_secret`. We can do that using `introspect`: https://datatracker.ietf.org/doc/html/rfc7662.

Couple of other changes:

1. Made sure that a `User` object is returned, with only the username and roles. This way, we're sure not to leak any other information to our own application, and by extension to endpoints such as /authentication-test (just as precaution). Moreover, it simplifies the rest of the code, making authorization-checks less error-prone.
2. Checking the introspected information: is the user still active?
3. Added unittests
