### PR TITLE
Update docker workflow

### DIFF
--- a/.github/workflows/dockerized-tests.yml
+++ b/.github/workflows/dockerized-tests.yml
@@ -66,20 +66,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      # My hope is that by retrieving the image, it can use the cache.
-      # But I fear that cache needs to be archived/restored separately.
-      # I want to avoid re-building the docker image, but I do not see
-      # an option for that in build-push-action. Perhaps it should just
-      # be a shell `docker push` command instead.
-      - name: Retrieve Image
-        uses: actions/download-artifact@v4
-        with:
-          name: aiod_mc_image
-          path: /tmp
-      - name: Load Image
-        run: |
-          docker load --input /tmp/aiod_mc_image.tar
-          docker image ls -a
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/dockerized-tests.yml
+++ b/.github/workflows/dockerized-tests.yml
@@ -1,6 +1,6 @@
 name: Docker - build, test, push
 
-# This workflow will built docker image and run tests inside the container.
+# This workflow will build docker image and run tests inside the container.
 # This workflow is only executed if there is pull request with change in pyproject.toml dependencies, 
 # or in Dockerfile, or in docker workflow. 
 
@@ -10,9 +10,32 @@ on:
       - '.github/workflows/docker-image.yml'
       - 'pyproject.toml'
       - 'Dockerfile'
+
+  push:
+    branches:
+      - 'develop'
+
+  release:
+    types: [published]
       
   # allows to manually start a workflow run from the GitHub UI or using the GitHub API.    
   workflow_dispatch:
+    inputs:
+      push-image:
+        description: "Push image to docker hub"
+        required: false
+        type: boolean
+        default: false
+      push-description:
+        description: "Update docker hub description"
+        required: false
+        type: boolean
+        default: false
+      tag:
+        description: "Tag for the docker image"
+        required: false
+        default: "workflow-dispatch"
+
 
 jobs:
   build:
@@ -27,11 +50,11 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          tags: aiod/metadata_catalogue:latest
+          tags: aiod/metadata_catalogue:ci
           outputs: type=docker,dest=/tmp/aiod_mc_image.tar
           cache-from: type=gha
           cache-to: type=gha,mode=min
-      # We store the image as an artifact so it can be used by the `test` step,
+      # We store the image as an artifact, so it can be used by the `test` step
       # and inspected manually if needed (download it through Github Actions UI)
       - name: Store Image
         uses: actions/upload-artifact@v4
@@ -44,6 +67,7 @@ jobs:
     needs: [build]
     steps:
       # We need to check out the repository, so that we have the `scripts` directory to mount.
+      # This is required to run the backup script tests.
       - uses: actions/checkout@v4
       - name: Retrieve Image
         uses: actions/download-artifact@v4
@@ -56,13 +80,23 @@ jobs:
           docker image ls -a
       - name: Run pytest from docker
         run: |
-          docker run -v ./scripts:/scripts -e KEYCLOAK_CLIENT_SECRET="mocked_secret" --entrypoint "" aiod/metadata_catalogue sh -c "pip install \".[dev]\" && pytest tests -s"
+          docker run -v ./scripts:/scripts -e KEYCLOAK_CLIENT_SECRET="mocked_secret" --entrypoint "" aiod/metadata_catalogue:ci sh -c "pip install \".[dev]\" && pytest tests -s"
 
   publish:
-    # TODO: Make conditional on being a release or manual action
     needs: [test]
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
+      # The correct tag depends on how this workflow was invoked, see also docker-description.md
+      - name: Set Develop Tag
+        if: github.ref == 'refs/heads/develop'
+        run: echo "IMAGE_TAGS=aiod/metadata_catalogue:develop" >> "$GITHUB_ENV"
+      - name: Set Release Tag
+        if: github.event_name == 'release'
+        run: echo "IMAGE_TAGS=aiod/metadata_catalogue:latest,aiod/metadata_catalogue:${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+      - name: Set Dispatch Tag
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "IMAGE_TAGS=aiod/metadata_catalogue:${{ inputs.tag }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -70,18 +104,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.AIOD_DOCKER_PAT }}
+      - name: Echo tags
+        run: echo $IMAGE_TAGS
       - name: Build
