### PR TITLE
bugfix huggingface validator

### DIFF
--- a/src/database/validators/huggingface_validators.py
+++ b/src/database/validators/huggingface_validators.py
@@ -1,4 +1,5 @@
 import re
+from huggingface_hub.utils import validate_repo_id
 
 REPO_ID_ILLEGAL_CHARACTERS = re.compile(r"[^0-9a-zA-Z-_./]+")
 MSG_PREFIX = "The platform_resource_identifier for HuggingFace should be a valid repo_id. "
@@ -18,19 +19,5 @@ def throw_error_on_invalid_identifier(platform_resource_identifier: str):
     https://huggingface.co/docs/huggingface_hub/package_reference/utilities#huggingface_hub.utils.validate_repo_id
     """
     repo_id = platform_resource_identifier
-    if REPO_ID_ILLEGAL_CHARACTERS.search(repo_id):
-        msg = "A repo_id should only contain [a-zA-Z0-9] or ”-”, ”_”, ”.”"
-        raise ValueError(MSG_PREFIX + msg)
-    if not (1 < len(repo_id) < 96):
-        msg = "A repo_id should be between 1 and 96 characters."
-        raise ValueError(MSG_PREFIX + msg)
-    if repo_id.count("/") > 1:
-        msg = (
-            "For new repositories, there should be a single forward slash in the repo_id ("
-            "namespace/repo_name). Legacy repositories are without a namespace. This repo_id has "
-            "too many forward slashes."
-        )
-        raise ValueError(MSG_PREFIX + msg)
-    if ".." in repo_id:
-        msg = "A repo_id may not contain multiple consecutive dots."
-        raise ValueError(MSG_PREFIX + msg)
+    validate_repo_id(repo_id=repo_id)
+    

--- a/src/database/validators/huggingface_validators.py
+++ b/src/database/validators/huggingface_validators.py
@@ -1,10 +1,6 @@
 import re
 from huggingface_hub.utils import validate_repo_id
 
-REPO_ID_ILLEGAL_CHARACTERS = re.compile(r"[^0-9a-zA-Z-_./]+")
-MSG_PREFIX = "The platform_resource_identifier for HuggingFace should be a valid repo_id. "
-
-
 def throw_error_on_invalid_identifier(platform_resource_identifier: str):
     """
     Throw a ValueError on an invalid repository identifier.
@@ -20,4 +16,3 @@ def throw_error_on_invalid_identifier(platform_resource_identifier: str):
     """
     repo_id = platform_resource_identifier
     validate_repo_id(repo_id=repo_id)
-    

--- a/src/database/validators/huggingface_validators.py
+++ b/src/database/validators/huggingface_validators.py
@@ -1,5 +1,6 @@
 from huggingface_hub.utils import validate_repo_id
 
+
 def throw_error_on_invalid_identifier(platform_resource_identifier: str):
     """
     Throw a ValueError on an invalid repository identifier.

--- a/src/database/validators/huggingface_validators.py
+++ b/src/database/validators/huggingface_validators.py
@@ -1,4 +1,3 @@
-import re
 from huggingface_hub.utils import validate_repo_id
 
 def throw_error_on_invalid_identifier(platform_resource_identifier: str):

--- a/src/tests/routers/resource_routers/test_router_dataset.py
+++ b/src/tests/routers/resource_routers/test_router_dataset.py
@@ -7,7 +7,6 @@ from starlette.testclient import TestClient
 from authentication import keycloak_openid
 from database.model.agent.person import Person
 from database.session import DbSession
