### PR TITLE
Add resource filters to GET endpoints

### DIFF
--- a/alembic/alembic/versions/0f2fe1324047_non_nullable_date_modified_and_date_created.py
+++ b/alembic/alembic/versions/0f2fe1324047_non_nullable_date_modified_and_date_created.py
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '0f2fe1324047'
-down_revision: Union[str, None] = '279e17c48ea1'
+revision: str = "0f2fe1324047"
+down_revision: Union[str, None] = "279e17c48ea1"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/alembic/versions/0f2fe1324047_non_nullable_date_modified_and_date_created.py
+++ b/alembic/alembic/versions/0f2fe1324047_non_nullable_date_modified_and_date_created.py
@@ -1,0 +1,38 @@
+"""Make columns date_modified and date_created non-nullable in table aiod_entry
+
+Revision ID: 0f2fe1324047
+Revises: 279e17c48ea1
+Create Date: 2024-10-31 16:37:23.196383
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0f2fe1324047'
+down_revision: Union[str, None] = '279e17c48ea1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    for column in ["date_created", "date_modified"]:
+        op.alter_column(
+            "aiod_entry",
+            column,
+            existing_type=sa.DateTime(),
+            nullable=False,
+        )
+
+
+def downgrade() -> None:
+    for column in ["date_created", "date_modified"]:
+        op.alter_column(
+            "aiod_entry",
+            column,
+            existing_type=sa.DateTime(),
+            nullable=True,
+        )

--- a/src/database/model/concept/aiod_entry.py
+++ b/src/database/model/concept/aiod_entry.py
@@ -35,8 +35,8 @@ class AIoDEntryORM(AIoDEntryBase, table=True):  # type: ignore [call-arg]
     status: Status | None = Relationship()
 
     # date_modified is updated in the resource_router
-    date_modified: datetime | None = Field(default_factory=datetime.utcnow)
-    date_created: datetime | None = Field(default_factory=datetime.utcnow)
+    date_modified: datetime = Field(default_factory=datetime.utcnow)
+    date_created: datetime = Field(default_factory=datetime.utcnow)
 
     class RelationshipConfig:
         editor: list[int] = ManyToMany()  # No deletion triggers: "orphan" Persons should be kept

--- a/src/database/model/platform/platform.py
+++ b/src/database/model/platform/platform.py
@@ -27,4 +27,4 @@ class Platform(PlatformBase, table=True):  # type: ignore [call-arg]
     # which is difficult for foreign key constraints
 
     identifier: int = Field(primary_key=True, default=None)
-    date_deleted: datetime.datetime | None = Field()
+    date_deleted: datetime.datetime | None = Field()  # Always be NULL due to hard_deletions

--- a/src/database/model/resource_read_and_create.py
+++ b/src/database/model/resource_read_and_create.py
@@ -17,6 +17,7 @@ from database.model.serializers import create_getter_dict
 
 if TYPE_CHECKING:
     from database.model.concept.concept import AIoDConcept
+    from database.model.platform.platform import Platform
     from database.model.relationships import _ResourceRelationship
 
 
@@ -55,7 +56,7 @@ def _get_field_definitions_create(
     }
 
 
-def resource_create(resource_class: Type["AIoDConcept"]) -> Type[SQLModel]:
+def resource_create(resource_class: Type["AIoDConcept"] | Type["Platform"]) -> Type[SQLModel]:
     """
     Create a SQLModel for a Create class of a resource. This Create class is a Pydantic class
     that can be used for POST and PUT requests (and thus has no identifier), and is not backed by a
@@ -75,7 +76,7 @@ def resource_create(resource_class: Type["AIoDConcept"]) -> Type[SQLModel]:
     return model
 
 
