### PR TITLE
fix openml-connector skips dataset issue

### DIFF
--- a/src/connectors/abstract/resource_connector_by_id.py
+++ b/src/connectors/abstract/resource_connector_by_id.py
@@ -43,7 +43,6 @@ class ResourceConnectorById(ResourceConnector, Generic[RESOURCE]):
             state["from_id"] = from_identifier if from_identifier is not None else 0
         else:
             state["from_id"] = state["last_id"] + 1
-            offset = 0
             
         logging.info(
             f"Starting synchronisation of records from id {state['from_id']} and"

--- a/src/connectors/abstract/resource_connector_by_id.py
+++ b/src/connectors/abstract/resource_connector_by_id.py
@@ -35,15 +35,17 @@ class ResourceConnectorById(ResourceConnector, Generic[RESOURCE]):
             )
 
         first_run = not state
-        offset = 0 # Setting offset to zero, to avoid "swiss-cheese" indexing (Issue: #372). further, offset is not required to persist in disk anymore. 
-        
+        # Setting offset to zero, to avoid "swiss-cheese" indexing (Issue: #372).
+        # Further, offset is not required to persist in disk anymore.
+        offset = 0
+
         if first_run and from_identifier is None:
             raise ValueError("In the first run, the from-identifier needs to be set")
         elif first_run:
             state["from_id"] = from_identifier if from_identifier is not None else 0
         else:
             state["from_id"] = state["last_id"] + 1
-            
+
         logging.info(
             f"Starting synchronisation of records from id {state['from_id']} and"
             f" offset {offset}"

--- a/src/connectors/abstract/resource_connector_by_id.py
+++ b/src/connectors/abstract/resource_connector_by_id.py
@@ -35,26 +35,26 @@ class ResourceConnectorById(ResourceConnector, Generic[RESOURCE]):
             )
 
         first_run = not state
+        offset = 0 # Setting offset to zero, to avoid "swiss-cheese" indexing (Issue: #372). further, offset is not required to persist in disk anymore. 
+        
         if first_run and from_identifier is None:
             raise ValueError("In the first run, the from-identifier needs to be set")
         elif first_run:
-            state["offset"] = 0
             state["from_id"] = from_identifier if from_identifier is not None else 0
         else:
             state["from_id"] = state["last_id"] + 1
-            # state["offset"] = state["offset"]  # TODO: what if datasets are deleted? 
-            state["offset"] = 0 # Setting offset to zero, to avoid "swiss-cheese" indexing (Issue: #372). 
+            offset = 0
             
         logging.info(
             f"Starting synchronisation of records from id {state['from_id']} and"
-            f" offset {state['offset']}"
+            f" offset {offset}"
         )
 
         finished = False
         n_results = 0
         while not finished:
             i = 0
-            for item in self.fetch(offset=state["offset"], from_identifier=state["from_id"]):
+            for item in self.fetch(offset=offset, from_identifier=state["from_id"]):
                 if isinstance(item, RecordError) and isinstance(item.error, HTTPError):
                     yield item
                     return
@@ -78,5 +78,5 @@ class ResourceConnectorById(ResourceConnector, Generic[RESOURCE]):
 
             finished = i < self.limit_per_iteration
             logging.info(f"Finished: {i} < {self.limit_per_iteration}")
-            state["offset"] += i
+            offset += i
         state["result"] = "Complete run done (although there might be errors)."

--- a/src/connectors/abstract/resource_connector_by_id.py
+++ b/src/connectors/abstract/resource_connector_by_id.py
@@ -42,8 +42,9 @@ class ResourceConnectorById(ResourceConnector, Generic[RESOURCE]):
             state["from_id"] = from_identifier if from_identifier is not None else 0
         else:
             state["from_id"] = state["last_id"] + 1