-from huggingface_hub.utils._validators import HFValidationError
 
 
 def test_happy_path(
@@ -67,8 +66,8 @@ def test_post_invalid_huggingface_identifier(
     assert (
         response.json()["detail"][0]["msg"]
         == "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are"
-            " forbidden, '-' and '.' cannot start or end the name, max length is 96:"
-            f" '{body['platform_resource_identifier']}'."
+        " forbidden, '-' and '.' cannot start or end the name, max length is 96:"
+        f" '{body['platform_resource_identifier']}'."
     )
 
 

--- a/src/tests/routers/resource_routers/test_router_dataset.py
+++ b/src/tests/routers/resource_routers/test_router_dataset.py
@@ -7,6 +7,7 @@ from starlette.testclient import TestClient
 from authentication import keycloak_openid
 from database.model.agent.person import Person
 from database.session import DbSession
+from huggingface_hub.utils._validators import HFValidationError
 
 
 def test_happy_path(
@@ -59,14 +60,15 @@ def test_post_invalid_huggingface_identifier(
 ):
     keycloak_openid.userinfo = mocked_privileged_token
 
-    body = {"name": "name", "platform": "huggingface", "platform_resource_identifier": "a"}
+    body = {"name": "name", "platform": "huggingface", "platform_resource_identifier": ""}
 
     response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.json()
     assert (
         response.json()["detail"][0]["msg"]
-        == "The platform_resource_identifier for HuggingFace should be a valid repo_id. A repo_id "
-        "should be between 1 and 96 characters."
+        == "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are"
+            " forbidden, '-' and '.' cannot start or end the name, max length is 96:"
+            f" '{body['platform_resource_identifier']}'."
     )
 
 

--- a/src/tests/uploader/huggingface/test_dataset_uploader.py
+++ b/src/tests/uploader/huggingface/test_dataset_uploader.py
@@ -196,7 +196,8 @@ ERROR_MSG_PREFIX = f"The platform_resource_identifier is invalid for {PlatformNa
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
                     ERROR_MSG_PREFIX
-                    + "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: "
+                    + "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are "
+                    "forbidden, '-' and '.' cannot start or end the name, max length is 96: "
                     "'user/Test name with ?'."
                 ),
             ),
@@ -221,8 +222,8 @@ ERROR_MSG_PREFIX = f"The platform_resource_identifier is invalid for {PlatformNa
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
                     ERROR_MSG_PREFIX
-                    + "Repo id must be in the form 'repo_name' or 'namespace/repo_name': 'user/data/set'. " 
-                    "Use `repo_type` argument if needed."
+                    + "Repo id must be in the form 'repo_name' or 'namespace/repo_name': "
+                    "'user/data/set'. Use `repo_type` argument if needed."
                 ),
             ),
         ),
@@ -233,8 +234,8 @@ ERROR_MSG_PREFIX = f"The platform_resource_identifier is invalid for {PlatformNa
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
                     ERROR_MSG_PREFIX
-                    + "The namespace (the first part of the platform_resource_identifier) should be "
-                    "equal to the username, but wrong-namespace != user."
+                    + "The namespace (the first part of the platform_resource_identifier) "
+                    "should be equal to the username, but wrong-namespace != user."
                 ),
             ),
         ),
@@ -245,7 +246,8 @@ ERROR_MSG_PREFIX = f"The platform_resource_identifier is invalid for {PlatformNa
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
                     ERROR_MSG_PREFIX
-                    +"Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: "
+                    + "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are "
+                    "forbidden, '-' and '.' cannot start or end the name, max length is 96: "
                     "'user/" + "a" * 200 + "'."
                 ),
             ),
@@ -259,6 +261,6 @@ def test_validate_repo_id(username: str, dataset_name: str, expected_error: HTTP
     else:
         with pytest.raises(type(expected_error)) as exception_info:
             huggingface_uploader._validate_repo_id(dataset_name, username)
-        print(exception_info.value.detail)
+
         assert exception_info.value.status_code == expected_error.status_code
         assert exception_info.value.detail == expected_error.detail

--- a/src/tests/uploader/huggingface/test_dataset_uploader.py
+++ b/src/tests/uploader/huggingface/test_dataset_uploader.py
@@ -196,8 +196,8 @@ ERROR_MSG_PREFIX = f"The platform_resource_identifier is invalid for {PlatformNa
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
                     ERROR_MSG_PREFIX
-                    + "The platform_resource_identifier for HuggingFace should be a valid repo_id. "
-                    "A repo_id should only contain [a-zA-Z0-9] or ”-”, ”_”, ”.”"
+                    + "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: "
+                    "'user/Test name with ?'."
                 ),
             ),
         ),
@@ -221,10 +221,8 @@ ERROR_MSG_PREFIX = f"The platform_resource_identifier is invalid for {PlatformNa
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
                     ERROR_MSG_PREFIX
-                    + "The platform_resource_identifier for HuggingFace should be a valid repo_id. "
-                    "For new repositories, there should be a single forward slash in the repo_id "
-                    "(namespace/repo_name). Legacy repositories are without a namespace. This "
-                    "repo_id has too many forward slashes."
+                    + "Repo id must be in the form 'repo_name' or 'namespace/repo_name': 'user/data/set'. " 
+                    "Use `repo_type` argument if needed."
                 ),
             ),
         ),
