### PR TITLE
Fix to intermediate download of a resource's content

### DIFF
--- a/src/routers/resource_ai_asset_router.py
+++ b/src/routers/resource_ai_asset_router.py
@@ -72,7 +72,7 @@ class ResourceAIAssetRouter(ResourceRouter):
                     detail=(
                         "Multiple distributions encountered. "
                         "Use another endpoint indicating the distribution index `distribution_idx` "
-                        "at the end of the url for a especific distribution.",
+                        "at the end of the url for a specific distribution.",
                     ),
                 )
             elif distribution_idx >= len(distributions):
@@ -80,18 +80,9 @@ class ResourceAIAssetRouter(ResourceRouter):
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Distribution index out of range.",
                 )
-
             url = distributions[distribution_idx].content_url
-            encoding_format = distributions[distribution_idx].encoding_format
-            filename = distributions[distribution_idx].name
 
-            headers = {
-                "Content-Disposition": ("attachment; " f"filename={filename or url.split('/')[-1]}")
-            }
-            if encoding_format:
-                headers["Content-Type"] = encoding_format
-
-            return RedirectResponse(url=url, status_code=status.HTTP_303_SEE_OTHER, headers=headers)
+            return RedirectResponse(url=url, status_code=status.HTTP_303_SEE_OTHER)
 
         def get_resource_content_default(
             identifier: Annotated[

--- a/src/tests/routers/ai_asset_routers/test_router_aiassets_retrieve_content.py
+++ b/src/tests/routers/ai_asset_routers/test_router_aiassets_retrieve_content.py
@@ -2,7 +2,6 @@ import copy
 from unittest.mock import Mock
 
 import pytest
-import responses
 from fastapi import status
 from pytest import FixtureRequest
 from starlette.testclient import TestClient
@@ -10,7 +9,6 @@ from starlette.testclient import TestClient
 from authentication import keycloak_openid
 from database.model.agent.person import Person
 from database.session import DbSession
-from tests.testutils.paths import path_test_resources
 
 TEST_URL1 = "https://www.example.com/example1.csv/content"
 TEST_URL2 = "https://www.example.com/example2.tsv/content"
@@ -19,57 +17,12 @@ SAMPLE_RESOURCE_NAME = "datasets"
 SAMPLE_ENDPOINT = f"{SAMPLE_RESOURCE_NAME}/v1/1/content"
 
 
-def mock_response1(mocked_requests: responses.RequestsMock):
-    with open(
-        path_test_resources() / "contents" / "example1.csv",
-        "r",
-    ) as f:
-        csv_data = f.read()
-
-    mocked_requests.add(
-        responses.GET,
-        TEST_URL1,
-        body=csv_data,
-        status=200,
-    )
-
-
-def mock_response2(mocked_requests: responses.RequestsMock):
-    with open(
-        path_test_resources() / "contents" / "example2.tsv",
-        "r",
-    ) as f:
-        csv_data = f.read()
-    mocked_requests.add(
-        responses.GET,
-        TEST_URL2,
-        body=csv_data,
-        status=200,
-    )
-
-
-def set_up(
-    client: TestClient,
-    mocked_privileged_token: Mock,
-    body: dict,
-    person: Person,
-    resource_name: str,
-):
-    """
-    Set up the test environment for API endpoint testing.
-    This function prepares the test environment by mocking user info,
-    adding a person to the database, and sending a POST request to the
-    specified endpoint for the given resource.
-    """
+@pytest.fixture
+def db_with_person(person: Person, mocked_privileged_token: Mock) -> None:
     keycloak_openid.introspect = mocked_privileged_token
     with DbSession() as session:
         session.add(person)
         session.commit()
-
-    response = client.post(
-        f"/{resource_name}/v1", json=body, headers={"Authorization": "Fake token"}
-    )
-    assert response.status_code == status.HTTP_200_OK, response.json()
 
 
 @pytest.fixture(params=["datasets", "case_studies", "experiments", "ml_models", "publications"])
@@ -79,9 +32,8 @@ def resource_name(request: FixtureRequest) -> str:
 
 def test_ai_asset_has_endpoints(
     client: TestClient,
-    mocked_privileged_token: Mock,
     body_asset_with_single_distribution: dict,
-    person: Person,
+    db_with_person: None,
     resource_name: str,
 ):
     """
@@ -93,24 +45,23 @@ def test_ai_asset_has_endpoints(
     return a response with status code 200.
     """
     body = copy.deepcopy(body_asset_with_single_distribution)
-    set_up(client, mocked_privileged_token, body, person, resource_name)
+    response = client.post(
+        f"/{resource_name}/v1", json=body, headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
     default_endpoint = f"{resource_name}/v1/1/content"
 
-    with responses.RequestsMock() as mocked_requests:
-        mock_response1(mocked_requests)
-
-        response = client.get(default_endpoint)
-        assert response.status_code == status.HTTP_200_OK, response.json()
-        response0 = client.get(default_endpoint + "/0")
-        assert response0.status_code == status.HTTP_200_OK, response0.json()
+    response = client.get(default_endpoint, allow_redirects=False)
+    assert response.status_code == status.HTTP_303_SEE_OTHER, response.status_code
+    response0 = client.get(default_endpoint + "/0", allow_redirects=False)
+    assert response0.status_code == status.HTTP_303_SEE_OTHER, response0.status_code
 
 
 def test_endpoints_when_empty_distribution(
     client: TestClient,
-    mocked_privileged_token: Mock,
     body_asset: dict,
-    person: Person,
+    db_with_person: None,
 ):
     """
     Test retrieving content from an AIAsset with an empty distribution list.
@@ -121,15 +72,19 @@ def test_endpoints_when_empty_distribution(
     """
     body = copy.deepcopy(body_asset)
     body["distribution"] = []
-    set_up(client, mocked_privileged_token, body, person, SAMPLE_RESOURCE_NAME)
 
-    response = client.get(SAMPLE_ENDPOINT)
-    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
-    assert response.json()["detail"] == "Distribution not found.", response.json()
+    response = client.post(
+        f"/{SAMPLE_RESOURCE_NAME}/v1", json=body, headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
-    response0 = client.get(SAMPLE_ENDPOINT + "/0")
-    assert response0.status_code == status.HTTP_404_NOT_FOUND, response0.json()
-    assert response0.json()["detail"] == "Distribution not found.", response0.json()
+    response = client.get(SAMPLE_ENDPOINT, allow_redirects=False)
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.content
+    assert response.json()["detail"] == "Distribution not found.", response.content
+
+    response0 = client.get(SAMPLE_ENDPOINT + "/0", allow_redirects=False)
+    assert response0.status_code == status.HTTP_404_NOT_FOUND, response0.content
+    assert response0.json()["detail"] == "Distribution not found.", response0.content
 
 
 @pytest.fixture
@@ -143,9 +98,8 @@ def body_asset_with_single_distribution(body_asset: dict) -> dict:
 
 def test_endpoints_when_single_distribution(
     client: TestClient,
-    mocked_privileged_token: Mock,
     body_asset_with_single_distribution: dict,
-    person: Person,
+    db_with_person: None,
 ):
     """
     Test retrieving content from an AIAsset with a single distribution.
@@ -155,34 +109,30 @@ def test_endpoints_when_single_distribution(
     content, headers, and filename are returned.
     """
     body = copy.deepcopy(body_asset_with_single_distribution)
-    set_up(client, mocked_privileged_token, body, person, SAMPLE_RESOURCE_NAME)
+    response = client.post(
+        f"/{SAMPLE_RESOURCE_NAME}/v1", json=body, headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
-    with responses.RequestsMock() as mocked_requests:
-        mock_response1(mocked_requests)
+    response = client.get(SAMPLE_ENDPOINT, allow_redirects=False)
+    assert response.status_code == status.HTTP_303_SEE_OTHER, response.content
+    headers = response.headers
+    assert headers["Content-Disposition"] == "attachment; filename=example1.csv", headers
+    assert headers["Content-Type"] == "text/csv", headers
+    assert headers["location"] == TEST_URL1, headers
 
-        response = client.get(SAMPLE_ENDPOINT)
-        assert response.status_code == status.HTTP_200_OK, response.json()
-        assert str(response.content, encoding="utf-8") == "row1,row2,row3\n1,2,3", response.content
-        assert (
-            response.headers.get("Content-Disposition") == "attachment; filename=example1.csv"
-        ), response.headers
-        assert response.headers.get("Content-Type") == "text/csv", response.headers
+    response0 = client.get(SAMPLE_ENDPOINT + "/0", allow_redirects=False)
+    assert response0.status_code == status.HTTP_303_SEE_OTHER, response0.content
+    headers0 = response.headers
+    assert headers0["Content-Disposition"] == "attachment; filename=example1.csv", headers0
+    assert headers0["Content-Type"] == "text/csv", headers0
+    assert headers0["location"] == TEST_URL1, headers0
 
-        response0 = client.get(SAMPLE_ENDPOINT + "/0")
-        assert response0.status_code == status.HTTP_200_OK, response0.json()
-        assert (
-            str(response0.content, encoding="utf-8") == "row1,row2,row3\n1,2,3"
-        ), response0.content
+    response1 = client.get(SAMPLE_ENDPOINT + "/1", allow_redirects=False)
+    assert response1.status_code == status.HTTP_400_BAD_REQUEST, response1.content
 
-        response1 = client.get(SAMPLE_ENDPOINT + "/1")
-        assert response1.status_code == status.HTTP_400_BAD_REQUEST, response1.json()
-        assert response1.json()["detail"] == "Distribution index out of range.", response1.json()
-
-        response2 = client.get(SAMPLE_ENDPOINT + "/-1")
-        assert response2.status_code == status.HTTP_200_OK, response2.json()
-        assert (
-            str(response2.content, encoding="utf-8") == "row1,row2,row3\n1,2,3"
-        ), response2.content
+    response2 = client.get(SAMPLE_ENDPOINT + "/-1", allow_redirects=False)
+    assert response2.status_code == status.HTTP_303_SEE_OTHER, response2.content
 
 
 @pytest.fixture
@@ -198,9 +148,8 @@ def body_asset_with_two_distributions(body_asset_with_single_distribution: dict)
 
 def test_endpoints_when_two_distributions(
     client: TestClient,
-    mocked_privileged_token: Mock,
     body_asset_with_two_distributions: dict,
-    person: Person,
+    db_with_person: None,
 ):
     """
     Test getting content from an AIAsset with multiple distributions.
@@ -210,35 +159,30 @@ def test_endpoints_when_two_distributions(
     content, headers, and filename are returned.
     """
     body = copy.deepcopy(body_asset_with_two_distributions)
-    set_up(client, mocked_privileged_token, body, person, SAMPLE_RESOURCE_NAME)
+    response = client.post(
+        f"/{SAMPLE_RESOURCE_NAME}/v1", json=body, headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
-    with responses.RequestsMock() as mocked_requests:
-        mock_response1(mocked_requests)
-        mock_response2(mocked_requests)
+    response = client.get(SAMPLE_ENDPOINT, allow_redirects=False)
+    assert response.status_code == status.HTTP_409_CONFLICT, response.content
+    assert response.json()["detail"] == [
+        "Multiple distributions encountered. "
+        "Use another endpoint indicating the distribution index `distribution_idx` "
+        "at the end of the url for a especific distribution."
+    ], response.content
 
-        response = client.get(SAMPLE_ENDPOINT)
-        assert response.status_code == status.HTTP_409_CONFLICT, response.json()
-        assert response.json()["detail"] == [
-            "Multiple distributions encountered. "
-            "Use another endpoint indicating the distribution index `distribution_idx` "
-            "at the end of the url for a especific distribution."
-        ], response.json()
+    response0 = client.get(SAMPLE_ENDPOINT + "/0", allow_redirects=False)
+    assert response0.status_code == status.HTTP_303_SEE_OTHER, response0.content
+    headers0 = response0.headers
+    assert headers0["Content-Disposition"] == "attachment; filename=example1.csv", headers0
+    assert headers0["Content-Type"] == "text/csv", headers0
+    assert headers0["location"] == TEST_URL1, headers0
 
-        response0 = client.get(SAMPLE_ENDPOINT + "/0")
-        assert response0.status_code == status.HTTP_200_OK, response0.json()
-        assert (
-            str(response0.content, encoding="utf-8") == "row1,row2,row3\n1,2,3"
-        ), response0.content
-        assert (
-            response0.headers.get("Content-Disposition") == "attachment; filename=example1.csv"
-        ), response0.headers
-        assert response0.headers.get("Content-Type") == "text/csv", response0.headers
-
-        response1 = client.get(SAMPLE_ENDPOINT + "/1")
-        assert response1.status_code == status.HTTP_200_OK, response1.json()
-        assert (
-            str(response1.content, encoding="utf-8") == "col1;col2;col3\n1;2;3"
-        ), response1.content
+    response1 = client.get(SAMPLE_ENDPOINT + "/1", allow_redirects=False)
+    headers1 = response1.headers
+    assert response1.status_code == status.HTTP_303_SEE_OTHER, response1.content
+    assert headers1["location"] == TEST_URL2, headers1
 
 
 @pytest.fixture(params=["", None])
@@ -253,9 +197,8 @@ def encoding_format(request: FixtureRequest) -> str:
 
 def test_headers_when_distribution_has_missing_fields(
     client: TestClient,
-    mocked_privileged_token: Mock,
     body_asset_with_single_distribution: dict,
-    person: Person,
+    db_with_person: None,
     filename: str,
     encoding_format: str,
 ):
@@ -264,7 +207,7 @@ def test_headers_when_distribution_has_missing_fields(
     filename and/or encoding format.
 
     The headers should be filled with the last part of the url in case the filename is missing
-    in the distribution. On the other hand, the encoding format should be filled with "unknown".
+    in the distribution.
     """
     body = copy.deepcopy(body_asset_with_single_distribution)
     body["distribution"][0]["name"] = filename
@@ -272,23 +215,19 @@ def test_headers_when_distribution_has_missing_fields(
 
     alternate_filename = body["distribution"][0]["content_url"].split("/")[-1]
 
-    set_up(client, mocked_privileged_token, body, person, SAMPLE_RESOURCE_NAME)
+    response = client.post(
+        f"/{SAMPLE_RESOURCE_NAME}/v1", json=body, headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
-    with responses.RequestsMock() as mocked_requests:
-        mock_response1(mocked_requests)
+    response = client.get(SAMPLE_ENDPOINT, allow_redirects=False)
+    assert response.status_code == status.HTTP_303_SEE_OTHER, response.content
+    headers = response.headers
+    assert headers["Content-Disposition"] == f"attachment; filename={alternate_filename}", headers
+    assert "content-type" not in headers.keys(), headers
 
-        response = client.get(SAMPLE_ENDPOINT)
-        assert response.status_code == status.HTTP_200_OK, response.json()
-        assert (
-            response.headers.get("Content-Disposition")
-            == f"attachment; filename={alternate_filename}"
-        ), response.headers
-        assert "content-type" not in response.headers.keys(), response.headers
-
-        response0 = client.get(SAMPLE_ENDPOINT + "/0")
-        assert response0.status_code == status.HTTP_200_OK, response0.json()
-        assert (
-            response0.headers.get("Content-Disposition")
-            == f"attachment; filename={alternate_filename}"
-        ), response0.headers
-        assert "content-type" not in response0.headers.keys(), response0.headers
+    response0 = client.get(SAMPLE_ENDPOINT + "/0", allow_redirects=False)
+    assert response0.status_code == status.HTTP_303_SEE_OTHER, response0.content
+    headers0 = response0.headers
+    assert headers0["Content-Disposition"] == f"attachment; filename={alternate_filename}", headers0
+    assert "content-type" not in headers0.keys(), headers0


### PR DESCRIPTION
I replaced the `request.get` in the code by `RedirectResponse`. This way the aiod redirects the call to the specific URL to download the content of a resource. Then, the download will be handled on the client side instead of downloading on the server side and passing it to the client. 