### PR TITLE
Add security linting, request timeouts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,10 @@ repos:
     rev: 22.12.0
     hooks:
       - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.1
+    hooks:
+      - id: ruff  # only do linting for security for now
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991
     hooks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,6 @@ services:
       - ${AIOD_REST_PORT}:8000
     volumes:
       - ./src:/app:ro
-    stdin_open: true # docker run -i
     command: >
       python main.py
       --build-db if-absent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,14 @@ py-modules = []
 [tool.black]
 line-length = 100
 
+[tool.ruff]
+exclude = [
+    "src/tests",
+]
+
+[tool.ruff.lint]
+select = ["S"]
+
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore::FutureWarning"

--- a/src/config.py
+++ b/src/config.py
@@ -6,3 +6,4 @@ with open(pathlib.Path(__file__).parent / "config.toml", "rb") as fh:
 
 DB_CONFIG = CONFIG.get("database", {})
 KEYCLOAK_CONFIG = CONFIG.get("keycloak", {})
+REQUEST_TIMEOUT = CONFIG.get("dev", {}).get("request_timeout", None)

--- a/src/config.toml
+++ b/src/config.toml
@@ -12,6 +12,7 @@ password = "ok"
 # Additional options for development
 [dev]
 reload = true
+request_timeout = 10  # seconds
 
 # Authentication and authorization
 [keycloak]

--- a/src/connectors/huggingface/huggingface_dataset_connector.py
+++ b/src/connectors/huggingface/huggingface_dataset_connector.py
@@ -7,6 +7,7 @@ import requests
 from huggingface_hub import list_datasets
 from huggingface_hub.hf_api import DatasetInfo
 
+from config import REQUEST_TIMEOUT
 from connectors.abstract.resource_connector_on_start_up import ResourceConnectorOnStartUp
 from connectors.record_error import RecordError
 from connectors.resource_with_relations import ResourceWithRelations
@@ -37,7 +38,7 @@ class HuggingFaceDatasetConnector(ResourceConnectorOnStartUp[Dataset]):
 
     @staticmethod
     def _get(url: str, dataset_id: str) -> typing.List[typing.Dict[str, typing.Any]]:
-        response = requests.get(url, params={"dataset": dataset_id})
+        response = requests.get(url, params={"dataset": dataset_id}, timeout=REQUEST_TIMEOUT)
         response_json = response.json()
         if not response.ok:
             msg = response_json["error"]

--- a/src/connectors/openml/openml_dataset_connector.py
+++ b/src/connectors/openml/openml_dataset_connector.py
@@ -11,6 +11,7 @@ from requests.exceptions import HTTPError
 from sqlmodel import SQLModel
 from typing import Iterator
 
+from config import REQUEST_TIMEOUT
 from connectors.abstract.resource_connector_by_id import ResourceConnectorById
 from connectors.record_error import RecordError
 from database.model import field_length
@@ -40,7 +41,7 @@ class OpenMlDatasetConnector(ResourceConnectorById[Dataset]):
 
     def retry(self, identifier: int) -> SQLModel | RecordError:
         url_qual = f"https://www.openml.org/api/v1/json/data/qualities/{identifier}"
-        response = requests.get(url_qual)
+        response = requests.get(url_qual, timeout=REQUEST_TIMEOUT)
         if not response.ok:
             msg = response.json()["error"]["message"]
             return RecordError(
@@ -54,7 +55,7 @@ class OpenMlDatasetConnector(ResourceConnectorById[Dataset]):
         self, identifier: int, qualities: list[dict[str, str]]
     ) -> SQLModel | RecordError:
         url_data = f"https://www.openml.org/api/v1/json/data/{identifier}"
-        response = requests.get(url_data)
+        response = requests.get(url_data, timeout=REQUEST_TIMEOUT)
         if not response.ok:
             msg = response.json()["error"]["message"]
             return RecordError(
@@ -105,7 +106,7 @@ class OpenMlDatasetConnector(ResourceConnectorById[Dataset]):
             "https://www.openml.org/api/v1/json/data/list/"
             f"limit/{self.limit_per_iteration}/offset/{offset}"
         )
-        response = requests.get(url_data)
+        response = requests.get(url_data, timeout=REQUEST_TIMEOUT)
         if not response.ok:
             status_code = response.status_code
             msg = response.json()["error"]["message"]

--- a/src/connectors/openml/openml_mlmodel_connector.py
+++ b/src/connectors/openml/openml_mlmodel_connector.py
@@ -11,6 +11,7 @@ from requests.exceptions import HTTPError
 from sqlmodel import SQLModel
 from typing import Iterator, Any
 