-def resource_read(resource_class: Type["AIoDConcept"]) -> Type[SQLModel]:
+def resource_read(resource_class: Type["AIoDConcept"] | Type["Platform"]) -> Type[SQLModel]:
     """
     Create a SQLModel for a Read class of a resource. This Read class is a Pydantic class
     that can be used for GET requests (and thus has a required identifier), and is not backed by a

--- a/src/dependencies/filtering.py
+++ b/src/dependencies/filtering.py
@@ -1,0 +1,26 @@
+import datetime
+from typing import Annotated
+
+from fastapi import Query, Depends
+from pydantic import BaseModel
+from sqlmodel import Field
+
+
+class ResourceFilters(BaseModel):
+    """Resource filters used in GET endpoints"""
+
+    date_modified_after: datetime.date | None = Field(
+        Query(
+            description="Get only resources modified after this date (yyyy-mm-dd, inclusive).",
+            default=None,
+        )
+    )
+    date_modified_before: datetime.date | None = Field(
+        Query(
+            description="Get only resources modified before this date (yyyy-mm-dd, exclusive).",
+            default=None,
+        )
+    )
+
+
+ResourceFiltersParams = Annotated[ResourceFilters, Depends(ResourceFilters)]

--- a/src/dependencies/pagination.py
+++ b/src/dependencies/pagination.py
@@ -1,0 +1,27 @@
+from typing import Annotated
+
+from fastapi import Query, Depends
+from pydantic import BaseModel
+from sqlmodel import Field
+
+
+class Pagination(BaseModel):
+    """Offset-based pagination."""
+
+    offset: int = Field(
+        Query(
+            description="Specifies the number of resources that should be skipped.", default=0, ge=0
+        )
+    )
+    # Query inside field to ensure description is shown in Swagger.
+    # Refer to https://github.com/tiangolo/fastapi/issues/4700
+    limit: int = Field(
+        Query(
+            description="Specified the maximum number of resources that should be returned.",
+            default=10,
+            le=1000,
+        )
+    )
+
+
+PaginationParams = Annotated[Pagination, Depends(Pagination)]

--- a/src/main.py
+++ b/src/main.py
@@ -84,7 +84,7 @@ def add_routes(app: FastAPI, url_prefix=""):
             router.resource_name_plural: count
             for router in resource_routers.router_list
             if issubclass(router.resource_class, AIoDConcept)
-            and (count := router.get_resource_count_func()(detailed=True))
+            and (count := router.get_resource_count_func()(detailed=True))  # type:ignore
         }
 
     for router in (

--- a/src/main.py
+++ b/src/main.py
@@ -84,7 +84,7 @@ def add_routes(app: FastAPI, url_prefix=""):
             router.resource_name_plural: count
             for router in resource_routers.router_list
             if issubclass(router.resource_class, AIoDConcept)
-            and (count := router.get_resource_count_func()(detailed=True))  # type:ignore
+            and (count := router.get_resource_count_func()(detailed=True))
         }
 
     for router in (

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -7,10 +7,9 @@ from wsgiref.handlers import format_date_time
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
 from fastapi.encoders import jsonable_encoder
-from pydantic import BaseModel
 from sqlalchemy import and_, func
 from sqlalchemy.sql.operators import is_
-from sqlmodel import SQLModel, Session, select, Field
+from sqlmodel import SQLModel, Session, select
 from starlette.responses import JSONResponse
 
 from authentication import User, get_user_or_none, get_user_or_raise
@@ -27,50 +26,9 @@ from database.model.resource_read_and_create import (
 )
 from database.model.serializers import deserialize_resource_relationships
 from database.session import DbSession
+from dependencies.filtering import ResourceFilters, ResourceFiltersParams
+from dependencies.pagination import Pagination, PaginationParams
 from error_handling import as_http_exception
-
-
-class Pagination(BaseModel):
-    """Offset-based pagination."""
-
-    offset: int = Field(
-        Query(
-            description="Specifies the number of resources that should be skipped.", default=0, ge=0
-        )
-    )
-    # Query inside field to ensure description is shown in Swagger.
-    # Refer to https://github.com/tiangolo/fastapi/issues/4700
-    limit: int = Field(
-        Query(
-            description="Specified the maximum number of resources that should be returned.",
-            default=10,
-            le=1000,
-        )
-    )
-
-
-class ResourceFilters(BaseModel):
-    """
-    AIoD Resource filters
-
-    Filters are used in GET endpoints:
-    - GET /[resource]s/
-    - GET /platforms/{platform_name}/[resource]s/
-    """
-
-    date_modified_after: datetime.date | None = Field(
-        Query(
-            description="Get only resources modified after this date (yyyy-mm-dd, inclusive).",
-            default=None,
-        )
-    )
-    date_modified_before: datetime.date | None = Field(
-        Query(
-            description="Get only resources modified before this date (yyyy-mm-dd, exclusive).",
-            default=None,
-        )
-    )
-
 
 RESOURCE = TypeVar("RESOURCE", bound=AbstractAIResource)
 RESOURCE_CREATE = TypeVar("RESOURCE_CREATE", bound=SQLModel)
@@ -280,8 +238,8 @@ class ResourceRouter(abc.ABC):
         """
 
         def get_resources(
-            pagination: Annotated[Pagination, Depends(Pagination)],
-            resource_filters: Annotated[ResourceFilters, Depends(ResourceFilters)],
+            pagination: PaginationParams,
+            resource_filters: ResourceFiltersParams,
             schema: self._possible_schemas_type = "aiod",  # type:ignore
             user: User | None = Depends(get_user_or_none),
         ):
@@ -350,8 +308,8 @@ class ResourceRouter(abc.ABC):
                     example="huggingface",
                 ),
             ],
-            pagination: Annotated[Pagination, Depends(Pagination)],
-            resource_filters: Annotated[ResourceFilters, Depends(ResourceFilters)],
+            pagination: PaginationParams,
+            resource_filters: ResourceFiltersParams,
             schema: self._possible_schemas_type = "aiod",  # type:ignore
             user: User | None = Depends(get_user_or_none),
         ):

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -17,6 +17,7 @@ from authentication import User, get_user_or_none, get_user_or_raise
 from config import KEYCLOAK_CONFIG
 from converters.schema_converters.schema_converter import SchemaConverter
 from database.model.ai_resource.resource import AbstractAIResource
