### PR TITLE
Fix/360

### DIFF
--- a/src/database/model/relationships.py
+++ b/src/database/model/relationships.py
@@ -136,6 +136,11 @@ class OneToOne(_ResourceRelationshipSingle):
     def create_triggers(self, parent_class: Type[SQLModel], field_name: str):
         if self.on_delete_trigger_deletion_by is not None:
             to_delete = datatype_of_field(parent_class, field_name)
+            if isinstance(to_delete, str):
+                raise ValueError(
+                    "Deletion trigger is configured wrongly: field cannot use a forward reference "
+                    f"`{parent_class}.{field_name}`"
+                )
             if not issubclass(to_delete, SQLModel):
                 raise ValueError(
                     "The deletion trigger is configured wrongly: the field doesn't "
@@ -199,6 +204,11 @@ class ManyToMany(_ResourceRelationshipList):
         if self.on_delete_trigger_orphan_deletion is not None:
             link = parent_class.__sqlmodel_relationships__[field_name].link_model
             to_delete = datatype_of_field(parent_class, field_name)
+            if isinstance(to_delete, str):
+                raise ValueError(
+                    "Deletion trigger is configured wrongly: field cannot use a forward reference "
+                    f"`{parent_class}.{field_name}`"
+                )
             if not issubclass(to_delete, SQLModel):
                 raise ValueError(
                     "The deletion trigger is configured wrongly: the field doesn't "

--- a/src/tests/database/model/ai_asset/test_ai_asset_delete.py
+++ b/src/tests/database/model/ai_asset/test_ai_asset_delete.py
@@ -11,6 +11,9 @@ from database.session import DbSession
 def test_happy_path(client: TestClient):
     dataset_distribution = datatype_of_field(Dataset, "distribution")
     publication_distribution = datatype_of_field(Publication, "distribution")
+    assert not isinstance(dataset_distribution, str)
+    assert not isinstance(publication_distribution, str)
+
     dataset_1 = Dataset(
         name="dataset 1",
         distribution=[

--- a/src/tests/database/model/resource/test_resource_delete.py
+++ b/src/tests/database/model/resource/test_resource_delete.py
@@ -14,6 +14,8 @@ from database.session import DbSession
 def test_happy_path(client: TestClient):
     dataset_media = datatype_of_field(Dataset, "media")
     dataset_note = datatype_of_field(Dataset, "note")
+    assert not isinstance(dataset_media, str)
+    assert not isinstance(dataset_note, str)
 
     alternate_name_a = AlternateName(name="a")
     alternate_name_b = AlternateName(name="b")


### PR DESCRIPTION
Closes #360 

Note that the previous annotation was simply wrong. There is even a comment in the code that specified the method _can_ return a string

 https://github.com/aiondemand/AIOD-rest-api/blob/69c10331ccb3d6e711719133993644c9faf8f0e5/src/connectors/resource_with_relations.py#L38

With SqlAlchemy 2.0.33+ the internal methods changed to provide a ForwardRef, which broke our code. Previous behavior was to simply return the string of the Forward Ref, so this batch just brings that behavior back.