+from config import REQUEST_TIMEOUT
 from connectors.abstract.resource_connector_by_id import ResourceConnectorById
 from connectors.record_error import RecordError
 from database.model import field_length
@@ -45,7 +46,7 @@ class OpenMlMLModelConnector(ResourceConnectorById[MLModel]):
 
     def fetch_record(self, identifier: int) -> ResourceWithRelations[MLModel] | RecordError:
         url_mlmodel = f"https://www.openml.org/api/v1/json/flow/{identifier}"
-        response = requests.get(url_mlmodel)
+        response = requests.get(url_mlmodel, timeout=REQUEST_TIMEOUT)
         if not response.ok:
             msg = response.json()["error"]["message"]
             return RecordError(
@@ -101,7 +102,7 @@ class OpenMlMLModelConnector(ResourceConnectorById[MLModel]):
             "https://www.openml.org/api/v1/json/flow/list/"
             f"limit/{self.limit_per_iteration}/offset/{offset}"
         )
-        response = requests.get(url_mlmodel)
+        response = requests.get(url_mlmodel, timeout=REQUEST_TIMEOUT)
 
         if not response.ok:
             status_code = response.status_code

--- a/src/connectors/zenodo/zenodo_dataset_connector.py
+++ b/src/connectors/zenodo/zenodo_dataset_connector.py
@@ -10,6 +10,7 @@ from sickle.iterator import BaseOAIIterator
 from starlette import status
 from typing import Iterator, Tuple
 
+from config import REQUEST_TIMEOUT
 from connectors.abstract.resource_connector_by_date import ResourceConnectorByDate
 from connectors.record_error import RecordError
 from connectors.resource_with_relations import ResourceWithRelations
@@ -65,7 +66,9 @@ class ZenodoDatasetConnector(ResourceConnectorByDate[Dataset]):
     @limits(calls=GLOBAL_MAX_CALLS_MINUTE, period=ONE_MINUTE)
     @limits(calls=GLOBAL_MAX_CALLS_HOUR, period=ONE_HOUR)
     def _get_record(id_number: str) -> requests.Response:
-        response = requests.get(f"https://zenodo.org/api/records/{id_number}/files")
+        response = requests.get(
+            f"https://zenodo.org/api/records/{id_number}/files", timeout=REQUEST_TIMEOUT
+        )
         return response
 
     def _dataset_from_record(

--- a/src/database/deletion/triggers.py
+++ b/src/database/deletion/triggers.py
@@ -58,7 +58,7 @@ def create_deletion_trigger_one_to_one(
             DELETE FROM {delete_name}
             WHERE {delete_name}.{to_delete_identifier} = OLD.{trigger_identifier_link};
         END;
-        """
+        """  # noqa: S608  # never user input
     )
     event.listen(trigger.metadata, "after_create", ddl)
 
@@ -97,7 +97,7 @@ def create_deletion_trigger_many_to_one(
                 WHERE {trigger_name}.{trigger_identifier_link} = OLD.{trigger_identifier_link}
             );
         END;
-        """
+        """  # noqa: S608  # never user input
     )
     event.listen(trigger.metadata, "after_create", ddl)
 
@@ -139,7 +139,7 @@ def create_deletion_trigger_many_to_many(
                 SELECT 1 FROM {link_name}
                 WHERE {link_name}.{link_to_identifier} = {delete_name}.{to_delete_identifier}
         )
