### PR TITLE
Add migration to extend distribution content_url to LONG

### DIFF
--- a/alembic/README.md
+++ b/alembic/README.md
@@ -17,7 +17,7 @@ With the sqlserver container running, you can migrate to the latest schema with:
 ```commandline
 docker run -v $(pwd)/alembic:/alembic:ro  -v $(pwd)/src:/app -it --network aiod_default  aiod-migration
 ```
-Make sure that the specifid `--network` is the docker network that has the `sqlserver` container.
+Make sure that the specified `--network` is the docker network that has the `sqlserver` container.
 The alembic directory is mounted to ensure the latest migrations are available, 
 the src directory is mounted so the migration scripts can use defined classes and variable from the project.
 
@@ -27,6 +27,22 @@ the src directory is mounted so the migration scripts can use defined classes an
 
 Following the usage commands above, on a new release we should run alembic to ensure the latest schema changes are applied.
 The default entrypoint of the container specifies to upgrade the database to the latest schema.
+
+## Adding a Revision
+
+Build the docker image above, and start a container of it with shell as entry: 
+
+```bash
+docker run -v $(pwd)/alembic:/alembic  -v $(pwd)/src:/app -it --network aiod_default --entrypoint=/bin/bash  aiod-migration
+```
+
+Then follow regular `alembic` steps:
+```bash
+alembic revision -m "revision message"
+```
+Then edit the generated file (note that it should also exist on your host machine, so you might prefer to edit it there).
+
+Note that working from a docker container is not strictly necessary, but it helps set up the PYTHONPATH correctly, so that you can import from the `src` directory.
 
 ## TODO
  - set up support for auto-generating migration scripts: https://alembic.sqlalchemy.org/en/latest/autogenerate.html

--- a/alembic/alembic/versions/279e17c48ea1_extend_description_length.py
+++ b/alembic/alembic/versions/279e17c48ea1_extend_description_length.py
@@ -1,0 +1,42 @@
+"""Extend description length
+
+Revision ID: 279e17c48ea1
+Revises: 0a23b40cc09c
+Create Date: 2024-10-29 14:38:30.684251
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+from sqlalchemy import String
+
+from database.model.field_length import LONG
+
+# revision identifiers, used by Alembic.
+revision: str = "279e17c48ea1"
+down_revision: Union[str, None] = "0a23b40cc09c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # All models that have associated distributions
+    for table in [
+        "dataset",
+        "case_study",
+        "publication",
+        "computational_asset",
+        "ml_model",
+        "experiment",
+    ]:
+        op.alter_column(
+            f"distribution_{table}",
+            "content_url",
+            type_=String(LONG),
+        )
+
+
+def downgrade() -> None:
+    # from NORMAL
+    pass


### PR DESCRIPTION
PR #335 changed the field length of the distribution url in the model, but not in the database. This PR adds an alembic migration script so that values which are valid for the API are now also valid for the database.