### PR TITLE
Add basic ownership as temporary prototype for demo

### DIFF
--- a/src/authentication.py
+++ b/src/authentication.py
@@ -48,6 +48,9 @@ keycloak_openid = KeycloakOpenID(
 class User(BaseModel):
     name: str = Field(description="The username.")
     roles: set[str] = Field(description="The roles.")
+    subject_identifier: str = Field(
+        description="Unique identifier for the user that created the resource."
+    )
 
     def has_role(self, role: str) -> bool:
         return role in self.roles
@@ -85,7 +88,9 @@ async def _get_user(token) -> User:
             logging.error("Invalid userinfo or inactive user.")
             raise InvalidUserError("Invalid userinfo or inactive user")  # caught below
         return User(
-            name=userinfo["username"], roles=set(userinfo.get("realm_access", {}).get("roles", []))
+            name=userinfo["username"],
+            roles=set(userinfo.get("realm_access", {}).get("roles", [])),
+            subject_identifier=userinfo["sub"],
         )
     except InvalidUserError:
         raise

--- a/src/database/model/concept/aiod_entry.py
+++ b/src/database/model/concept/aiod_entry.py
@@ -14,6 +14,7 @@ from database.model.serializers import (
 
 if TYPE_CHECKING:
     from database.model.agent.person import Person
+    from authentication import User
 
 
 class AIoDEntryBase(SQLModel):
@@ -38,6 +39,8 @@ class AIoDEntryORM(AIoDEntryBase, table=True):  # type: ignore [call-arg]
     date_modified: datetime | None = Field(default_factory=datetime.utcnow)
     date_created: datetime | None = Field(default_factory=datetime.utcnow)
 
+    creator_identifier: str = Field(max_length=32 + 4, default="")
+
     class RelationshipConfig:
         editor: list[int] = ManyToMany()  # No deletion triggers: "orphan" Persons should be kept
         status: str | None = ManyToOne(
@@ -45,6 +48,9 @@ class AIoDEntryORM(AIoDEntryBase, table=True):  # type: ignore [call-arg]
             identifier_name="status_identifier",
             deserializer=FindByNameDeserializer(Status),
         )
+
+    def owned_by(self, user: "User") -> bool:
+        return self.creator_identifier == user.subject_identifier
 
 
 class AIoDEntryCreate(AIoDEntryBase):

--- a/src/database/model/concept/concept.py
+++ b/src/database/model/concept/concept.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
 import os
-from typing import Optional, Tuple
+from typing import Optional, Tuple, TYPE_CHECKING
 
 from pydantic import validator
 from sqlalchemy import CheckConstraint, Index
@@ -15,6 +15,9 @@ from database.model.platform.platform_names import PlatformName
 from database.model.relationships import OneToOne
 from database.model.serializers import CastDeserializer
 from database.validators import huggingface_validators, openml_validators, zenodo_validators
+
+if TYPE_CHECKING:
+    from authentication import User
 
 IS_SQLITE = os.getenv("DB") == "SQLite"
 CONSTRAINT_LOWERCASE = f"{'platform' if IS_SQLITE else 'BINARY(platform)'} = LOWER(platform)"
@@ -112,3 +115,7 @@ class AIoDConcept(AIoDConceptBase):
             ),
             CheckConstraint(CONSTRAINT_LOWERCASE, name=f"{cls.__name__}_platform_lowercase"),
         ) + tuple(cls.table_arguments())
+
+    def owned_by(self, user: "User") -> bool:
+        assert self.aiod_entry is not None, f"Expected concept to have aiod_entry: {self}"
+        return self.aiod_entry.owned_by(user)

--- a/src/main.py
+++ b/src/main.py
@@ -80,7 +80,10 @@ def add_routes(app: FastAPI, url_prefix=""):
                 query = (
                     select(router_.resource_class)
                     .join(AIoDEntryORM)
-                    .where(AIoDEntryORM.creator_identifier == user.subject_identifier)
+                    .where(
+                        AIoDEntryORM.creator_identifier == user.subject_identifier,
+                        router_.resource_class.date_deleted == None,  # noqa
+                    )
                 )
                 user_orm_assets = session.scalars(query).all()
                 wrapped_assets = [


### PR DESCRIPTION
This is a draft PR and not meant to merge. We have to work with a different system later to account for groups etc., this is a quick hack for the prototype.

----

## What this does
With this PR, every asset uploaded to the metadata catalogue will have an associated user identifier that is considered the owner. This user identifier is the 'sub' token provided by keycloak. With this PR, users can only edit or delete assets they uploaded themselves. Attempting to edit or delete an asset created by a different user will result in an error. All assets are still public: user B can still see assets uploaded by user A.

## How to test
Instructions assume default variables as defined in `.env` for credentials, etc.

### Updating the Database
This update requires a change to the database schema. No migration has been developed yet, so the easiest thing to do is to run the startup once with `--rebuild-db always` (if you do not care about the data in your local instance).

> [!caution]
> Using `--rebuild-db always` will delete all data from the database. If you use it, make sure you do not care about the data. 
> It is advised to turn off `--rebuild-db always` as soon as you do not need it anymore, to avoid unintended loss of data.

If you care about the keeping the data in your database, you could just add the column yourself in mysql (UNTESTED):

    docker exec -it sqlserver mysql -uroot -pok -e 'alter table aiod_entry add column creator_identifier varchar(36) NOT NULL' aiod

However, I strongly recommend you do not test this feature on a database with data you care about.. Note that previous entries will no longer be editable by anyone through the REST API.

### Create an Extra User
As the default config only ships with one predefined user, you'll need to create a second one:

  1. Navigate to `localhost/aiod-auth` and enter admin credentials (admin/password)
  2. In the top-left dropdown, switch the realm from Keycloak to aiod.
  3. Go to `Users>add user`, give it some name.
  4. Edit the user by clicking on it, go to Credentials and set a password, go to Role mapping and add edit_aiod_resources.

### Try it in the REST API
You can now create an asset with your new user, and try to edit or delete it with the default user (or vice versa).
You should get an error when you try to edit a resource the user did not create.