-        """
+        """  # noqa: S608  # never user input
         for link_name in link_names
     )
     ddl = DDL(
@@ -153,6 +153,6 @@ def create_deletion_trigger_many_to_many(
             DELETE FROM {delete_name}
             WHERE {links_clause};
         END;
-        """
+        """  # noqa: S608  # never user input
     )
     event.listen(trigger.metadata, "after_create", ddl)

--- a/src/main.py
+++ b/src/main.py
@@ -131,7 +131,12 @@ def create_app() -> FastAPI:
 def main():
     """Run the application. Placed in a separate function, to avoid having global variables"""
     args = _parse_args()
-    uvicorn.run("main:create_app", host="0.0.0.0", reload=args.reload, factory=True)
+    uvicorn.run(
+        "main:create_app",
+        host="0.0.0.0",  # noqa: S104  # required to make the interface available outside of docker
+        reload=args.reload,
+        factory=True,
+    )
 
 
 if __name__ == "__main__":

--- a/src/tests/connectors/zenodo/test_get_datasets_zenodo.py
+++ b/src/tests/connectors/zenodo/test_get_datasets_zenodo.py
@@ -9,6 +9,7 @@ from ratelimit import limits
 from ratelimit.exception import RateLimitException
 from requests.exceptions import HTTPError
 
+from config import REQUEST_TIMEOUT
 from connectors.record_error import RecordError
 from connectors.zenodo import zenodo_dataset_connector
 from connectors.zenodo.zenodo_dataset_connector import ZenodoDatasetConnector
@@ -168,7 +169,9 @@ def test_fetch_records_rate_limit(monkeypatch):
     @staticmethod
     @limits(calls=1, period=60)
     def mock_check(id_number):
-        response = requests.get(f"https://zenodo.org/api/records/{id_number}/files")
+        response = requests.get(
+            f"https://zenodo.org/api/records/{id_number}/files", timeout=REQUEST_TIMEOUT
+        )
         return response
 
     monkeypatch.setattr(ZenodoDatasetConnector, "_get_record", mock_check)

--- a/src/uploaders/zenodo_uploader.py
+++ b/src/uploaders/zenodo_uploader.py
@@ -8,6 +8,7 @@ from typing import Optional
 from fastapi import UploadFile, HTTPException, status
 
 from authentication import User
+from config import REQUEST_TIMEOUT
 
 from database.model.agent.contact import Contact
 from database.model.ai_asset.license import License
@@ -142,6 +143,7 @@ class ZenodoUploader(Uploader):
                 self.BASE_URL,
                 params=params,
                 json={"metadata": metadata},
+                timeout=REQUEST_TIMEOUT,
             )
         except Exception as exc:
             raise as_http_exception(exc)
@@ -158,7 +160,7 @@ class ZenodoUploader(Uploader):
         """
         params = {"access_token": token}
         try:
-            res = requests.get(f"{self.BASE_URL}/{repo_id}", params=params)
+            res = requests.get(f"{self.BASE_URL}/{repo_id}", params=params, timeout=REQUEST_TIMEOUT)
         except Exception as exc:
             raise as_http_exception(exc)
 
@@ -179,6 +181,7 @@ class ZenodoUploader(Uploader):
                 params={"access_token": token},
                 data=json.dumps({"metadata": metadata}),
                 headers=headers,
+                timeout=REQUEST_TIMEOUT,
             )
         except Exception as exc:
             raise as_http_exception(exc)
@@ -194,7 +197,10 @@ class ZenodoUploader(Uploader):
         params = {"access_token": token}
         try:
             res = requests.put(
-                f"{repo_url}/{file.filename}", data=io.BufferedReader(file.file), params=params
+                f"{repo_url}/{file.filename}",
+                data=io.BufferedReader(file.file),
+                params=params,
+                timeout=REQUEST_TIMEOUT,
             )
         except Exception as exc:
             raise as_http_exception(exc)
@@ -209,7 +215,9 @@ class ZenodoUploader(Uploader):
         """
         params = {"access_token": token}
         try:
-            res = requests.post(f"{self.BASE_URL}/{repo_id}/actions/publish", params=params)
+            res = requests.post(
+                f"{self.BASE_URL}/{repo_id}/actions/publish", params=params, timeout=REQUEST_TIMEOUT
+            )
         except Exception as exc:
             raise as_http_exception(exc)
 
@@ -229,7 +237,7 @@ class ZenodoUploader(Uploader):
         url = public_url or f"{self.BASE_URL}/{repo_id}"
 
         try:
-            res = requests.get(f"{url}/files", params=params)
+            res = requests.get(f"{url}/files", params=params, timeout=REQUEST_TIMEOUT)
         except Exception as exc:
             raise as_http_exception(exc)
 
@@ -261,7 +269,9 @@ class ZenodoUploader(Uploader):
         Checks if the provided license is valid for uploading content to Zenodo.
         """
         try:
-            res = requests.get("https://zenodo.org/api/vocabularies/licenses?q=&tags=data")
+            res = requests.get(
+                "https://zenodo.org/api/vocabularies/licenses?q=&tags=data", timeout=REQUEST_TIMEOUT
+            )
         except Exception as exc:
             raise as_http_exception(exc)
         if res.status_code != status.HTTP_200_OK:


### PR DESCRIPTION
I added security linting through ruff. This is a reimplementation of (most) bandit checks, but in Rust. We will probably move over to `ruff` for all linting and formatting since its much faster, which is why I opted to use Ruff here instead of Bandit as was recommended in the audit.