### PR TITLE
Github actions - Added scripts to volume to be used by pytests 

### DIFF
--- a/.github/workflows/dockerized-tests.yml
+++ b/.github/workflows/dockerized-tests.yml
@@ -27,16 +27,5 @@ jobs:
       
       - name: Run docker container and pytest tests
         run: |
-          docker run -d --name apiserver -e KEYCLOAK_CLIENT_SECRET="mocked_secret" aiod_metadata_catalogue
-          sleep 5
-          docker exec apiserver mkdir -p /scripts
-          docker cp scripts/ apiserver:/scripts
-          docker exec apiserver sh -c "pip install '.[dev]' && pytest tests -s"
-        
-  
-          
-  
-  
-    
-
+          docker run -v ./scripts:/scripts -e KEYCLOAK_CLIENT_SECRET="mocked_secret" --entrypoint "" aiod_metadata_catalogue sh -c "pip install \".[dev]\" && pytest tests -s"
 

--- a/.github/workflows/dockerized-tests.yml
+++ b/.github/workflows/dockerized-tests.yml
@@ -27,8 +27,12 @@ jobs:
       
       - name: Run docker container and pytest tests
         run: |
-          docker run -e KEYCLOAK_CLIENT_SECRET="mocked_secret" --entrypoint "" aiod_metadata_catalogue sh -c "pip install \".[dev]\" && pytest tests -s"
-  
+          docker run -d --name apiserver -e KEYCLOAK_CLIENT_SECRET="mocked_secret" aiod_metadata_catalogue
+          sleep 5
+          docker exec apiserver mkdir -p /scripts
+          docker cp scripts/ apiserver:/scripts
+          docker exec apiserver sh -c "pip install '.[dev]' && pytest tests -s"
+        
   
           
   


### PR DESCRIPTION
The backup and restoration features include pytest units that utilise two shell scripts from the `scripts` folder. 
Because of this, the previous github actions workflow (`dockerized-tests.yml`) was failing. To ensure that the pytests can run correctly, the scripts folder was added in this PR as a mapped volume to the testing container. 

