### PR TITLE
Checking for roles such as crud_datasets, create_datasets etc.

### DIFF
--- a/src/authentication.py
+++ b/src/authentication.py
@@ -51,6 +51,9 @@ class User(BaseModel):
     def has_role(self, role: str) -> bool:
         return role in self.roles
 
+    def has_any_role(self, *roles: str) -> bool:
+        return bool(set(roles) & self.roles)
+
 
 async def get_current_user(token=Security(oidc)) -> User:
     """

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -378,10 +378,14 @@ class ResourceRouter(abc.ABC):
             resource_create: clz_create,  # type: ignore
             user: User = Depends(get_current_user),
         ):
-            if not user.has_role(KEYCLOAK_CONFIG.get("role")):
+            if not user.has_any_role(
+                KEYCLOAK_CONFIG.get("role"),
+                f"create_{self.resource_name_plural}",
+                f"crud_{self.resource_name_plural}",
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail="You do not have permission to edit Aiod resources.",
+                    detail=f"You do not have permission to create {self.resource_name_plural}.",
                 )
             try:
                 with DbSession() as session:
@@ -418,10 +422,14 @@ class ResourceRouter(abc.ABC):
             resource_create_instance: clz_create,  # type: ignore
             user: User = Depends(get_current_user),
         ):
-            if not user.has_role(KEYCLOAK_CONFIG.get("role")):
+            if not user.has_any_role(
+                KEYCLOAK_CONFIG.get("role"),
+                f"update_{self.resource_name_plural}",
+                f"crud_{self.resource_name_plural}",
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail="You do not have permission to edit Aiod resources.",
+                    detail=f"You do not have permission to edit {self.resource_name_plural}.",
                 )
 
             with DbSession() as session:
@@ -459,10 +467,14 @@ class ResourceRouter(abc.ABC):
             user: User = Depends(get_current_user),
         ):
             with DbSession() as session:
-                if not user.has_role(KEYCLOAK_CONFIG.get("role")):
+                if not user.has_any_role(
+                    KEYCLOAK_CONFIG.get("role"),
+                    f"delete_{self.resource_name_plural}",
+                    f"crud_{self.resource_name_plural}",
+                ):
                     raise HTTPException(
                         status_code=status.HTTP_403_FORBIDDEN,
-                        detail="You do not have permission to delete Aiod resources.",
+                        detail=f"You do not have permission to delete {self.resource_name_plural}.",
                     )
                 try:
                     # Raise error if it does not exist

--- a/src/tests/routers/generic/test_authentication.py
+++ b/src/tests/routers/generic/test_authentication.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 
+import pytest
 from sqlalchemy.future import Engine
 from starlette.testclient import TestClient
 
@@ -39,6 +40,28 @@ def test_platform_get_unauthenticated(
     assert len(response.json()) == 1
 
 
+@pytest.mark.parametrize(
+    "mocked_token",
+    [
+        ["edit_aiod_resources"],
+        ["delete_test_resources"],
+        ["crud_test_resources"],
+        ["delete_test_resources", "create_datasets"],
+        ["edit_aiod_resources", "crud_test_resources"],
+    ],
+    indirect=True,
+)
+def test_delete_authorized(
+    client_test_resource, mocked_token: Mock, engine_test_resource_filled: Engine
+):
+    keycloak_openid.introspect = mocked_token
+    response = client_test_resource.delete(
+        "/test_resources/v0/1",
+        headers={"Authorization": "fake-token"},
+    )
+    assert response.status_code == 200, response.json()
+
+
 def test_delete_unauthenticated(
     client_test_resource: TestClient, engine_test_resource_filled: Engine
 ):
@@ -46,6 +69,9 @@ def test_delete_unauthenticated(
     assert response.status_code == 401, response.json()
 
 
+@pytest.mark.parametrize(
+    "mocked_token", [["create_test_resources"], ["delete_datasets"]], indirect=True
+)
 def test_delete_unauthorized(client_test_resource: TestClient, mocked_token: Mock):
     keycloak_openid.introspect = mocked_token
     response = client_test_resource.delete(
@@ -54,9 +80,33 @@ def test_delete_unauthorized(client_test_resource: TestClient, mocked_token: Moc
     )
     assert response.status_code == 403, response.json()
     response_json = response.json()
-    assert response_json["detail"] == "You do not have permission to delete Aiod resources."
+    assert response_json["detail"] == "You do not have permission to delete test_resources."
 
 
+@pytest.mark.parametrize(
+    "mocked_token",
+    [
+        ["edit_aiod_resources"],
+        ["create_test_resources"],
+        ["crud_test_resources"],
+        ["create_test_resources", "delete_datasets"],
+        ["edit_aiod_resources", "crud_test_resources"],
+    ],
+    indirect=True,
+)
+def test_post_authorized(client_test_resource, mocked_token: Mock):
+    keycloak_openid.introspect = mocked_token
+    response = client_test_resource.post(
+        "/test_resources/v0",
+        json={"title": "example"},
+        headers={"Authorization": "fake-token"},
+    )
+    assert response.status_code == 200, response.json()
+
+
+@pytest.mark.parametrize(
+    "mocked_token", [["delete_test_resources"], ["create_datasets"]], indirect=True
+)
 def test_post_unauthorized(client_test_resource: TestClient, mocked_token: Mock):
     keycloak_openid.introspect = mocked_token
     response = client_test_resource.post(
@@ -66,7 +116,7 @@ def test_post_unauthorized(client_test_resource: TestClient, mocked_token: Mock)
     )
     assert response.status_code == 403, response.json()
     response_json = response.json()
-    assert response_json["detail"] == "You do not have permission to edit Aiod resources."
+    assert response_json["detail"] == "You do not have permission to create test_resources."
 
 
 def test_post_unauthenticated(client_test_resource: TestClient):
@@ -78,7 +128,35 @@ def test_post_unauthenticated(client_test_resource: TestClient):
     )
 
 
-def test_put_unauthorized(client_test_resource: TestClient, mocked_token: Mock):
+@pytest.mark.parametrize(
+    "mocked_token",
+    [
+        ["edit_aiod_resources"],
+        ["update_test_resources"],
+        ["crud_test_resources"],
+        ["update_test_resources", "delete_datasets"],
+        ["edit_aiod_resources", "crud_test_resources"],
+    ],
+    indirect=True,
+)
+def test_put_authorized(
+    client_test_resource, mocked_token: Mock, engine_test_resource_filled: Engine
+):
+    keycloak_openid.introspect = mocked_token
+    response = client_test_resource.put(
+        "/test_resources/v0/1",
+        json={"title": "example"},
+        headers={"Authorization": "fake-token"},
+    )
+    assert response.status_code == 200, response.json()
+
+
+@pytest.mark.parametrize(
+    "mocked_token", [["delete_test_resources"], ["update_datasets"]], indirect=True
+)
+def test_put_unauthorized(
+    client_test_resource: TestClient, mocked_token: Mock, engine_test_resource_filled: Engine
+):
     keycloak_openid.introspect = mocked_token
     response = client_test_resource.put(
         "/test_resources/v0/1",
@@ -87,7 +165,7 @@ def test_put_unauthorized(client_test_resource: TestClient, mocked_token: Mock):
     )
     assert response.status_code == 403, response.json()
     response_json = response.json()
-    assert response_json["detail"] == "You do not have permission to edit Aiod resources."
+    assert response_json["detail"] == "You do not have permission to edit test_resources."
 
 
 def test_put_unauthenticated(client_test_resource: TestClient):


### PR DESCRIPTION
Roles such as `create_datasets`, `update_datasets`, `delete_datasets`, `crud_datasets`, `create_events`...
You are allowed to POST a dataset if you have any role of `edit_aiod_resources`, `create_datasets` or `crud_datasets`.

This PR is just a quick fix to add some functionality (we might not even use it just yet).
Out of scope:  more advanced functionality such as "you can only edit your own dataset".