+        if: (github.event_name != 'workflow_dispatch') || inputs.push-image
         uses: docker/build-push-action@v5
         with:
           push: true
           context: .
           file: ./Dockerfile
-          tags: |
-            aiod/metadata_catalogue:latest
-            aiod/metadata_catalogue:${{ github.sha }}
+          tags: ${{ env.IMAGE_TAGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
       - name: Update repository description
+        if: (github.event_name == 'release') || inputs.push-description
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/dockerized-tests.yml
+++ b/.github/workflows/dockerized-tests.yml
@@ -29,6 +29,8 @@ jobs:
           file: ./Dockerfile
           tags: aiod/metadata_catalogue:latest
           outputs: type=docker,dest=/tmp/aiod_mc_image.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
       # We store the image as an artifact so it can be used by the `test` step,
       # and inspected manually if needed (download it through Github Actions UI)
       - name: Store Image
@@ -91,4 +93,13 @@ jobs:
           tags: |
             aiod/metadata_catalogue:latest
             aiod/metadata_catalogue:${{ github.sha }}
-      # peter-evans/dockerhub-description@v3
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+      - name: Update repository description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.AIOD_DOCKER_PAT }}
+          repository: aiod/metadata_catalogue
+          readme-filepath: ./docker-description.md
+          short-description: "Metadata catalogue REST API for AI on Demand."

--- a/.github/workflows/dockerized-tests.yml
+++ b/.github/workflows/dockerized-tests.yml
@@ -1,4 +1,4 @@
-name: Built docker image and run tests
+name: Docker - build, test, push
 
 # This workflow will built docker image and run tests inside the container.
 # This workflow is only executed if there is pull request with change in pyproject.toml dependencies, 
@@ -15,17 +15,80 @@ on:
   workflow_dispatch:
 
 jobs:
-  built:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-
     steps:
-      - uses: actions/checkout@v2
-      - name: Build the docker image
-        run: docker build --tag aiod_metadata_catalogue:latest -f Dockerfile .
-      
-      - name: Run docker container and pytest tests
-        run: |
-          docker run -v ./scripts:/scripts -e KEYCLOAK_CLIENT_SECRET="mocked_secret" --entrypoint "" aiod_metadata_catalogue sh -c "pip install \".[dev]\" && pytest tests -s"
+      - uses: actions/checkout@v4
+      # We do not bother with setup-qemu-action since we don't care about emulation right now
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: aiod/metadata_catalogue:latest
+          outputs: type=docker,dest=/tmp/aiod_mc_image.tar
+      # We store the image as an artifact so it can be used by the `test` step,
+      # and inspected manually if needed (download it through Github Actions UI)
+      - name: Store Image
+        uses: actions/upload-artifact@v4
+        with:
+          name: aiod_mc_image
+          path: /tmp/aiod_mc_image.tar
 
+  test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      # We need to check out the repository, so that we have the `scripts` directory to mount.
+      - uses: actions/checkout@v4
+      - name: Retrieve Image
+        uses: actions/download-artifact@v4
+        with:
+          name: aiod_mc_image
+          path: /tmp
+      - name: Load Image
+        run: |
+          docker load --input /tmp/aiod_mc_image.tar
+          docker image ls -a
+      - name: Run pytest from docker
+        run: |
+          docker run -v ./scripts:/scripts -e KEYCLOAK_CLIENT_SECRET="mocked_secret" --entrypoint "" aiod/metadata_catalogue sh -c "pip install \".[dev]\" && pytest tests -s"
+
+  publish:
+    # TODO: Make conditional on being a release or manual action
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      # My hope is that by retrieving the image, it can use the cache.
+      # But I fear that cache needs to be archived/restored separately.
+      # I want to avoid re-building the docker image, but I do not see
+      # an option for that in build-push-action. Perhaps it should just
+      # be a shell `docker push` command instead.
+      - name: Retrieve Image
+        uses: actions/download-artifact@v4
+        with:
+          name: aiod_mc_image
+          path: /tmp
+      - name: Load Image
+        run: |
+          docker load --input /tmp/aiod_mc_image.tar
+          docker image ls -a
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.AIOD_DOCKER_PAT }}
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          tags: |
+            aiod/metadata_catalogue:latest
+            aiod/metadata_catalogue:${{ github.sha }}
+      # peter-evans/dockerhub-description@v3

