### PR TITLE
Include sanity check in deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,4 +291,4 @@ To create a new release,
    - Check which services currently work (before the update). It's a sanity check for if a service _doesn't_ work later.
    - Update the code on the server by checking out the release
    - Merge configurations as necessary
-10. Notify everyone (e.g., in the API channel in Slack). 
+9. Notify everyone (e.g., in the API channel in Slack). 

--- a/README.md
+++ b/README.md
@@ -287,4 +287,8 @@ To create a new release,
    release branch. Look at all closed PRs and create a changelog
 6. Create a PR from release branch to master
 7. After that's merged, create a PR from master to develop
-8. Notify everyone (e.g., in the API channel in Slack) and update the code on the server(s). 
+8. Deploy on the server(s):
+   - Check which services currently work (before the update). It's a sanity check for if a service _doesn't_ work later.
+   - Update the code on the server by checking out the release
+   - Merge configurations as necessary
+10. Notify everyone (e.g., in the API channel in Slack). 


### PR DESCRIPTION
During the last deployment, we found certain services were not running. And at that point we really would have liked to have made sure beforehand that those services used to be functional, just so we know the previous configuration worked.