### PR TITLE
Fix/hf

### DIFF
--- a/scripts/migrate_hf.py
+++ b/scripts/migrate_hf.py
@@ -6,6 +6,7 @@ a user changes their username or the dataset name. The `_id` field is persistent
 so can be used to avoid indexing the same dataset twice under a different platform identifier.
 """
 import logging
+import string
 from http import HTTPStatus
 
 from sqlalchemy import select
@@ -26,7 +27,11 @@ def main():
     with DbSession() as session:
         datasets_query = select(Dataset).where(Dataset.platform == PlatformName.huggingface)
         datasets = session.scalars(datasets_query).all()
+
         for dataset in datasets:
+            if all(c in string.hexdigits for c in dataset.id):
+                continue  # entry already updated to use new-style id
+
             response = requests.get(
                 f"https://huggingface.co/api/datasets/{dataset.name}",
                 params={"full": "False"},
@@ -38,19 +43,18 @@ def main():
                 continue
 
             dataset_json = response.json()
-            persistent_id = dataset_json["_id"]
-            if dataset.name != persistent_id:
+            if dataset.id != dataset_json["id"]:
                 logging.info(
-                    f"Dataset {dataset.name} moved to {dataset_json['id']}"
+                    f"Dataset {dataset.id} moved to {dataset_json['id']}"
                     "Deleting the old entry. The new entry either already exists or"
                     "will be added on a later synchronization invocation."
                 )
                 session.delete(dataset)
                 continue
 
-            logging.info(f"Setting id of {dataset.id} to {persistent_id}")
+            persistent_id = dataset_json["_id"]
+            logging.info(f"Setting platform id of {dataset.id} to {persistent_id}")
             dataset.platform_resource_identifier = persistent_id
-            session.add(dataset)
             break
         session.commit()
 

--- a/scripts/migrate_hf.py
+++ b/scripts/migrate_hf.py
@@ -1,0 +1,59 @@
+"""
+Updates the metadata of Hugging Face entries to use `_id` instead of `id` as platform identifier.
+
+The `id` field (i.e., `username/datasetname`, e.g., `pgijsbers/titanic`) is subject to change when
+a user changes their username or the dataset name. The `_id` field is persistent across these changes,
+so can be used to avoid indexing the same dataset twice under a different platform identifier.
+"""
+import logging
+from http import HTTPStatus
+
+from sqlalchemy import select
+from database.session import DbSession, EngineSingleton
+from database.model.dataset.dataset import Dataset
+from database.model.platform.platform import Platform
+from database.model.platform.platform_names import PlatformName
+from database.model.concept.concept import AIoDConcept
+
+# Magic import which triggers ORM setup
+import database.setup
+
+import requests
+
+
+def main():
+    AIoDConcept.metadata.create_all(EngineSingleton().engine, checkfirst=True)
+    with DbSession() as session:
+        datasets_query = select(Dataset).where(Dataset.platform == PlatformName.huggingface)
+        datasets = session.scalars(datasets_query).all()
+        for dataset in datasets:
+            response = requests.get(
+                f"https://huggingface.co/api/datasets/{dataset.name}",
+                params={"full": "False"},
+                headers={},
+                timeout=10,
+            )
+            if response.status_code != HTTPStatus.OK:
+                logging.warning(f"Dataset {dataset.name} could not be retrieved.")
+                continue
+
+            dataset_json = response.json()
+            persistent_id = dataset_json["_id"]
+            if dataset.name != persistent_id:
+                logging.info(
+                    f"Dataset {dataset.name} moved to {dataset_json['id']}"
+                    "Deleting the old entry. The new entry either already exists or"
+                    "will be added on a later synchronization invocation."
+                )
+                session.delete(dataset)
+                continue
+
+            logging.info(f"Setting id of {dataset.id} to {persistent_id}")
+            dataset.platform_resource_identifier = persistent_id
+            session.add(dataset)
+            break
+        session.commit()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_hf.py
+++ b/scripts/migrate_hf.py
@@ -4,6 +4,8 @@ Updates the metadata of Hugging Face entries to use `_id` instead of `id` as pla
 The `id` field (i.e., `username/datasetname`, e.g., `pgijsbers/titanic`) is subject to change when
 a user changes their username or the dataset name. The `_id` field is persistent across these changes,
 so can be used to avoid indexing the same dataset twice under a different platform identifier.
+
+To be run once (around sometime Nov 2024), likely not needed after that. See also #385, 392.
 """
 import logging
 import string