+from database.model.concept.aiod_entry import AIoDEntryORM
 from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
@@ -41,9 +42,32 @@ class Pagination(BaseModel):
     # Refer to https://github.com/tiangolo/fastapi/issues/4700
     limit: int = Field(
         Query(
-            description="Specified the maximum number of resources that should be " "returned.",
+            description="Specified the maximum number of resources that should be returned.",
             default=10,
             le=1000,
+        )
+    )
+
+
+class ResourceFilters(BaseModel):
+    """
+    AIoD Resource filters
+
+    Filters are used in GET endpoints:
+    - GET /[resource]s/
+    - GET /platforms/{platform_name}/[resource]s/
+    """
+
+    date_modified_after: datetime.date | None = Field(
+        Query(
+            description="Get only resources modified after this date (yyyy-mm-dd, inclusive).",
+            default=None,
+        )
+    )
+    date_modified_before: datetime.date | None = Field(
+        Query(
+            description="Get only resources modified before this date (yyyy-mm-dd, exclusive).",
+            default=None,
         )
     )
 
@@ -208,6 +232,7 @@ class ResourceRouter(abc.ABC):
         self,
         schema: str,
         pagination: Pagination,
+        resource_filters: ResourceFilters,
         user: User | None = None,
         platform: str | None = None,
     ):
@@ -221,7 +246,7 @@ class ResourceRouter(abc.ABC):
                     else self.resource_class_read.from_orm
                 )
                 resources: Any = self._retrieve_resources_and_post_process(
-                    session, pagination, user, platform
+                    session, pagination, resource_filters, user, platform
                 )
                 return self._wrap_with_headers([convert_schema(resource) for resource in resources])
             except Exception as e:
@@ -254,12 +279,17 @@ class ResourceRouter(abc.ABC):
         """
 
         def get_resources(
-            pagination: Pagination = Depends(),
+            pagination: Annotated[Pagination, Depends(Pagination)],
+            resource_filters: Annotated[ResourceFilters, Depends(ResourceFilters)],
             schema: self._possible_schemas_type = "aiod",  # type:ignore
             user: User | None = Depends(get_user_or_none),
         ):
             resources = self.get_resources(
-                pagination=pagination, schema=schema, user=user, platform=None
+                schema=schema,
+                pagination=pagination,
+                resource_filters=resource_filters,
+                user=user,
+                platform=None,
             )
             return resources
 
@@ -320,11 +350,16 @@ class ResourceRouter(abc.ABC):
                 ),
             ],
             pagination: Annotated[Pagination, Depends(Pagination)],
+            resource_filters: Annotated[ResourceFilters, Depends(ResourceFilters)],
             schema: self._possible_schemas_type = "aiod",  # type:ignore
             user: User | None = Depends(get_user_or_none),
         ):
             resources = self.get_resources(
-                pagination=pagination, schema=schema, user=user, platform=platform
+                schema=schema,
+                pagination=pagination,
+                resource_filters=resource_filters,
+                user=user,
+                platform=platform,
             )
             return resources
 
@@ -550,18 +585,26 @@ class ResourceRouter(abc.ABC):
         self,
         session: Session,
         pagination: Pagination,
+        resource_filters: ResourceFilters,
         platform: str | None = None,
     ) -> Sequence[type[RESOURCE_MODEL]]:
         """
-        Retrieve a sequence of resources from the database based on the provided identifier
-        and platform (if applicable).
+        Retrieve a sequence of resources from the database based on the provided identifier,
+        platform and resource filters (if applicable).
         """
         where_clause = and_(
             is_(self.resource_class.date_deleted, None),
             (self.resource_class.platform == platform) if platform is not None else True,
+            AIoDEntryORM.date_modified >= resource_filters.date_modified_after
+            if resource_filters.date_modified_after is not None
+            else True,
+            AIoDEntryORM.date_modified < resource_filters.date_modified_before
+            if resource_filters.date_modified_before is not None
+            else True,
         )
         query = (
             select(self.resource_class)
+            .join(self.resource_class.aiod_entry)
             .where(where_clause)
             .offset(pagination.offset)
             .limit(pagination.limit)
@@ -589,6 +632,7 @@ class ResourceRouter(abc.ABC):
         self,
         session: Session,
         pagination: Pagination,
+        resource_filters: ResourceFilters,
         user: User | None = None,
         platform: str | None = None,
     ) -> Sequence[type[RESOURCE_MODEL]]:
@@ -598,7 +642,7 @@ class ResourceRouter(abc.ABC):
         implement further verification on user access to the resource.
         """
         resources: Sequence[type[RESOURCE_MODEL]] = self._retrieve_resources(
-            session, pagination, platform
+            session, pagination, resource_filters, platform
         )
         return self._mask_or_filter(resources, session, user)
 

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -84,6 +84,7 @@ class ResourceRouter(abc.ABC):
 
     It creates the basic endpoints for each resource:
     - GET /[resource]s/
+    - GET /counts/[resource]s/
     - GET /[resource]s/{identifier}
     - GET /platforms/{platform_name}/[resource]s/
     - GET /platforms/{platform_name}/[resource]s/{identifier}
