### PR TITLE
Correct docstring of Huggingface validator

### DIFF
--- a/src/database/validators/huggingface_validators.py
+++ b/src/database/validators/huggingface_validators.py
@@ -8,8 +8,8 @@ def throw_error_on_invalid_identifier(platform_resource_identifier: str):
     Valid repo_ids:
         Between 1 and 96 characters.
         Either “repo_name” or “namespace/repo_name”
-        [a-zA-Z0-9] or ”-”, ”_”, ”.”
-        ”—” and ”..” are forbidden
+        [a-zA-Z0-9] or ”-”, ”_”, ”.”.
+        The following sequences ”--” and ”..” are forbidden.
 
     Refer to:
     https://huggingface.co/docs/huggingface_hub/package_reference/utilities#huggingface_hub.utils.validate_repo_id


### PR DESCRIPTION
Replacing a single dash "-" with encoding b'\xe2\x80\x94' with double dash "--" with encoding b'-'.