--- a/scripts/migrate_hf.py
+++ b/scripts/migrate_hf.py
@@ -53,7 +53,9 @@ def main():
                 continue
 
             persistent_id = dataset_json["_id"]
-            logging.info(f"Setting platform id of {dataset.platform_resource_identifier} to {persistent_id}")
+            logging.info(
+                f"Setting platform id of {dataset.platform_resource_identifier} to {persistent_id}"
+            )
             dataset.platform_resource_identifier = persistent_id
         session.commit()
 

--- a/scripts/migrate_hf.py
+++ b/scripts/migrate_hf.py
@@ -29,7 +29,7 @@ def main():
         datasets = session.scalars(datasets_query).all()
 
         for dataset in datasets:
-            if all(c in string.hexdigits for c in dataset.id):
+            if all(c in string.hexdigits for c in dataset.platform_resource_identifier):
                 continue  # entry already updated to use new-style id
 
             response = requests.get(
@@ -43,9 +43,9 @@ def main():
                 continue
 
             dataset_json = response.json()
-            if dataset.id != dataset_json["id"]:
+            if dataset.platform_resource_identifier != dataset_json["id"]:
                 logging.info(
-                    f"Dataset {dataset.id} moved to {dataset_json['id']}"
+                    f"Dataset {dataset.platform_resource_identifier} moved to {dataset_json['id']}"
                     "Deleting the old entry. The new entry either already exists or"
                     "will be added on a later synchronization invocation."
                 )
@@ -53,9 +53,8 @@ def main():
                 continue
 
             persistent_id = dataset_json["_id"]
-            logging.info(f"Setting platform id of {dataset.id} to {persistent_id}")
+            logging.info(f"Setting platform id of {dataset.platform_resource_identifier} to {persistent_id}")
             dataset.platform_resource_identifier = persistent_id
-            break
         session.commit()
 
 

--- a/src/connectors/huggingface/huggingface_dataset_connector.py
+++ b/src/connectors/huggingface/huggingface_dataset_connector.py
@@ -59,6 +59,7 @@ class HuggingFaceDatasetConnector(ResourceConnectorOnStartUp[Dataset]):
                     dataset, pydantic_class, pydantic_class_publication, pydantic_class_contact
                 )
             except Exception as e:
+                # We use the normal id here since it is more informative and can be used to visit hf
                 yield RecordError(identifier=dataset.id, error=e)
 
     def fetch_dataset(
@@ -119,7 +120,7 @@ class HuggingFaceDatasetConnector(ResourceConnectorOnStartUp[Dataset]):
         return ResourceWithRelations[pydantic_class](  # type:ignore
             resource=pydantic_class(
                 aiod_entry=AIoDEntryCreate(status="published"),
-                platform_resource_identifier=dataset.id,
+                platform_resource_identifier=dataset._id,
                 platform=self.platform_name,
                 name=dataset.id,
                 same_as=f"https://huggingface.co/datasets/{dataset.id}",

--- a/src/connectors/huggingface/huggingface_dataset_connector.py
+++ b/src/connectors/huggingface/huggingface_dataset_connector.py
@@ -120,7 +120,7 @@ class HuggingFaceDatasetConnector(ResourceConnectorOnStartUp[Dataset]):
         return ResourceWithRelations[pydantic_class](  # type:ignore
             resource=pydantic_class(
                 aiod_entry=AIoDEntryCreate(status="published"),
-                platform_resource_identifier=dataset._id,
+                platform_resource_identifier=dataset._id,  # see #385, 392
                 platform=self.platform_name,
                 name=dataset.id,
                 same_as=f"https://huggingface.co/datasets/{dataset.id}",

--- a/src/database/deletion/triggers.py
+++ b/src/database/deletion/triggers.py
@@ -7,17 +7,21 @@ tables are referenced by multiple tables. See src/README.md for additional infor
 
 from typing import Type
 
-from sqlalchemy import DDL, event
+from sqlalchemy import DDL
 from sqlmodel import SQLModel
 
 from database.model.helper_functions import get_relationships, non_abstract_subclasses
 
 
-def add_delete_triggers(parent_class: Type[SQLModel]):
+def create_delete_triggers(parent_class: Type[SQLModel]):
     classes: list[Type[SQLModel]] = non_abstract_subclasses(parent_class)
+    triggers = []
     for cls in classes:
         for name, value in get_relationships(cls).items():
-            value.create_triggers(cls, name)
+            trigger = value.create_triggers(cls, name)
+            if trigger is not None:
+                triggers.append(trigger)
+    return triggers
 
 
 def create_deletion_trigger_one_to_one(
@@ -49,7 +53,7 @@ def create_deletion_trigger_one_to_one(
     trigger_name = trigger.__tablename__
     delete_name = to_delete.__tablename__
 
-    ddl = DDL(
+    return DDL(
         f"""
         CREATE TRIGGER IF NOT EXISTS delete_{trigger_name}_{trigger_identifier_link}_{delete_name}
         AFTER DELETE ON {trigger_name}
@@ -60,7 +64,6 @@ def create_deletion_trigger_one_to_one(
         END;
         """  # noqa: S608  # never user input
     )
-    event.listen(trigger.__table__, "after_create", ddl)
 
 
 def create_deletion_trigger_many_to_one(
@@ -84,7 +87,7 @@ def create_deletion_trigger_many_to_one(
     trigger_name = trigger.__tablename__
     delete_name = to_delete.__tablename__
 
-    ddl = DDL(
+    return DDL(
         f"""
         CREATE TRIGGER IF NOT EXISTS delete_{trigger_name}_{delete_name}
         AFTER DELETE ON {trigger_name}
@@ -99,7 +102,6 @@ def create_deletion_trigger_many_to_one(
         END;
         """  # noqa: S608  # never user input
     )
-    event.listen(trigger.__table__, "after_create", ddl)
 
 
 def create_deletion_trigger_many_to_many(
@@ -142,7 +144,7 @@ def create_deletion_trigger_many_to_many(
         """  # noqa: S608  # never user input
         for link_name in link_names
     )
-    ddl = DDL(
+    return DDL(
         f"""
         CREATE TRIGGER IF NOT EXISTS delete_{link_name}
         AFTER DELETE ON {trigger_name}
@@ -155,4 +157,3 @@ def create_deletion_trigger_many_to_many(
         END;
         """  # noqa: S608  # never user input
     )
-    event.listen(trigger.__table__, "after_create", ddl)

--- a/src/database/deletion/triggers.py
+++ b/src/database/deletion/triggers.py
@@ -51,7 +51,7 @@ def create_deletion_trigger_one_to_one(
 
     ddl = DDL(
         f"""
-        CREATE TRIGGER delete_{trigger_name}_{trigger_identifier_link}_{delete_name}
+        CREATE TRIGGER IF NOT EXISTS delete_{trigger_name}_{trigger_identifier_link}_{delete_name}
         AFTER DELETE ON {trigger_name}
         FOR EACH ROW
         BEGIN
@@ -60,7 +60,7 @@ def create_deletion_trigger_one_to_one(
         END;
         """  # noqa: S608  # never user input
     )
-    event.listen(trigger.metadata, "after_create", ddl)
+    event.listen(trigger.__table__, "after_create", ddl)
 
 
 def create_deletion_trigger_many_to_one(
@@ -86,7 +86,7 @@ def create_deletion_trigger_many_to_one(
 
     ddl = DDL(
         f"""
-        CREATE TRIGGER delete_{trigger_name}_{delete_name}
+        CREATE TRIGGER IF NOT EXISTS delete_{trigger_name}_{delete_name}
         AFTER DELETE ON {trigger_name}
         FOR EACH ROW
         BEGIN
@@ -99,7 +99,7 @@ def create_deletion_trigger_many_to_one(
         END;
         """  # noqa: S608  # never user input
     )
-    event.listen(trigger.metadata, "after_create", ddl)
+    event.listen(trigger.__table__, "after_create", ddl)
 
 
 def create_deletion_trigger_many_to_many(
@@ -144,7 +144,7 @@ def create_deletion_trigger_many_to_many(
     )
     ddl = DDL(
         f"""
-        CREATE TRIGGER delete_{link_name}
+        CREATE TRIGGER IF NOT EXISTS delete_{link_name}
         AFTER DELETE ON {trigger_name}
         FOR EACH ROW
         BEGIN
@@ -155,4 +155,4 @@ def create_deletion_trigger_many_to_many(
         END;
         """  # noqa: S608  # never user input
     )
-    event.listen(trigger.metadata, "after_create", ddl)
+    event.listen(trigger.__table__, "after_create", ddl)

--- a/src/database/model/relationships.py
+++ b/src/database/model/relationships.py
@@ -146,7 +146,7 @@ class OneToOne(_ResourceRelationshipSingle):
                     "The deletion trigger is configured wrongly: the field doesn't "
                     f"point to a SQLModel class: {parent_class} . {field_name}"
                 )
-            triggers.create_deletion_trigger_one_to_one(
+            return triggers.create_deletion_trigger_one_to_one(
                 trigger=parent_class,
                 trigger_identifier_link=self.on_delete_trigger_deletion_by,
                 to_delete=to_delete,
@@ -170,7 +170,7 @@ class ManyToOne(_ResourceRelationshipSingle):
             to_delete_identifier = getattr(
                 parent_class.RelationshipConfig, field_name
             ).identifier_name
-            triggers.create_deletion_trigger_many_to_one(
+            return triggers.create_deletion_trigger_many_to_one(
                 trigger=parent_class,
                 to_delete=self.on_delete_trigger_deletion_of_orphan,
                 trigger_identifier_link=to_delete_identifier,
@@ -216,6 +216,6 @@ class ManyToMany(_ResourceRelationshipList):
                 )
 
             other_links = self.on_delete_trigger_orphan_deletion()
-            triggers.create_deletion_trigger_many_to_many(
+            return triggers.create_deletion_trigger_many_to_many(
                 trigger=parent_class, link=link, to_delete=to_delete, other_links=other_links
             )

--- a/src/main.py
+++ b/src/main.py
@@ -132,17 +132,13 @@ def create_app() -> FastAPI:
 
         drop_database = args.build_db == "drop-then-build"
         create_database(delete_first=drop_database)
+        add_delete_triggers(AIoDConcept)
         AIoDConcept.metadata.create_all(EngineSingleton().engine, checkfirst=True)
         with DbSession() as session:
             existing_platforms = session.scalars(select(Platform)).all()
             if not any(existing_platforms):
                 session.add_all([Platform(name=name) for name in PlatformName])
                 session.commit()
-
-                # this is a bit of a hack: instead of checking whether the triggers exist, we check
-                # whether platforms are already present. If platforms were not present, the db is
-                # empty, and so the triggers should still be added.
-                add_delete_triggers(AIoDConcept)
 
     add_routes(app, url_prefix=args.url_prefix)
     return app

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,7 @@ from sqlmodel import select
 
 from authentication import get_user_or_raise, User
 from config import KEYCLOAK_CONFIG
-from database.deletion.triggers import add_delete_triggers
+from database.deletion.triggers import create_delete_triggers
 from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
@@ -132,9 +132,11 @@ def create_app() -> FastAPI:
 
         drop_database = args.build_db == "drop-then-build"
         create_database(delete_first=drop_database)
-        add_delete_triggers(AIoDConcept)
         AIoDConcept.metadata.create_all(EngineSingleton().engine, checkfirst=True)
         with DbSession() as session:
+            triggers = create_delete_triggers(AIoDConcept)
+            for trigger in triggers:
+                session.execute(trigger)
             existing_platforms = session.scalars(select(Platform)).all()
             if not any(existing_platforms):
                 session.add_all([Platform(name=name) for name in PlatformName])


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
This PR encompasses two changes: 
  - Update the trigger creation logic, so that the triggers actually get created.
  - Register huggingface datasets under their private identifier, instead of the public one which is subject to change (#385)

To accommodate the last change, there is also a script `migrate_hf.py` which checks huggingface datasets already present in the database and 1. removes them if their identifier is no longer valid and 2. updates their identifiers otherwise.

## How to Test
<!-- Describe a way to test the change of this PR -->

### Setting up an old database and verifying the wrong behavior
A bit of a doozy with so much going on. First, let's create a version of an "old" style database:

```
docker compose --profile "*" down
git checkout develop
./scripts/clean.sh
docker compose --env-file=.env --env-file=override.env --profile "huggingface-datasets" up -d
```
That will start populating the `develop` database with huggingface entries, old-style.
Keep track of progress with
```
docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "select platform_resource_identifier, name from dataset where name in ('fka/awesome-chatgpt-prompts', 'PleIAs/common_corpus');"
docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "select COUNT(*) from dataset; select COUNT(*) from ai_asset; select count(*) from ai_resource;"
```
and make sure some (>10) datasets are uploaded, and the first query shows both the `fka/awesome-chatgpt-prompts` and `PleIAs/common_corpus` datasets, since we will use them later.
Also note that no AIoD triggers are created:
```
docker exec -it sqlserver mysql -uroot -pok --database=information_schema -e 'select TRIGGER_NAME from TRIGGERS;'
```
Let's stop harvesting (assuming you have enough datasets):
```
docker container stop huggingface-dataset-connector
```
To really make sure no triggers happen, let's delete a dataset. Because the trigger listens for hard-deletes, and datasets are deleted "softly" by default, we briefly need to disable this behavior.  Change the expression in 
[this`if` statement](https://github.com/aiondemand/AIOD-rest-api/blob/f784e9b1536cbce76098c0d2d631c444f964b7f5/src/routers/resource_router.py#L489) to always be `True`.
Then visit localhost, log in with the test user, and delete a dataset (pick any identifier >=10 to avoid deleting one of the two datasets we need later). The dataset will be deleted successfully, but their relations remain:
```
docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "select COUNT(*) from dataset; select COUNT(*) from ai_asset; select count(*) from ai_resource;"
```
Undo your change you made to the resource connector:
```
git checkout .
```
and shut down the services:
```
docker compose --profile "*" down
```

### Verifying new behavior
Start the services again on the new branch (this may take a little longer):
```
git checkout fix/hf-id
docker compose --env-file=.env --env-file=override.env up -d 
```
verify no data has changed, but delete triggers have been added:
```
docker exec -it sqlserver mysql -uroot -pok --database=information_schema -e 'select TRIGGER_NAME from TRIGGERS;'
docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "select COUNT(*) from dataset; select COUNT(*) from ai_asset; select count(*) from ai_resource;"  
```
(since the database cannot retroactively use the trigger, there will remain one fewer dataset than ai asset)

Now we modify some data to simulate the situation where a HF user has changed their account name (see also #385):
```
docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "update dataset set platform_resource_identifier='NaiveDev/coco-2017-instance', name='NaiveDev/coco-2017-instance' where platform_resource_identifier='fka/awesome-chatgpt-prompts';
update dataset set platform_resource_identifier='aha-org/coco-2017-instance', name='aha-org/coco-2017-instance' where platform_resource_identifier='PleIAs/common_corpus';"
```
The user `aha-org` changed their name to `NaiveDev`, and so we now modify two dataset entries to simulate being an old and new version of the indexed data. This is the behavior the HF connector would have if encountered a renamed dataset, since uniqueness is only enforced with `user/dataset`.
Let's run our migration script:
```
docker run -it -v $(pwd):/all --network='AIOD-rest-api_default' --entrypoint=/bin/bash aiod_metadata_catalogue -c 'python /all/scripts/migrate_hf.py'
```
and let's verify that our HF entries are updated accordingly:
```
docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "select platform_resource_identifier, name from dataset where name in ('aha-org/coco-2017-instance', 'NaiveDev/coco-2017-instance');"
docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "select platform_resource_identifier, name from dataset; select COUNT(*) from dataset;"
```
We see the `aha-org` dataset was removed, along with its linked resources, and the `NaiveDev` had assigned their new id correctly. Moreover, the related ai resource and ai asset entry that related to the `aha-org` dataset are also deleted through their triggers. Poke around in the database some more to check everything is OK, if needed.
Now let's spin up the HF connector:
```
docker compose --env-file=.env --env-file=override.env --profile "huggingface-datasets" up -d
```
and after a while verify that new entries have the correct `platform_resource_identifier` associated (i.e. a hex string).

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