--- a/docker-description.md
+++ b/docker-description.md
@@ -1,9 +1,7 @@
 # AIOD Metadata Catalogue
 
 Image for AI on Demand's (AIOD) metadata catalogue REST API, developed on [Github](https://github.com/aiondemand/AIOD-rest-api/).
-This image also requires _at least_ a database setup to function, but for all features authentication (through keycloak) and 
-search (through elastic search) also need to be configured.
-Please refer to the documentation in the readme of the ["AIOD-rest-api"](https://github.com/aiondemand/AIOD-rest-api) repository.
+This image requires a properly configured database setup to function. Additionally, to have all features working, authentication (via Keycloak) and search (through Elasticsearch) must also be configured. Please refer to the documentation available in the README of the ["AIOD-rest-api"](https://github.com/aiondemand/AIOD-rest-api) repository.
 
 The following tags are available:
 

--- a/docker-description.md
+++ b/docker-description.md
@@ -4,3 +4,10 @@ Image for AI on Demand's (AIOD) metadata catalogue REST API, developed on [Githu
 This image also requires _at least_ a database setup to function, but for all features authentication (through keycloak) and 
 search (through elastic search) also need to be configured.
 Please refer to the documentation in the readme of the ["AIOD-rest-api"](https://github.com/aiondemand/AIOD-rest-api) repository.
+
+The following tags are available:
+
+ - `latest`: the latest official release
+ - `develop`: the head of the development branch
+ - `v*`, e.g. `v1.3.20240308`: that specific release
+ - a number of custom tags may be introduced for testing, but these are not intended for general use.

--- a/docker-description.md
+++ b/docker-description.md
@@ -1,0 +1,6 @@
+# AIOD Metadata Catalogue
+
+Image for AI on Demand's (AIOD) metadata catalogue REST API, developed on [Github](https://github.com/aiondemand/AIOD-rest-api/).
+This image also requires _at least_ a database setup to function, but for all features authentication (through keycloak) and 
+search (through elastic search) also need to be configured.
+Please refer to the documentation in the readme of the ["AIOD-rest-api"](https://github.com/aiondemand/AIOD-rest-api) repository.


### PR DESCRIPTION
This PR updates the docker workflow:

 - The workflow can now also publish images to docker hub under `aiod/metadata_catalogue`. This happens when:
   - A release is made, pushes with tags `latest` and whatever the version tag is e.g., `v1.3.20240308`.
   - Develop is pushed, pushes with tag `develop`
   - The workflow is dispatched through the Actions tab on Github, pushes with the tag provided in the input
 - The workflow can update the description of that repository, based on the content of `docker-description.md`
 - Using the workflow dispatch, can also update the repository description(s) without updating any image.
 

A build cache is used to avoid double work between `build` and `push` jobs, but it seems to persist between workflows so this hopefully also speeds up the workflow. Otherwise, I would expect a slight slowdown as splitting the workflow into separate jobs (which run on separate runners), means we have to import/export the image from `build` to `test`.

I had hoped to be able to push the built image from `build` directly without rerunning build. While it uses cache now, and thus shouldn't take too much extra time, this largely negates the benefit of splitting `build` and `test`. I would consider merging those jobs again as it should result in a speed up, though it 'feels' nice that the jobs are now separate.

> [!warning]
> **Before merging**, I still want to verify that the `develop` and `release` triggers and flow are set up appropriately. I will do this on a fork. But I don't suspect any (major) changes.