@@ -604,7 +605,7 @@ class ResourceRouter(abc.ABC):
         )
         query = (
             select(self.resource_class)
-            .join(self.resource_class.aiod_entry)
+            .join(self.resource_class.aiod_entry, isouter=True)
             .where(where_clause)
             .offset(pagination.offset)
             .limit(pagination.limit)

--- a/src/routers/resource_routers/__init__.py
+++ b/src/routers/resource_routers/__init__.py
@@ -16,7 +16,7 @@ from .service_router import ServiceRouter
 from .team_router import TeamRouter
 from .. import ResourceRouter
 
-router_list: list[ResourceRouter] = [
+router_list: list[ResourceRouter | PlatformRouter] = [
     PlatformRouter(),
     CaseStudyRouter(),
     ComputationalAssetRouter(),

--- a/src/routers/resource_routers/platform_router.py
+++ b/src/routers/resource_routers/platform_router.py
@@ -59,7 +59,7 @@ class PlatformRouter:
 
         router.add_api_route(
             path=f"{url_prefix}/{self.resource_name_plural}/{version}",
-            endpoint=self.get_resources,
+            endpoint=self.get_resources_func(),
             response_model=response_model_plural,  # type: ignore
             name=f"List {self.resource_name_plural}",
             description=f"Retrieve all meta-data of the {self.resource_name_plural}.",
@@ -67,7 +67,7 @@ class PlatformRouter:
         )
         router.add_api_route(
             path=f"{url_prefix}/counts/{self.resource_name_plural}/{version}",
-            endpoint=self.get_resource_count,
+            endpoint=self.get_resource_count_func(),
             response_model=int | dict[str, int],
             name=f"Count of {self.resource_name_plural}",
             description=f"Retrieve the number of {self.resource_name_plural}.",
@@ -76,14 +76,14 @@ class PlatformRouter:
         router.add_api_route(
             path=f"{url_prefix}/{self.resource_name_plural}/{version}",
             methods={"POST"},
-            endpoint=self.register_resource,
+            endpoint=self.register_resource_func(),
             name=self.resource_name,
             description=f"Register a {self.resource_name} with AIoD.",
             **default_kwargs,
         )
         router.add_api_route(
             path=url_prefix + f"/{self.resource_name_plural}/{version}/{{identifier}}",
-            endpoint=self.get_resource,
+            endpoint=self.get_resource_func(),
             response_model=response_model,  # type: ignore
             name=self.resource_name,
             description=f"Retrieve all meta-data for a {self.resource_name} identified by the AIoD "
@@ -93,7 +93,7 @@ class PlatformRouter:
         router.add_api_route(
             path=f"{url_prefix}/{self.resource_name_plural}/{version}/{{identifier}}",
             methods={"PUT"},
-            endpoint=self.put_resource,
+            endpoint=self.put_resource_func(),
             name=self.resource_name,
             description=f"Update an existing {self.resource_name}.",
             **default_kwargs,
@@ -101,7 +101,7 @@ class PlatformRouter:
         router.add_api_route(
             path=f"{url_prefix}/{self.resource_name_plural}/{version}/{{identifier}}",
             methods={"DELETE"},
-            endpoint=self.delete_resource,
+            endpoint=self.delete_resource_func(),
             name=self.resource_name,
             description=f"Delete a {self.resource_name}.",
             **default_kwargs,
@@ -126,38 +126,73 @@ class PlatformRouter:
         except Exception as e:
             raise as_http_exception(e)
 
-    def get_resource_count(self):
-        """Get the total count of resources."""
-        try:
-            with DbSession() as session:
-                return session.query(self.resource_class).count()
+    def get_resources_func(self):
+        """
+        Return a function that can be used to retrieve a list of resources.
+        This function returns a function (instead of being that function directly) because the
+        docstring and the variables are dynamic, and used in Swagger.
+        """
 
-        except Exception as e:
-            raise as_http_exception(e)
+        return self.get_resources
 
-    def register_resource(
-        self,
-        resource_create: Platform,
-        user: User = Depends(get_user_or_raise),
-    ):
-        if not user.has_any_role(
-            KEYCLOAK_CONFIG.get("role"),
-            f"create_{self.resource_name_plural}",
-            f"crud_{self.resource_name_plural}",
+    def get_resource_count_func(self):
+        """
+        Gets the total number of resources from the database.
+        This function returns a function (instead of being that function directly) because the
+        docstring and the variables are dynamic, and used in Swagger.
+        """
+
+        def get_resource_count():
+            try:
+                with DbSession() as session:
+                    return session.query(self.resource_class).count()
+
+            except Exception as e:
+                raise as_http_exception(e)
+
+        return get_resource_count
+
+    def get_resource_func(self):
+        """
+        Return a function that can be used to retrieve a single resource.
+        This function returns a function (instead of being that function directly) because the
+        docstring and the variables are dynamic, and used in Swagger.
+        """
+
+        return self.get_resource
+
+    def register_resource_func(self):
+        """
+        Return a function that can be used to register a resource.
+        This function returns a function (instead of being that function directly) because the
+        docstring is dynamic and used in Swagger.
+        """
+        clz_create = self.resource_class_create
+
+        def register_resource(
+            resource_create: clz_create,  # type: ignore
+            user: User = Depends(get_user_or_raise),
         ):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"You do not have permission to create {self.resource_name_plural}.",
-            )
-        try:
-            with DbSession() as session:
-                try:
-                    resource = self.create_resource(session, resource_create)
-                    return {"identifier": resource.identifier}
-                except Exception as e:
-                    self._raise_clean_http_exception(e, session)
-        except Exception as e:
-            raise as_http_exception(e)
+            if not user.has_any_role(
+                KEYCLOAK_CONFIG.get("role"),
+                f"create_{self.resource_name_plural}",
+                f"crud_{self.resource_name_plural}",
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"You do not have permission to create {self.resource_name_plural}.",
+                )
+            try:
+                with DbSession() as session:
+                    try:
+                        resource = self.create_resource(session, resource_create)
+                        return {"identifier": resource.identifier}
+                    except Exception as e:
+                        self._raise_clean_http_exception(e, session)
+            except Exception as e:
+                raise as_http_exception(e)
+
+        return register_resource
 
     def create_resource(self, session: Session, resource_create_instance: SQLModel):
         """Store a resource in the database"""
@@ -169,64 +204,80 @@ class PlatformRouter:
         session.commit()
         return resource
 
-    def put_resource(
-        self,
-        identifier: int,
-        resource_create_instance: Platform,
-        user: User = Depends(get_user_or_raise),
-    ):
-        if not user.has_any_role(
-            KEYCLOAK_CONFIG.get("role"),
-            f"update_{self.resource_name_plural}",
-            f"crud_{self.resource_name_plural}",
+    def put_resource_func(self):
+        """
+        Return a function that can be used to update a resource.
+        This function returns a function (instead of being that function directly) because the
+        docstring is dynamic and used in Swagger.
+        """
+        clz_create = self.resource_class_create
+        def put_resource(
+            identifier: int,
+            resource_create_instance: clz_create,  # type: ignore
+            user: User = Depends(get_user_or_raise),
         ):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"You do not have permission to edit {self.resource_name_plural}.",
-            )
-
-        with DbSession() as session:
-            try:
-                resource: Any = self._retrieve_resource(session, identifier)
-                for attribute_name in resource.schema()["properties"]:
-                    if hasattr(resource_create_instance, attribute_name):
-                        new_value = getattr(resource_create_instance, attribute_name)
-                        setattr(resource, attribute_name, new_value)
-                deserialize_resource_relationships(
-                    session, self.resource_class, resource, resource_create_instance
-                )
-                try:
-                    session.merge(resource)
-                    session.commit()
-                except Exception as e:
-                    self._raise_clean_http_exception(e, session)
-                return None
-            except Exception as e:
-                raise self._raise_clean_http_exception(e, session)
-
-    def delete_resource(
-        self,
-        identifier: str,
-        user: User = Depends(get_user_or_raise),
-    ):
-        with DbSession() as session:
             if not user.has_any_role(
                 KEYCLOAK_CONFIG.get("role"),
-                f"delete_{self.resource_name_plural}",
+                f"update_{self.resource_name_plural}",
                 f"crud_{self.resource_name_plural}",
             ):
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail=f"You do not have permission to delete {self.resource_name_plural}.",
+                    detail=f"You do not have permission to edit {self.resource_name_plural}.",
                 )
-            try:
-                # Raise error if it does not exist
-                resource: Any = self._retrieve_resource(session, identifier)
-                session.delete(resource)
-                session.commit()
-                return None
-            except Exception as e:
-                raise as_http_exception(e)
+
+            with DbSession() as session:
+                try:
+                    resource: Any = self._retrieve_resource(session, identifier)
+                    for attribute_name in resource.schema()["properties"]:
+                        if hasattr(resource_create_instance, attribute_name):
+                            new_value = getattr(resource_create_instance, attribute_name)
+                            setattr(resource, attribute_name, new_value)
+                    deserialize_resource_relationships(
+                        session, self.resource_class, resource, resource_create_instance
+                    )
+                    try:
+                        session.merge(resource)
+                        session.commit()
+                    except Exception as e:
+                        self._raise_clean_http_exception(e, session)
+                    return None
+                except Exception as e:
+                    raise self._raise_clean_http_exception(e, session)
+
+        return put_resource
+
+    def delete_resource_func(self):
+        """
+        Return a function that can be used to delete a resource.
+        This function returns a function (instead of being that function directly) because the
+        docstring is dynamic and used in Swagger.
+        """
+
+        def delete_resource(
+            identifier: str,
+            user: User = Depends(get_user_or_raise),
+        ):
+            with DbSession() as session:
+                if not user.has_any_role(
+                    KEYCLOAK_CONFIG.get("role"),
+                    f"delete_{self.resource_name_plural}",
+                    f"crud_{self.resource_name_plural}",
+                ):
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail=f"You do not have permission to delete {self.resource_name_plural}.",
+                    )
+                try:
+                    # Raise error if it does not exist
+                    resource: Any = self._retrieve_resource(session, identifier)
+                    session.delete(resource)
+                    session.commit()
+                    return None
+                except Exception as e:
+                    raise as_http_exception(e)
+
+        return delete_resource
 
     def _retrieve_resource(
         self,

--- a/src/routers/resource_routers/platform_router.py
+++ b/src/routers/resource_routers/platform_router.py
@@ -1,8 +1,35 @@
+import traceback
+from typing import Any, Sequence
+
+from fastapi import Depends, HTTPException, status, APIRouter
+from sqlmodel import SQLModel, Session, select
+
+from authentication import User, get_user_or_raise
+from config import KEYCLOAK_CONFIG
 from database.model.platform.platform import Platform
-from routers.resource_router import ResourceRouter
+from database.model.resource_read_and_create import resource_create, resource_read
+from database.model.serializers import deserialize_resource_relationships
+from database.session import DbSession
+from error_handling import as_http_exception
 
 
-class PlatformRouter(ResourceRouter):
+class PlatformRouter:
+    """
+    Router class for FastAPI Platform router.
+
+    It creates the basic endpoints for Platform:
+    - GET /platforms/
+    - GET /counts/platforms/
+    - GET /platforms/{identifier}
+    - POST /platforms
+    - PUT /platforms/{identifier}
+    - DELETE /platforms/{identifier}
+    """
+
+    def __init__(self):
+        self.resource_class_create = resource_create(self.resource_class)
+        self.resource_class_read = resource_read(self.resource_class)
+
     @property
     def version(self) -> int:
         return 1
@@ -18,3 +45,241 @@ class PlatformRouter(ResourceRouter):
     @property
     def resource_class(self) -> type[Platform]:
         return Platform
+
+    def create(self, url_prefix: str) -> APIRouter:
+        router = APIRouter()
+        version = f"v{self.version}"
+        default_kwargs = {
+            "response_model_exclude_none": True,
+            "deprecated": False,
+            "tags": [self.resource_name_plural],
+        }
+        response_model = self.resource_class_read  # type:ignore
+        response_model_plural = list[self.resource_class_read]  # type:ignore
+
+        router.add_api_route(
+            path=f"{url_prefix}/{self.resource_name_plural}/{version}",
+            endpoint=self.get_resources,
+            response_model=response_model_plural,  # type: ignore
+            name=f"List {self.resource_name_plural}",
+            description=f"Retrieve all meta-data of the {self.resource_name_plural}.",
+            **default_kwargs,
+        )
+        router.add_api_route(
+            path=f"{url_prefix}/counts/{self.resource_name_plural}/{version}",
+            endpoint=self.get_resource_count,
+            response_model=int | dict[str, int],
+            name=f"Count of {self.resource_name_plural}",
+            description=f"Retrieve the number of {self.resource_name_plural}.",
+            **default_kwargs,
+        )
+        router.add_api_route(
+            path=f"{url_prefix}/{self.resource_name_plural}/{version}",
+            methods={"POST"},
+            endpoint=self.register_resource,
+            name=self.resource_name,
+            description=f"Register a {self.resource_name} with AIoD.",
+            **default_kwargs,
+        )
+        router.add_api_route(
+            path=url_prefix + f"/{self.resource_name_plural}/{version}/{{identifier}}",
+            endpoint=self.get_resource,
+            response_model=response_model,  # type: ignore
+            name=self.resource_name,
+            description=f"Retrieve all meta-data for a {self.resource_name} identified by the AIoD "
+            "identifier.",
+            **default_kwargs,
+        )
+        router.add_api_route(
+            path=f"{url_prefix}/{self.resource_name_plural}/{version}/{{identifier}}",
+            methods={"PUT"},
+            endpoint=self.put_resource,
+            name=self.resource_name,
+            description=f"Update an existing {self.resource_name}.",
+            **default_kwargs,
+        )
+        router.add_api_route(
+            path=f"{url_prefix}/{self.resource_name_plural}/{version}/{{identifier}}",
+            methods={"DELETE"},
+            endpoint=self.delete_resource,
+            name=self.resource_name,
+            description=f"Delete a {self.resource_name}.",
+            **default_kwargs,
+        )
+        return router
+
+    def get_resources(self):
+        """Fetch all resources."""
+        with DbSession(autoflush=False) as session:
+            try:
+                resources: Any = self._retrieve_resources(session)
+                return [self.resource_class_read.model_validate(resource) for resource in resources]
+            except Exception as e:
+                raise as_http_exception(e)
+
+    def get_resource(self, identifier: str):
+        """Get the resource identified by AIoD identifier."""
+        try:
+            with DbSession(autoflush=False) as session:
+                resource: Any = self._retrieve_resource(session, identifier)
+                return self.resource_class_read.model_validate(resource)
+        except Exception as e:
+            raise as_http_exception(e)
+
+    def get_resource_count(self):
+        """Get the total count of resources."""
+        try:
+            with DbSession() as session:
+                return session.query(self.resource_class).count()
+
+        except Exception as e:
+            raise as_http_exception(e)
+
+    def register_resource(
+        self,
+        resource_create: Platform,
+        user: User = Depends(get_user_or_raise),
+    ):
+        if not user.has_any_role(
+            KEYCLOAK_CONFIG.get("role"),
+            f"create_{self.resource_name_plural}",
+            f"crud_{self.resource_name_plural}",
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"You do not have permission to create {self.resource_name_plural}.",
+            )
+        try:
+            with DbSession() as session:
+                try:
+                    resource = self.create_resource(session, resource_create)
+                    return {"identifier": resource.identifier}
+                except Exception as e:
+                    self._raise_clean_http_exception(e, session)
+        except Exception as e:
+            raise as_http_exception(e)
+
+    def create_resource(self, session: Session, resource_create_instance: SQLModel):
+        """Store a resource in the database"""
+        resource = self.resource_class.model_validate(resource_create_instance)
+        deserialize_resource_relationships(
+            session, self.resource_class, resource, resource_create_instance
+        )
+        session.add(resource)
+        session.commit()
+        return resource
+
+    def put_resource(
+        self,
+        identifier: int,
+        resource_create_instance: Platform,
+        user: User = Depends(get_user_or_raise),
+    ):
+        if not user.has_any_role(
+            KEYCLOAK_CONFIG.get("role"),
+            f"update_{self.resource_name_plural}",
+            f"crud_{self.resource_name_plural}",
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"You do not have permission to edit {self.resource_name_plural}.",
+            )
+
+        with DbSession() as session:
+            try:
+                resource: Any = self._retrieve_resource(session, identifier)
+                for attribute_name in resource.schema()["properties"]:
+                    if hasattr(resource_create_instance, attribute_name):
+                        new_value = getattr(resource_create_instance, attribute_name)
+                        setattr(resource, attribute_name, new_value)
+                deserialize_resource_relationships(
+                    session, self.resource_class, resource, resource_create_instance
+                )
+                try:
+                    session.merge(resource)
+                    session.commit()
+                except Exception as e:
+                    self._raise_clean_http_exception(e, session)
+                return None
+            except Exception as e:
+                raise self._raise_clean_http_exception(e, session)
+
+    def delete_resource(
+        self,
+        identifier: str,
+        user: User = Depends(get_user_or_raise),
+    ):
+        with DbSession() as session:
+            if not user.has_any_role(
+                KEYCLOAK_CONFIG.get("role"),
+                f"delete_{self.resource_name_plural}",
+                f"crud_{self.resource_name_plural}",
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"You do not have permission to delete {self.resource_name_plural}.",
+                )
+            try:
+                # Raise error if it does not exist
+                resource: Any = self._retrieve_resource(session, identifier)
+                session.delete(resource)
+                session.commit()
+                return None
+            except Exception as e:
+                raise as_http_exception(e)
+
+    def _retrieve_resource(
+        self,
+        session: Session,
+        identifier: int | str,
+    ) -> Platform:
+        """Retrieve a resource from the database based on the provided identifier."""
+        query = select(self.resource_class).where(self.resource_class.identifier == identifier)
+
+        resource = session.scalars(query).first()
+        if not resource:
+            name = f"{self.resource_name.capitalize()} '{identifier}'"
+            msg = "not found in the database."
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"{name} {msg}")
+        return resource
+
+    def _retrieve_resources(
+        self,
+        session: Session,
+    ) -> Sequence[Platform]:
+        """
+        Retrieve a sequence of resources from the database based on the provided identifier.
+        """
+        query = select(self.resource_class)
+        resources: Sequence = session.scalars(query).all()
+        return resources
+
+    def _raise_clean_http_exception(self, e: Exception, session: Session):
+        """Raise an understandable exception based on this SQL IntegrityError."""
+        session.rollback()
+        if isinstance(e, HTTPException):
+            raise e
+        if len(e.args) == 0:
+            traceback.print_exc()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Unexpected exception while processing your request. Please "
+                "contact the maintainers.",
+            ) from e
+        error = e.args[0]
+        # Note that the "real" errors are different from testing errors, because we use a
+        # sqlite db while testing and a mysql db when running the application. The correct error
+        # handling is therefore not tested. TODO: can we improve this?
+        if ("UNIQUE" in error and "platform.name" in error) or (
+            "Duplicate entry" in error and "platform_name" in error
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"There already exists a {self.resource_name} with the same name.",
+            ) from e
+        if "constraint failed" in error:
+            error_msg = error.split("constraint failed: ")[-1]
+            status_code = status.HTTP_400_BAD_REQUEST
+        else:
+            raise e
+        raise HTTPException(status_code=status_code, detail=error_msg) from e

--- a/src/routers/resource_routers/platform_router.py
+++ b/src/routers/resource_routers/platform_router.py
@@ -211,6 +211,7 @@ class PlatformRouter:
         docstring is dynamic and used in Swagger.
         """
         clz_create = self.resource_class_create
+
         def put_resource(
             identifier: int,
             resource_create_instance: clz_create,  # type: ignore

--- a/src/routers/resource_routers/platform_router.py
+++ b/src/routers/resource_routers/platform_router.py
@@ -10,6 +10,7 @@ from database.model.platform.platform import Platform
 from database.model.resource_read_and_create import resource_create, resource_read
 from database.model.serializers import deserialize_resource_relationships
 from database.session import DbSession
+from dependencies.pagination import Pagination, PaginationParams
 from error_handling import as_http_exception
 
 
@@ -108,11 +109,11 @@ class PlatformRouter:
         )
         return router
 
-    def get_resources(self):
+    def get_resources(self, pagination: Pagination):
         """Fetch all resources."""
         with DbSession(autoflush=False) as session:
             try:
-                resources: Any = self._retrieve_resources(session)
+                resources: Any = self._retrieve_resources(session, pagination)
                 return [self.resource_class_read.model_validate(resource) for resource in resources]
             except Exception as e:
                 raise as_http_exception(e)
@@ -133,7 +134,11 @@ class PlatformRouter:
         docstring and the variables are dynamic, and used in Swagger.
         """
 
-        return self.get_resources
+        def get_resources(pagination: PaginationParams):
+            resources = self.get_resources(pagination=pagination)
+            return resources
+
+        return get_resources
 
     def get_resource_count_func(self):
         """
@@ -298,11 +303,12 @@ class PlatformRouter:
     def _retrieve_resources(
         self,
         session: Session,
+        pagination: Pagination,
     ) -> Sequence[Platform]:
         """
         Retrieve a sequence of resources from the database based on the provided identifier.
         """
-        query = select(self.resource_class)
+        query = select(self.resource_class).offset(pagination.offset).limit(pagination.limit)
         resources: Sequence = session.scalars(query).all()
         return resources
 

--- a/src/tests/routers/resource_routers/test_resource_router.py
+++ b/src/tests/routers/resource_routers/test_resource_router.py
@@ -32,6 +32,7 @@ from authentication import keycloak_openid
     [
         ({"date_modified_after": datetime.today().strftime("%Y-%m-%d")}, 1),
         ({"date_modified_before": datetime.today().strftime("%Y-%m-%d")}, 0),
+        ({"date_modified_after": (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d")}, 0),
         ({"date_modified_before": (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d")}, 1),
         (
             {
@@ -68,4 +69,5 @@ def test_happy_path_with_filters(
     assert response.status_code == 200, response.json()
 
     response_json = response.json()
-    assert isinstance(response_json, list) and len(response_json) == expected_count
+    assert isinstance(response_json, list)
+    assert len(response_json) == expected_count

--- a/src/tests/routers/resource_routers/test_resource_router.py
+++ b/src/tests/routers/resource_routers/test_resource_router.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+from starlette.testclient import TestClient
+
+from authentication import keycloak_openid
+
+
+@pytest.mark.parametrize(
+    "resource_type",
+    [
+        "case_studies",
+        "computational_assets",
+        "contacts",
+        "datasets",
+        "educational_resources",
+        "events",
+        "experiments",
+        "ml_models",
+        "news",
+        "organisations",
+        "persons",
+        "projects",
+        "publications",
+        "services",
+        "teams",
+    ],
+)
+@pytest.mark.parametrize(
+    "resource_filters,expected_count",
+    [
+        ({"date_modified_after": datetime.today().strftime("%Y-%m-%d")}, 1),
+        ({"date_modified_before": datetime.today().strftime("%Y-%m-%d")}, 0),
+        ({"date_modified_before": (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d")}, 1),
+        (
+            {
+                "date_modified_after": datetime.today().strftime("%Y-%m-%d"),
+                "date_modified_before": datetime.today().strftime("%Y-%m-%d"),
+            },
+            0,
+        ),
+        (
+            {
+                "date_modified_after": datetime.today().strftime("%Y-%m-%d"),
+                "date_modified_before": (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d"),
+            },
+            1,
+        ),
+    ],
+)
+def test_happy_path_with_filters(
+    client: TestClient,
+    mocked_privileged_token: Mock,
+    body_asset: dict,
+    resource_type,
+    resource_filters: dict,
+    expected_count: int,
+):
+    keycloak_openid.introspect = mocked_privileged_token
+
+    response = client.post(
+        f"/{resource_type}/v1", json=body_asset, headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == 200, response.json()
+
+    response = client.get(f"/{resource_type}/v1", params=resource_filters)
+    assert response.status_code == 200, response.json()
+
+    response_json = response.json()
+    assert isinstance(response_json, list) and len(response_json) == expected_count


### PR DESCRIPTION
* Adding resource filters based on `aiod_entry.date_modified`: `date_modified_after` and `date_modified_before`
* Making `AIoDEntryORM.date_modified` and `AIoDEntryORM.date_created` required as they are always created automatically using `default_factory`
* Create a separate `PlatformRouter` independent of `ResourceRouter`