### PR TITLE
Add `source` field to `News` asset

### DIFF
--- a/alembic/alembic/versions/d09ed8ad4533_add_news_source.py
+++ b/alembic/alembic/versions/d09ed8ad4533_add_news_source.py
@@ -1,0 +1,31 @@
+"""Add news.source
+
+Revision ID: d09ed8ad4533
+Revises: 0f2fe1324047
+Create Date: 2024-11-21 09:36:49.556254
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import Column, String
+
+from database.model.field_length import LONG
+
+# revision identifiers, used by Alembic.
+revision: str = "d09ed8ad4533"
+down_revision: Union[str, None] = "0f2fe1324047"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        table_name="news",
+        column=Column("source", String(LONG)),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(table_name="news", column_name="source")

--- a/alembic/alembic/versions/d09ed8ad4533_add_news_source.py
+++ b/alembic/alembic/versions/d09ed8ad4533_add_news_source.py
@@ -23,7 +23,7 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.add_column(
         table_name="news",
-        column=Column("source", String(LONG)),
+        column=Column("source", String(LONG), nullable=True),
     )
 
 

--- a/src/database/model/news/news.py
+++ b/src/database/model/news/news.py
@@ -4,7 +4,7 @@ from sqlmodel import Field, Relationship
 
 from database.model.ai_resource.resource import AbstractAIResource, AIResourceBase
 from database.model.ai_resource.text import TextORM, Text
-from database.model.field_length import NORMAL
+from database.model.field_length import NORMAL, LONG
 from database.model.helper_functions import many_to_many_link_factory
 from database.model.news.news_category import NewsCategory
 from database.model.relationships import ManyToMany, OneToOne
@@ -25,6 +25,13 @@ class NewsBase(AIResourceBase):
         description="An alternative headline given to this news item.",
         max_length=NORMAL,
         schema_extra={"example": "An alternative headline."},
+    )
+    source: str | None = Field(
+        description="Location where the news item was originally published.",
+        max_length=LONG,
+        schema_extra={
+            "example": "https://tailor-network.eu/shaping-the-future-of-ai-within-the-eu/"
+        },
     )
 
 

--- a/src/tests/routers/resource_routers/test_router_news.py
+++ b/src/tests/routers/resource_routers/test_router_news.py
@@ -14,6 +14,7 @@ def test_happy_path(
     body["alternative_headline"] = "An alternative headline."
     body["category"] = ["research: education", "research: awards", "business: health"]
     body["content"] = {"plain": "plain content"}
+    body["source"] = "https://tailor-network.eu/shaping-the-future-of-ai-within-the-eu/"
 
     response = client.post("/news/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
@@ -24,6 +25,10 @@ def test_happy_path(
     response_json = response.json()
     assert response_json["headline"] == "A headline to show on top of the page."
     assert response_json["alternative_headline"] == "An alternative headline."
+    assert (
+        response_json["source"]
+        == "https://tailor-network.eu/shaping-the-future-of-ai-within-the-eu/"
+    )
     assert set(response_json["category"]) == {
         "research: education",
         "research: awards",


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
Add the `source` attribute to the News item.

## How to Test
<!-- Describe a way to test the change of this PR -->
The unit test is updated. Manual tests can be performed with the REST API.
First, make sure you have a database that's up-to-date with develop (for example, by `clean.sh`ing the data directory, and `up`ing the REST API). Upload a news item. Check out this feature branch, apply the migration, and test with the REST API (can you now add a source to the old item? create a new item with a source?).

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


