### PR TITLE
Rename drupal to ai4europe_cms

### DIFF
--- a/src/database/model/platform/platform_names.py
+++ b/src/database/model/platform/platform_names.py
@@ -9,7 +9,7 @@ class PlatformName(str, enum.Enum):
     """
 
     aiod = "aiod"
-    drupal = "drupal"
+    ai4europe_cms = "ai4europe_cms"
     example = "example"
     openml = "openml"
     huggingface = "huggingface"

--- a/src/routers/resource_routers/contact_router.py
+++ b/src/routers/resource_routers/contact_router.py
@@ -43,13 +43,13 @@ class ContactRouter(ResourceRouter):
     ) -> Sequence[type[Contact]]:
         """
         Only authenticated users can see the contact email.
-        For the old drupal platform, only users with "full_view_drupal_resources" role
+        For the old ai4europe_cms platform, only users with "full_view_ai4europe_cms_resources" role
         can view the contact emails.
         """
         for contact in resources:
             if not user or (
-                (contact.platform == PlatformName.drupal)
-                and not user.has_role("full_view_drupal_resources")
+                (contact.platform == PlatformName.ai4europe_cms)
+                and not user.has_role("full_view_ai4europe_cms_resources")
             ):
                 contact.email = [Email(name="******")]
         return resources

--- a/src/routers/resource_routers/person_router.py
+++ b/src/routers/resource_routers/person_router.py
@@ -28,12 +28,12 @@ class PersonRouter(ResourceRouter):
         resources: Sequence[type[Person]], session: Session, user: User | None
     ) -> Sequence[type[Person]]:
         """
-        For the old drupal platform, only users with "full_view_drupal_resources" role can
-        see the person's sensitive information.
+        For the old ai4europe_cms platform, only users with "full_view_ai4europe_cms_resources"
+        role can see the person's sensitive information.
         """
         for person in resources:
-            if (person.platform == PlatformName.drupal) and not (
-                user and user.has_role("full_view_drupal_resources")
+            if (person.platform == PlatformName.ai4europe_cms) and not (
+                user and user.has_role("full_view_ai4europe_cms_resources")
             ):
                 person.name = "******"
                 person.given_name = "******"

--- a/src/tests/routers/resource_routers/test_router_contact.py
+++ b/src/tests/routers/resource_routers/test_router_contact.py
@@ -173,25 +173,25 @@ def test_email_mask_for_authenticated_user(
     params=[
         "/contacts/v1",
         "/contacts/v1/1",
-        "/platforms/drupal/contacts/v1",
-        "/platforms/drupal/contacts/v1/fake:100",
+        "/platforms/ai4europe_cms/contacts/v1",
+        "/platforms/ai4europe_cms/contacts/v1/fake:100",
     ]
 )
 def endpoint_from_fixture2(request) -> str:
     return request.param
 
 
-def test_email_privacy_for_drupal(
+def test_email_privacy_for_ai4europe_cms(
     client: TestClient,
     mocked_privileged_token: Mock,
-    mocked_drupal_token: Mock,
+    mocked_ai4europe_cms_token: Mock,
     contact: Contact,
     platform: Platform,
     endpoint_from_fixture2: str,
 ):
 
     with DbSession() as session:
-        contact.platform = "drupal"
+        contact.platform = "ai4europe_cms"
         contact.platform_resource_identifier = "fake:100"
         email = Email(name="fake@email.com")
         another_email = Email(name="fake2@email.com")
@@ -211,7 +211,7 @@ def test_email_privacy_for_drupal(
     assert len(response_json) > 0, response_json
     assert response_json["email"] == ["******"]
 
-    keycloak_openid.introspect = mocked_drupal_token
+    keycloak_openid.introspect = mocked_ai4europe_cms_token
 
     response = client.get(endpoint_from_fixture2, headers=headers)
     response_json = response.json()

--- a/src/tests/routers/resource_routers/test_router_person.py
+++ b/src/tests/routers/resource_routers/test_router_person.py
@@ -56,30 +56,30 @@ def test_happy_path(
     params=[
         "/persons/v1",
         "/persons/v1/1",
-        "/platforms/drupal/persons/v1",
-        "/platforms/drupal/persons/v1/2",
+        "/platforms/ai4europe_cms/persons/v1",
+        "/platforms/ai4europe_cms/persons/v1/2",
     ]
 )
 def endpoint(request) -> str:
     return request.param
 
 
-def test_privacy_for_drupal(
+def test_privacy_for_ai4europe_cms(
     client: TestClient,
     mocked_privileged_token: Mock,
-    mocked_drupal_token: Mock,
+    mocked_ai4europe_cms_token: Mock,
     platform: Platform,
     person: Person,
     contact: Contact,
     endpoint: str,
 ):
-    """Test to ensure that only authenticated users with "full_view_drupal_resources" role
+    """Test to ensure that only authenticated users with "full_view_ai4europe_cms_resources" role
     can visualise fields such as name, given_name and surname of a person migrated from
-    the old drupal platform.
+    the old ai4europe_cms platform.
     """
 
     with DbSession() as session:
-        person.platform = "drupal"
+        person.platform = "ai4europe_cms"
         person.platform_resource_identifier = "2"
         person.name = "Joe Doe"
         person.given_name = "Joe"
@@ -100,7 +100,7 @@ def test_privacy_for_drupal(
         assert person_dict["given_name"] == "******"
         assert person_dict["surname"] == "******"
 
-    keycloak_openid.introspect = mocked_drupal_token
+    keycloak_openid.introspect = mocked_ai4europe_cms_token
     response = client.get(endpoint, headers=headers)
     response_json = response.json()
     response_json = [response_json] if isinstance(response_json, dict) else response_json

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -144,11 +144,11 @@ def mocked_privileged_token() -> Mock:
 
 
 @pytest.fixture()
-def mocked_drupal_token() -> Mock:
+def mocked_ai4europe_cms_token() -> Mock:
     roles = [
         "offline_access",
         "uma_authorization",
         "default-roles-aiod",
-        "full_view_drupal_resources",
+        "full_view_ai4europe_cms_resources",
     ]
     return Mock(return_value=_user_with_roles(*roles))


### PR DESCRIPTION
"drupal" was renamed to "ai4europe_cms" in all files to better represent the platform.