### PR TITLE
Bugfix/openml connector offset

### DIFF
--- a/src/connectors/abstract/resource_connector_by_id.py
+++ b/src/connectors/abstract/resource_connector_by_id.py
@@ -1,6 +1,7 @@
 import abc
 import logging
 from typing import Generic, Iterator
+from requests.exceptions import HTTPError
 
 from connectors.abstract.resource_connector import ResourceConnector, RESOURCE
 from connectors.record_error import RecordError
@@ -53,12 +54,7 @@ class ResourceConnectorById(ResourceConnector, Generic[RESOURCE]):
         while not finished:
             i = 0
             for item in self.fetch(offset=state["offset"], from_identifier=state["from_id"]):
-                if (
-                    isinstance(item, RecordError)
-                    and (item.identifier is None)
-                    and item.code
-                    and (item.code >= 400)
-                ):
+                if isinstance(item, RecordError) and isinstance(item.error, HTTPError):
                     yield item
                     return
                 i += 1

--- a/src/connectors/abstract/resource_connector_by_id.py
+++ b/src/connectors/abstract/resource_connector_by_id.py
@@ -53,6 +53,9 @@ class ResourceConnectorById(ResourceConnector, Generic[RESOURCE]):
         while not finished:
             i = 0
             for item in self.fetch(offset=state["offset"], from_identifier=state["from_id"]):
+                if isinstance(item, RecordError) and item.code and (item.code >= 400):
+                    yield item
+                    return
                 i += 1
                 if isinstance(item, ResourceWithRelations):
                     id_ = item.resource.platform_resource_identifier

--- a/src/connectors/abstract/resource_connector_by_id.py
+++ b/src/connectors/abstract/resource_connector_by_id.py
@@ -53,7 +53,12 @@ class ResourceConnectorById(ResourceConnector, Generic[RESOURCE]):
         while not finished:
             i = 0
             for item in self.fetch(offset=state["offset"], from_identifier=state["from_id"]):
-                if isinstance(item, RecordError) and item.code and (item.code >= 400):
+                if (
+                    isinstance(item, RecordError)
+                    and (item.identifier is None)
+                    and item.code
+                    and (item.code >= 400)
+                ):
                     yield item
                     return
                 i += 1

--- a/src/connectors/openml/openml_dataset_connector.py
+++ b/src/connectors/openml/openml_dataset_connector.py
@@ -2,6 +2,7 @@
 This module knows how to load an OpenML object based on its AIoD implementation,
 and how to convert the OpenML response to some agreed AIoD format.
 """
+
 from typing import Iterator
 
 import dateutil.parser
@@ -103,12 +104,14 @@ class OpenMlDatasetConnector(ResourceConnectorById[Dataset]):
             f"limit/{self.limit_per_iteration}/offset/{offset}"
         )
         response = requests.get(url_data)
+        status_code = response.status_code
         if not response.ok:
             msg = response.json()["error"]["message"]
-            yield RecordError(
-                identifier=None,
-                error=f"Error while fetching {url_data} from OpenML: '{msg}'.",
+            err_msg = (
+                f"Error while fetching {url_data} from OpenML: ({status_code}) with message:{msg}"
             )
+
+            yield RecordError(identifier=None, error=err_msg, code=status_code)
             return
 
         try:

--- a/src/connectors/openml/openml_dataset_connector.py
+++ b/src/connectors/openml/openml_dataset_connector.py
@@ -107,9 +107,7 @@ class OpenMlDatasetConnector(ResourceConnectorById[Dataset]):
         status_code = response.status_code
         if not response.ok:
             msg = response.json()["error"]["message"]
-            err_msg = (
-                f"Error while fetching {url_data} from OpenML: ({status_code}) with message:{msg}"
-            )
+            err_msg = f"Error while fetching {url_data} from OpenML: ({status_code}) {msg}"
 
             yield RecordError(identifier=None, error=err_msg, code=status_code)
             return

--- a/src/connectors/record_error.py
+++ b/src/connectors/record_error.py
@@ -5,4 +5,5 @@ import dataclasses
 class RecordError:
     identifier: str | None
     error: BaseException | str
+    code: int | None = None
     ignore: bool = False

--- a/src/connectors/record_error.py
+++ b/src/connectors/record_error.py
@@ -5,5 +5,4 @@ import dataclasses
 class RecordError:
     identifier: str | None
     error: BaseException | str
-    code: int | None = None
     ignore: bool = False

--- a/src/tests/connectors/openml/test_openml_dataset_connector.py
+++ b/src/tests/connectors/openml/test_openml_dataset_connector.py
@@ -9,6 +9,7 @@ OPENML_URL = "https://www.openml.org/api/v1/json"
 
 
 def test_first_run():
+    state = {}
     connector = OpenMlDatasetConnector(limit_per_iteration=2)
     with responses.RequestsMock() as mocked_requests:
         for offset in (0, 2):
@@ -16,10 +17,30 @@ def test_first_run():
         for i in range(2, 5):
             mock_get_data(mocked_requests, str(i))
 
-        datasets = list(connector.run(state={}, from_identifier=0, limit=None))
+        datasets = list(connector.run(state, from_identifier=0, limit=None))
+
+    assert state["offset"] == 3, state
     assert {d.name for d in datasets} == {"anneal", "labor", "kr-vs-kp"}
     assert len(datasets) == 3
     assert {len(d.citation) for d in datasets} == {0}
+
+
+def test_request_empty_list():
+    """Tests is the state doesn't change after a request when OpenML returns an empty list."""
+    state = {"offset": 2, "last_id": 3}
+    connector = OpenMlDatasetConnector(limit_per_iteration=2)
+    with responses.RequestsMock() as mocked_requests:
+        mocked_requests.add(
+            responses.GET,
+            f"{OPENML_URL}/data/list/limit/2/offset/2",
+            json={"error": {"code": "372", "message": "No results"}},
+            status=412,
+        )
+        datasets = list(connector.run(state, from_identifier=0, limit=None))
+
+        assert "No results" in datasets[0].error, datasets
+        assert state["offset"] == 2, state
+        assert state["last_id"] == 3, state
 
 
 def test_second_run():