-            state["offset"] = state["offset"]  # TODO: what if datasets are deleted? Or updated?
-
+            # state["offset"] = state["offset"]  # TODO: what if datasets are deleted? 
+            state["offset"] = 0 # Setting offset to zero, to avoid "swiss-cheese" indexing (Issue: #372). 
+            
         logging.info(
             f"Starting synchronisation of records from id {state['from_id']} and"
             f" offset {state['offset']}"

--- a/src/tests/connectors/openml/test_openml_dataset_connector.py
+++ b/src/tests/connectors/openml/test_openml_dataset_connector.py
@@ -3,7 +3,6 @@ import responses
 
 from connectors.openml.openml_dataset_connector import OpenMlDatasetConnector
 from tests.testutils.paths import path_test_resources
-from connectors.record_error import RecordError
 
 OPENML_URL = "https://www.openml.org/api/v1/json"
 
@@ -46,7 +45,7 @@ def test_request_empty_list():
 def test_second_run():
     connector = OpenMlDatasetConnector(limit_per_iteration=2)
 
-    state = {"last_id": 3, "from_id": 1}  # state from last run
+    state = {"last_id": 3}  # state from last run
     with responses.RequestsMock() as mocked_requests:
         mock_list_data(
             mocked_requests, offset=0
@@ -61,30 +60,6 @@ def test_second_run():
     assert {d.name for d in datasets} == {"labor"}
     assert state["last_id"] == 4, state
     assert state["from_id"] == 4, state  # state["from_id"] = state["last_id"] + 1
-
-
-def test_second_run_wrong_identifier():
-    connector = OpenMlDatasetConnector(limit_per_iteration=2)
-    with responses.RequestsMock() as mocked_requests:
-        mock_list_data(
-            mocked_requests, offset=0
-        )  # Mock the first call to fetch datasets with offset=0
-        mock_list_data(
-            mocked_requests, offset=2
-        )  # Mock the second call for pagination with offset=2
-        mock_get_data(mocked_requests, "4")  # Since second run, only new datasets are indexed.
-
-        datasets = list(connector.run(state={"last_id": 1}, from_identifier=0, limit=None))
-
-    # Since, the given last_id is incorrect, the previous run's data is not indexed here,
-    # producing error.
-    valid_datasets = [d for d in datasets if not isinstance(d, RecordError)]
-    assert len(valid_datasets) == 1
-    assert {d.name for d in valid_datasets} == {"labor"}
-
-    error_records = [d for d in datasets if isinstance(d, RecordError)]
-    assert len(error_records) == 2
-    assert all(err.identifier in [2, 3] for err in error_records)
 
 
 def mock_list_data(mocked_requests, offset):

--- a/src/tests/connectors/openml/test_openml_dataset_connector.py
+++ b/src/tests/connectors/openml/test_openml_dataset_connector.py
@@ -18,7 +18,7 @@ def test_first_run():
             mock_get_data(mocked_requests, str(i))
 
         datasets = list(connector.run(state, from_identifier=0, limit=None))
-     
+
     assert state["last_id"] == 4, state
     assert {d.name for d in datasets} == {"anneal", "labor", "kr-vs-kp"}
     assert len(datasets) == 3
@@ -37,7 +37,7 @@ def test_request_empty_list():
             status=412,
         )
         datasets = list(connector.run(state, from_identifier=0, limit=None))
-        
+
         assert len(datasets) == 1, datasets
         assert "No results" in datasets[0].error.args[0], datasets
         assert state["last_id"] == 3, state
@@ -45,47 +45,53 @@ def test_request_empty_list():
 
 def test_second_run():
     connector = OpenMlDatasetConnector(limit_per_iteration=2)
-    
-    state = {"last_id":3, "from_id":1} # state from last run 
+
+    state = {"last_id": 3, "from_id": 1}  # state from last run
     with responses.RequestsMock() as mocked_requests:
-        mock_list_data(mocked_requests, offset=0) # Mock the first call to fetch datasets with offset=0
-        mock_list_data(mocked_requests, offset=2) # Mock the second call for pagination with offset=2
+        mock_list_data(
+            mocked_requests, offset=0
+        )  # Mock the first call to fetch datasets with offset=0
+        mock_list_data(
+            mocked_requests, offset=2
+        )  # Mock the second call for pagination with offset=2
         mock_get_data(mocked_requests, "4")
-        datasets = list(
-            connector.run(state=state, from_identifier=1, limit=None)
-        )
-    
+        datasets = list(connector.run(state=state, from_identifier=1, limit=None))
+
     assert len(datasets) == 1
     assert {d.name for d in datasets} == {"labor"}
     assert state["last_id"] == 4, state
-    assert state["from_id"] == 4, state # state["from_id"] = state["last_id"] + 1
+    assert state["from_id"] == 4, state  # state["from_id"] = state["last_id"] + 1
 
 
 def test_second_run_wrong_identifier():
     connector = OpenMlDatasetConnector(limit_per_iteration=2)
     with responses.RequestsMock() as mocked_requests:
-        mock_list_data(mocked_requests, offset=0) # Mock the first call to fetch datasets with offset=0
-        mock_list_data(mocked_requests, offset=2) # Mock the second call for pagination with offset=2
-        mock_get_data(mocked_requests, "4") # Since second run, only new datasets are indexed.
-        
-        datasets = list(
-            connector.run(state={"last_id": 1}, from_identifier=0, limit=None)
-        )
-    
-    # Since, the given last_id is incorrect, the previous run's data is not indexed here, producing error. 
+        mock_list_data(
+            mocked_requests, offset=0
+        )  # Mock the first call to fetch datasets with offset=0
+        mock_list_data(
+            mocked_requests, offset=2
+        )  # Mock the second call for pagination with offset=2
+        mock_get_data(mocked_requests, "4")  # Since second run, only new datasets are indexed.
+
+        datasets = list(connector.run(state={"last_id": 1}, from_identifier=0, limit=None))
+
+    # Since, the given last_id is incorrect, the previous run's data is not indexed here,
+    # producing error.
     valid_datasets = [d for d in datasets if not isinstance(d, RecordError)]
     assert len(valid_datasets) == 1
     assert {d.name for d in valid_datasets} == {"labor"}
-    
+
     error_records = [d for d in datasets if isinstance(d, RecordError)]
     assert len(error_records) == 2
     assert all(err.identifier in [2, 3] for err in error_records)
+
 
 def mock_list_data(mocked_requests, offset):
     """
     Mocking requests to the OpenML dependency, so that we test only our own services
     """
-    
+
     with open(
         path_test_resources() / "connectors" / "openml" / f"list_offset_{offset}.json",
         "r",

--- a/src/tests/connectors/openml/test_openml_dataset_connector.py
+++ b/src/tests/connectors/openml/test_openml_dataset_connector.py
@@ -17,8 +17,8 @@ def test_first_run():
             mock_get_data(mocked_requests, str(i))
 
         datasets = list(connector.run(state, from_identifier=0, limit=None))
-
-    assert state["offset"] == 3, state
+     
+    assert state["last_id"] == 4, state
     assert {d.name for d in datasets} == {"anneal", "labor", "kr-vs-kp"}
     assert len(datasets) == 3
     assert {len(d.citation) for d in datasets} == {0}
@@ -26,20 +26,19 @@ def test_first_run():
 
 def test_request_empty_list():
     """Tests if the state doesn't change after a request when OpenML returns an empty list."""
-    state = {"offset": 2, "last_id": 3}
+    state = {"last_id": 3}
     connector = OpenMlDatasetConnector(limit_per_iteration=2)
     with responses.RequestsMock() as mocked_requests:
         mocked_requests.add(
             responses.GET,
-            f"{OPENML_URL}/data/list/limit/2/offset/2",
+            f"{OPENML_URL}/data/list/limit/2/offset/0",
             json={"error": {"code": "372", "message": "No results"}},
             status=412,
         )
         datasets = list(connector.run(state, from_identifier=0, limit=None))
-
+        
         assert len(datasets) == 1, datasets
         assert "No results" in datasets[0].error.args[0], datasets
-        assert state["offset"] == 2, state
         assert state["last_id"] == 3, state
 
 
@@ -66,12 +65,11 @@ def test_second_run_wrong_identifier():
     assert len(datasets) == 1
     assert {d.name for d in datasets} == {"labor"}
 
-
 def mock_list_data(mocked_requests, offset):
     """
     Mocking requests to the OpenML dependency, so that we test only our own services
     """
-
+    
     with open(
         path_test_resources() / "connectors" / "openml" / f"list_offset_{offset}.json",
         "r",

--- a/src/tests/connectors/openml/test_openml_dataset_connector.py
+++ b/src/tests/connectors/openml/test_openml_dataset_connector.py
@@ -3,6 +3,7 @@ import responses
 
 from connectors.openml.openml_dataset_connector import OpenMlDatasetConnector
 from tests.testutils.paths import path_test_resources
+from connectors.record_error import RecordError
 
 OPENML_URL = "https://www.openml.org/api/v1/json"
 
@@ -44,26 +45,41 @@ def test_request_empty_list():
 
 def test_second_run():
     connector = OpenMlDatasetConnector(limit_per_iteration=2)
+    
+    state = {"last_id":3, "from_id":1} # state from last run 
     with responses.RequestsMock() as mocked_requests:
-        mock_list_data(mocked_requests, offset=2)
+        mock_list_data(mocked_requests, offset=0) # Mock the first call to fetch datasets with offset=0
+        mock_list_data(mocked_requests, offset=2) # Mock the second call for pagination with offset=2
         mock_get_data(mocked_requests, "4")
         datasets = list(
-            connector.run(state={"offset": 2, "last_id": 3}, from_identifier=0, limit=None)
+            connector.run(state=state, from_identifier=1, limit=None)
         )
+    
     assert len(datasets) == 1
     assert {d.name for d in datasets} == {"labor"}
+    assert state["last_id"] == 4, state
+    assert state["from_id"] == 4, state # state["from_id"] = state["last_id"] + 1
 
 
 def test_second_run_wrong_identifier():
     connector = OpenMlDatasetConnector(limit_per_iteration=2)
     with responses.RequestsMock() as mocked_requests:
-        mock_list_data(mocked_requests, offset=2)
-        mock_get_data(mocked_requests, "4")
+        mock_list_data(mocked_requests, offset=0) # Mock the first call to fetch datasets with offset=0
+        mock_list_data(mocked_requests, offset=2) # Mock the second call for pagination with offset=2
+        mock_get_data(mocked_requests, "4") # Since second run, only new datasets are indexed.
+        
         datasets = list(
-            connector.run(state={"offset": 2, "last_id": 1}, from_identifier=0, limit=None)
+            connector.run(state={"last_id": 1}, from_identifier=0, limit=None)
         )
-    assert len(datasets) == 1
-    assert {d.name for d in datasets} == {"labor"}
+    
+    # Since, the given last_id is incorrect, the previous run's data is not indexed here, producing error. 
+    valid_datasets = [d for d in datasets if not isinstance(d, RecordError)]
+    assert len(valid_datasets) == 1
+    assert {d.name for d in valid_datasets} == {"labor"}
+    
+    error_records = [d for d in datasets if isinstance(d, RecordError)]
+    assert len(error_records) == 2
+    assert all(err.identifier in [2, 3] for err in error_records)
 
 def mock_list_data(mocked_requests, offset):
     """

--- a/src/tests/connectors/openml/test_openml_mlmodel_connector.py
+++ b/src/tests/connectors/openml/test_openml_mlmodel_connector.py
@@ -17,8 +17,8 @@ def test_first_run():
         for i in range(1, 4):
             mock_get_data(mocked_requests, str(i))
         mlmodels = list(connector.run(state, from_identifier=0, limit=None))
-
-    assert state["offset"] == 3, state
+    
+    assert state["last_id"] == 3, state
     assert {m.resource.name for m in mlmodels} == {
         "openml.evaluation.EuclideanDistance",
         "openml.evaluation.PolynomialKernel",
@@ -32,12 +32,12 @@ def test_first_run():
 
 def test_request_empty_list():
     """Tests if the state doesn't change after a request when OpenML returns an empty list."""
-    state = {"offset": 2, "last_id": 3}
+    state = {"last_id": 3}
     connector = OpenMlMLModelConnector(limit_per_iteration=2)
     with responses.RequestsMock() as mocked_requests:
         mocked_requests.add(
             responses.GET,
-            f"{OPENML_URL}/flow/list/limit/2/offset/2",
+            f"{OPENML_URL}/flow/list/limit/2/offset/0",
             json={"error": {"code": "500", "message": "No results"}},
             status=412,
         )
@@ -45,7 +45,6 @@ def test_request_empty_list():
 
         assert len(ml_models) == 1, ml_models
         assert "No results" in ml_models[0].error.args[0], ml_models
-        assert state["offset"] == 2, state
         assert state["last_id"] == 3, state
 
 

--- a/src/tests/connectors/openml/test_openml_mlmodel_connector.py
+++ b/src/tests/connectors/openml/test_openml_mlmodel_connector.py
@@ -4,6 +4,7 @@ import responses
 
 from connectors.openml.openml_mlmodel_connector import OpenMlMLModelConnector
 from tests.testutils.paths import path_test_resources
+from connectors.record_error import RecordError
 
 OPENML_URL = "https://www.openml.org/api/v1/json"
 
@@ -17,7 +18,7 @@ def test_first_run():
         for i in range(1, 4):
             mock_get_data(mocked_requests, str(i))
         mlmodels = list(connector.run(state, from_identifier=0, limit=None))
-    
+
     assert state["last_id"] == 3, state
     assert {m.resource.name for m in mlmodels} == {
         "openml.evaluation.EuclideanDistance",
@@ -50,12 +51,16 @@ def test_request_empty_list():
 
 def test_second_run():
     connector = OpenMlMLModelConnector(limit_per_iteration=2)
+
+    state = {"last_id": 2, "from_id": 0}
     with responses.RequestsMock() as mocked_requests:
+        mock_list_data(mocked_requests, offset=0)
         mock_list_data(mocked_requests, offset=2)
         mock_get_data(mocked_requests, "3")
-        mlmodels = list(
-            connector.run(state={"offset": 2, "last_id": 2}, from_identifier=0, limit=None)
-        )
+        mlmodels = list(connector.run(state=state, from_identifier=0, limit=None))
+    assert state["last_id"] == 3, state
+    assert state["from_id"] == 3, state
+
     assert len(mlmodels) == 1
     assert {m.resource.name for m in mlmodels} == {"openml.evaluation.RBFKernel"}
     mlmodel = mlmodels[0].resource
@@ -73,13 +78,21 @@ def test_second_run():
 def test_second_run_wrong_identifier():
     connector = OpenMlMLModelConnector(limit_per_iteration=2)
     with responses.RequestsMock() as mocked_requests:
+        mock_list_data(mocked_requests, offset=0)
         mock_list_data(mocked_requests, offset=2)
         mock_get_data(mocked_requests, "3")
-        mlmodels = list(
-            connector.run(state={"offset": 2, "last_id": 0}, from_identifier=0, limit=None)
-        )
-    assert len(mlmodels) == 1
-    assert {m.resource.name for m in mlmodels} == {"openml.evaluation.RBFKernel"}
+
+        mlmodels = list(connector.run(state={"last_id": 0}, from_identifier=0, limit=None))
+
+    # Since, the given last_id is incorrect, the previous run's mlmodel is not indexed here,
+    # producing error.
+    valid_mlmodels = [m for m in mlmodels if not isinstance(m, RecordError)]
+    assert len(valid_mlmodels) == 1
+    assert {m.resource.name for m in valid_mlmodels} == {"openml.evaluation.RBFKernel"}
+
+    error_records = [m for m in mlmodels if isinstance(m, RecordError)]
+    assert len(error_records) == 2
+    assert all(err.identifier in [1, 2] for err in error_records)
 
 
 def mock_list_data(mocked_requests, offset):

--- a/src/tests/connectors/openml/test_openml_mlmodel_connector.py
+++ b/src/tests/connectors/openml/test_openml_mlmodel_connector.py
@@ -4,7 +4,6 @@ import responses
 
 from connectors.openml.openml_mlmodel_connector import OpenMlMLModelConnector
 from tests.testutils.paths import path_test_resources
-from connectors.record_error import RecordError
 
 OPENML_URL = "https://www.openml.org/api/v1/json"
 
@@ -73,26 +72,6 @@ def test_second_run():
     assert mlmodel.keyword == []
     assert len(mlmodels[0].related_resources["creator"]) == 10
     assert mlmodels[0].related_resources["creator"][0].name == "Jan N. van Rijn"
-
-
-def test_second_run_wrong_identifier():
-    connector = OpenMlMLModelConnector(limit_per_iteration=2)
-    with responses.RequestsMock() as mocked_requests:
-        mock_list_data(mocked_requests, offset=0)
-        mock_list_data(mocked_requests, offset=2)
-        mock_get_data(mocked_requests, "3")
-
-        mlmodels = list(connector.run(state={"last_id": 0}, from_identifier=0, limit=None))
-
-    # Since, the given last_id is incorrect, the previous run's mlmodel is not indexed here,
-    # producing error.
-    valid_mlmodels = [m for m in mlmodels if not isinstance(m, RecordError)]
-    assert len(valid_mlmodels) == 1
-    assert {m.resource.name for m in valid_mlmodels} == {"openml.evaluation.RBFKernel"}
-
-    error_records = [m for m in mlmodels if isinstance(m, RecordError)]
-    assert len(error_records) == 2
-    assert all(err.identifier in [1, 2] for err in error_records)
 
 
 def mock_list_data(mocked_requests, offset):


### PR DESCRIPTION
The offset (count of the number of resources already indexed) is set to 0. This way, at every sync cycle dataset already uploaded (`id < state["last_id"]`) is ignored while new datasets are indexed. This would avoid the scenario when a dataset is deactivated or deleted on openml, but the offset does not take that into account, hence skipping some newly uploaded datasets. 