### PR TITLE
Maint/#217

### DIFF
--- a/src/routers/resource_ai_asset_router.py
+++ b/src/routers/resource_ai_asset_router.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 import requests
 from fastapi import APIRouter, HTTPException, status, Path
 from fastapi.responses import Response
@@ -48,10 +50,13 @@ class ResourceAIAssetRouter(ResourceRouter):
         """
 
         def get_resource_content(
-            identifier: str = Path(description=f"The identifier of the {self.resource_name}"),
-            distribution_idx: int = Path(
-                description=f"The index of the distribution within the {self.resource_name}"
-            ),
+            identifier: Annotated[
+                str, Path(description=f"The identifier of the {self.resource_name}")
+            ],
+            distribution_idx: Annotated[
+                int,
+                Path(description=f"The index of the distribution within the {self.resource_name}"),
+            ],
         ):
             metadata: AIAsset = self.get_resource(
                 identifier=identifier, schema="aiod", platform=None
@@ -98,7 +103,9 @@ class ResourceAIAssetRouter(ResourceRouter):
                 raise _wrap_as_http_exception(exc)
 
         def get_resource_content_default(
-            identifier: str = Path(description=f"The identifier of the {self.resource_name}"),
+            identifier: Annotated[
+                str, Path(description=f"The identifier of the {self.resource_name}")
+            ],
         ):
             return get_resource_content(identifier=identifier, distribution_idx=0)
 

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -308,11 +308,14 @@ class ResourceRouter(abc.ABC):
         """
 
         def get_resources(
-            platform: str = Path(
-                description="Return resources of this platform",
-                example="huggingface",
-            ),
-            pagination: Pagination = Depends(Pagination),
+            platform: Annotated[
+                str,
+                Path(
+                    description="Return resources of this platform",
+                    example="huggingface",
+                ),
+            ],
+            pagination: Annotated[Pagination, Depends(Pagination)],
             schema: self._possible_schemas_type = "aiod",  # type:ignore
         ):
             resources = self.get_resources(pagination=pagination, schema=schema, platform=platform)
@@ -344,11 +347,19 @@ class ResourceRouter(abc.ABC):
         """
 
         def get_resource(
-            identifier: str,
-            platform: str = Path(
-                description="Return resources of this platform",
-                example="huggingface",
-            ),
+            identifier: Annotated[
+                str,
+                Path(
+                    description="The identifier under which the resource is known by the platform.",
+                ),
+            ],
+            platform: Annotated[
+                str,
+                Path(
+                    description="Return resources of this platform",
+                    example="huggingface",
+                ),
+            ],
             schema: self._possible_schemas_type = "aiod",  # type:ignore
         ):
             return self.get_resource(identifier=identifier, schema=schema, platform=platform)

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -269,9 +269,9 @@ class ResourceRouter(abc.ABC):
         """
 
         def get_resource_count(
-            detailed: bool = Query(
-                description="If true, a more detailed output is returned.", default=False
-            )
+            detailed: Annotated[
+                bool, Query(description="If true, a more detailed output is returned.")
+            ] = False,
         ):
             try:
                 with DbSession() as session:

--- a/src/routers/upload_router_huggingface.py
+++ b/src/routers/upload_router_huggingface.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Path
 from fastapi import File, Query, UploadFile
 
@@ -10,18 +12,22 @@ class UploadRouterHuggingface:
 
         @router.post(url_prefix + "/upload/datasets/{identifier}/huggingface", tags=["upload"])
         def huggingFaceUpload(
-            identifier: int = Path(
-                description="The AIoD dataset identifier",
-            ),
-            file: UploadFile = File(
-                ..., title="File", description="This file will be uploaded to HuggingFace"
-            ),
-            token: str = Query(
-                ..., title="Huggingface Token", description="The access token of HuggingFace"
-            ),
-            username: str = Query(
-                ..., title="Huggingface username", description="The username of HuggingFace"
-            ),
+            identifier: Annotated[
+                int,
+                Path(
+                    description="The AIoD dataset identifier",
+                ),
+            ],
+            file: Annotated[
+                UploadFile,
+                File(title="File", description="This file will be uploaded to HuggingFace"),
+            ],
+            token: Annotated[
+                str, Query(title="Huggingface Token", description="The access token of HuggingFace")
+            ],
+            username: Annotated[
+                str, Query(title="Huggingface username", description="The username of HuggingFace")
+            ],
         ) -> int:
             return handle_upload(identifier, file, token, username)
 


### PR DESCRIPTION
This specifically only annotates those endpoints which has a `Path` or `Query` in their signature.
However, it may be useful to annotate all endpoint parameters this way, to explicitly state whether they are `Query`, `Path`, or `Body` parameters and provide them with additional metadata (description, example).