--- a/src/tests/connectors/openml/test_openml_dataset_connector.py
+++ b/src/tests/connectors/openml/test_openml_dataset_connector.py
@@ -1,5 +1,4 @@
 import json
-
 import responses
 
 from connectors.openml.openml_dataset_connector import OpenMlDatasetConnector
@@ -38,7 +37,8 @@ def test_request_empty_list():
         )
         datasets = list(connector.run(state, from_identifier=0, limit=None))
 
-        assert "No results" in datasets[0].error, datasets
+        assert len(datasets) == 1, datasets
+        assert "No results" in datasets[0].error.args[0], datasets
         assert state["offset"] == 2, state
         assert state["last_id"] == 3, state
 

--- a/src/tests/connectors/openml/test_openml_dataset_connector.py
+++ b/src/tests/connectors/openml/test_openml_dataset_connector.py
@@ -26,7 +26,7 @@ def test_first_run():
 
 
 def test_request_empty_list():
-    """Tests is the state doesn't change after a request when OpenML returns an empty list."""
+    """Tests if the state doesn't change after a request when OpenML returns an empty list."""
     state = {"offset": 2, "last_id": 3}
     connector = OpenMlDatasetConnector(limit_per_iteration=2)
     with responses.RequestsMock() as mocked_requests:

--- a/src/tests/connectors/openml/test_openml_mlmodel_connector.py
+++ b/src/tests/connectors/openml/test_openml_mlmodel_connector.py
@@ -41,9 +41,10 @@ def test_request_empty_list():
             json={"error": {"code": "500", "message": "No results"}},
             status=412,
         )
-        datasets = list(connector.run(state, from_identifier=0, limit=None))
+        ml_models = list(connector.run(state, from_identifier=0, limit=None))
 
-        assert "No results" in datasets[0].error, datasets
+        assert len(ml_models) == 1, ml_models
+        assert "No results" in ml_models[0].error.args[0], ml_models
         assert state["offset"] == 2, state
         assert state["last_id"] == 3, state
 


### PR DESCRIPTION
Bugfixes:

1.  Issue #266 - OpenML returns a response with status code 412, when a list is not found.
- Solved by returning a `RecordError` with a `HttpError` to the main loop. When this happens, the loop is interrupted without adding an unit to the counter, which is added to the `state[offset]`.
- Tests added to check the state after a response with `status_code=412`

2. The `_distributions()` function was returning an empty list when all the three fields: *dependencies*, *installation_notes*, and *binary_url* had not `None` values, instead of the opposite. 