@@ -235,8 +233,8 @@ ERROR_MSG_PREFIX = f"The platform_resource_identifier is invalid for {PlatformNa
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
                     ERROR_MSG_PREFIX
-                    + "The namespace (the first part of the platform_resource_identifier) should be"
-                    " equal to the username, but wrong-namespace != user."
+                    + "The namespace (the first part of the platform_resource_identifier) should be "
+                    "equal to the username, but wrong-namespace != user."
                 ),
             ),
         ),
@@ -247,8 +245,8 @@ ERROR_MSG_PREFIX = f"The platform_resource_identifier is invalid for {PlatformNa
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
                     ERROR_MSG_PREFIX
-                    + "The platform_resource_identifier for HuggingFace should be a valid repo_id. "
-                    "A repo_id should be between 1 and 96 characters."
+                    +"Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: "
+                    "'user/" + "a" * 200 + "'."
                 ),
             ),
         ),
@@ -261,6 +259,6 @@ def test_validate_repo_id(username: str, dataset_name: str, expected_error: HTTP
     else:
         with pytest.raises(type(expected_error)) as exception_info:
             huggingface_uploader._validate_repo_id(dataset_name, username)
-
+        print(exception_info.value.detail)
         assert exception_info.value.status_code == expected_error.status_code
         assert exception_info.value.detail == expected_error.detail

--- a/src/tests/validators/test_huggingface_validators.py
+++ b/src/tests/validators/test_huggingface_validators.py
@@ -19,16 +19,16 @@ from database.validators import huggingface_validators
         (
             "",
             ValueError(
-                "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' "
-                "cannot start or end the name, max length is 96: "
+                "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are "
+                "forbidden, '-' and '.' cannot start or end the name, max length is 96: "
                 "''."
             ),
         ),
         (
             "user/" + "a" * 200,
             ValueError(
-                "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' "
-                "cannot start or end the name, max length is 96: "
+                "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are "
+                "forbidden, '-' and '.' cannot start or end the name, max length is 96: "
                 "'user/" + "a" * 200 + "'."
             ),
         ),
@@ -40,5 +40,4 @@ def test_identifier(identifier: str, expected_error: ValueError | None):
     else:
         with pytest.raises(type(expected_error)) as exception_info:
             huggingface_validators.throw_error_on_invalid_identifier(identifier)
-        print(exception_info.value.args[0])
         assert exception_info.value.args[0] == expected_error.args[0]

--- a/src/tests/validators/test_huggingface_validators.py
+++ b/src/tests/validators/test_huggingface_validators.py
@@ -12,24 +12,24 @@ from database.validators import huggingface_validators
         (
             "user/data/set",
             ValueError(
-                "The platform_resource_identifier for HuggingFace should be a valid repo_id. For "
-                "new repositories, there should be a single forward slash in the repo_id "
-                "(namespace/repo_name). Legacy repositories are without a namespace. This repo_id "
-                "has too many forward slashes."
+                "Repo id must be in the form 'repo_name' or 'namespace/repo_name': "
+                "'user/data/set'. Use `repo_type` argument if needed."
             ),
         ),
         (
-            "a",
+            "",
             ValueError(
-                "The platform_resource_identifier for HuggingFace should be a valid repo_id. A "
-                "repo_id should be between 1 and 96 characters."
+                "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' "
+                "cannot start or end the name, max length is 96: "
+                "''."
             ),
         ),
         (
             "user/" + "a" * 200,
             ValueError(
-                "The platform_resource_identifier for HuggingFace should be a valid repo_id. A "
-                "repo_id should be between 1 and 96 characters."
+                "Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' "
+                "cannot start or end the name, max length is 96: "
+                "'user/" + "a" * 200 + "'."
             ),
         ),
     ],
@@ -40,4 +40,5 @@ def test_identifier(identifier: str, expected_error: ValueError | None):
     else:
         with pytest.raises(type(expected_error)) as exception_info:
             huggingface_validators.throw_error_on_invalid_identifier(identifier)
+        print(exception_info.value.args[0])
         assert exception_info.value.args[0] == expected_error.args[0]


### PR DESCRIPTION
Bugs in the validator implementation. It is now replaced with the `huggingface_hub.utils.validate_repo_id` as suggested [in the docs](https://huggingface.co/docs/huggingface_hub/package_reference/utilities#huggingface_hub.utils.validate_repo_id). 