### PR TITLE
Improve hf migration

### DIFF
--- a/scripts/migrate_hf.py
+++ b/scripts/migrate_hf.py
@@ -11,6 +11,7 @@ import logging
 import string
 from http import HTTPStatus
 import time
+from pathlib import Path
 
 from sqlalchemy import select
 from database.session import DbSession, EngineSingleton
@@ -23,11 +24,59 @@ from database.model.concept.concept import AIoDConcept
 import database.setup
 
 import requests
+import json
+
+import re
+from http import HTTPStatus
+
+
+def fetch_huggingface_metadata() -> list[dict]:
+    next_url ="https://huggingface.co/api/datasets"
+    datasets = []
+    while next_url:
+        logging.info(f"Counted {len(datasets)} so far.")
+        response = requests.get(
+            next_url,
+            params={"limit": 1000, "full": "False"},
+            headers={"Authorization":"Bearer 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"},
+        )
+        if response.status_code != HTTPStatus.OK:
+            logging.info("Stopping iteration", response.status_code, response.json())
+            break
+
+        datasets.extend(response.json())
+
+        next_info = response.headers.get('Link', '')
+        if next_url_match := re.search(r"<([^>]+)>", next_info):
+            next_url = next_url_match.group()[1:-1]
+        else:
+            next_url = None
+    return datasets
+
+
+def load_id_map():
+    HF_DATA_FILE = Path(__file__).parent / "hf_metadata.json"
+    if HF_DATA_FILE.exists():
+        logging.info(f"Loading HF data from {HF_DATA_FILE}.")
+        with open(HF_DATA_FILE, 'r') as fh:
+            hf_data = json.load(fh)
+    else:
+        logging.info("Fetching HF data from Hugging Face.")
+        hf_data = fetch_huggingface_metadata()
+        with open(HF_DATA_FILE, 'w') as fh:
+            json.dump(hf_data, fh)
+    id_map = {
+        data["id"]: data["_id"]
+        for data in hf_data
+    }
+    return id_map
 
 
 def main():
     logging.basicConfig(level=logging.INFO)
     AIoDConcept.metadata.create_all(EngineSingleton().engine, checkfirst=True)
+    id_map = load_id_map()
+
     with DbSession() as session:
         datasets_query = select(Dataset).where(Dataset.platform == PlatformName.huggingface)
         datasets = session.scalars(datasets_query).all()
@@ -40,59 +89,17 @@ def main():
     ]
     logging.info(f"Found {len(datasets)} huggingface datasets that need an update.")
 
-    for i, dataset in enumerate(datasets):
-        try:
-            response = requests.get(
-                f"https://huggingface.co/api/datasets/{dataset.name}",
-                params={"full": "False"},
-                headers={},
-                timeout=10,
-            )
-        except Exception as e:
-            logging.warning(f"Error retrieving dataset {dataset.name}: {e}")
-            continue
-
-        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-            logging.info(
-                f"Did not update dataset {dataset.name} as rate limit was exceeded."
-                "Rerun the script at a later time to correct this dataset's identifier."
-            )
-            # I can't find information on the dataset API fetch rate limits, this is for safety.
-            time.sleep(60)
-            continue
-
-        if response.status_code != HTTPStatus.OK:
-            logging.warning(
-                f"Dataset {dataset.name} could not be retrieved."
-                "This is almost always an indication that the dataset is removed, "
-                "so we are removing it from the index."
-            )
-            with DbSession() as session:
+    with DbSession() as session:
+        for dataset in datasets:
+            if new_id := id_map.get(dataset.platform_resource_identifier):
+                dataset.platform_resource_identifier = new_id
+                session.add(dataset)
+            else:
                 session.delete(dataset)
-            continue
+        session.commit()
+    logging.info("Done updating entries.")
 
-        dataset_json = response.json()
-        if dataset.platform_resource_identifier != dataset_json["id"]:
-            logging.info(
-                f"Dataset {dataset.platform_resource_identifier} moved to {dataset_json['id']}"
-                "Deleting the old entry. The new entry either already exists or"
-                "will be added on a later synchronization invocation."
-            )
-            with DbSession() as session:
-                session.delete(dataset)
-            continue
 
-        persistent_id = dataset_json["_id"]
-        logging.info(
-            f"Setting platform id of {dataset.platform_resource_identifier} to {persistent_id}"
-        )
-        dataset.platform_resource_identifier = persistent_id
-        with DbSession() as session:
-            session.add(dataset)
-            session.commit()
-
-        if i % 1000 == 0:
-            logging.info(f"Processed {i} of {len(datasets)} entries")
 
 
 if __name__ == "__main__":

--- a/scripts/migrate_hf.py
+++ b/scripts/migrate_hf.py
@@ -31,14 +31,15 @@ from http import HTTPStatus
 
 
 def fetch_huggingface_metadata() -> list[dict]:
-    next_url ="https://huggingface.co/api/datasets"
+    next_url = "https://huggingface.co/api/datasets"
     datasets = []
     while next_url:
         logging.info(f"Counted {len(datasets)} so far.")
         response = requests.get(
             next_url,
             params={"limit": 1000, "full": "False"},
-            headers={"Authorization":"Bearer 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"},
+            headers={"Authorization": "Bearer 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"},
+            timeout=20,
         )
         if response.status_code != HTTPStatus.OK:
             logging.info("Stopping iteration", response.status_code, response.json())
@@ -46,7 +47,7 @@ def fetch_huggingface_metadata() -> list[dict]:
 
         datasets.extend(response.json())
 
-        next_info = response.headers.get('Link', '')
+        next_info = response.headers.get("Link", "")
         if next_url_match := re.search(r"<([^>]+)>", next_info):
             next_url = next_url_match.group()[1:-1]
         else:
@@ -58,17 +59,14 @@ def load_id_map():
     HF_DATA_FILE = Path(__file__).parent / "hf_metadata.json"
     if HF_DATA_FILE.exists():
         logging.info(f"Loading HF data from {HF_DATA_FILE}.")
-        with open(HF_DATA_FILE, 'r') as fh:
+        with open(HF_DATA_FILE, "r") as fh:
             hf_data = json.load(fh)
     else:
         logging.info("Fetching HF data from Hugging Face.")
         hf_data = fetch_huggingface_metadata()
-        with open(HF_DATA_FILE, 'w') as fh:
+        with open(HF_DATA_FILE, "w") as fh:
             json.dump(hf_data, fh)
-    id_map = {
-        data["id"]: data["_id"]
-        for data in hf_data
-    }
+    id_map = {data["id"]: data["_id"] for data in hf_data}
     return id_map
 
 
@@ -82,9 +80,12 @@ def main():
         datasets = session.scalars(datasets_query).all()
 
     logging.info(f"Found {len(datasets)} huggingface datasets.")
-    is_old_style_identifier = lambda identifier: any(char not in string.hexdigits for char in identifier)
+    is_old_style_identifier = lambda identifier: any(
+        char not in string.hexdigits for char in identifier
+    )
     datasets = [
-        dataset for dataset in datasets
+        dataset
+        for dataset in datasets
         if is_old_style_identifier(dataset.platform_resource_identifier)
     ]
     logging.info(f"Found {len(datasets)} huggingface datasets that need an update.")
@@ -98,8 +99,6 @@ def main():
                 session.delete(dataset)
         session.commit()
     logging.info("Done updating entries.")
-
-
 
 
 if __name__ == "__main__":

--- a/scripts/migrate_hf.py
+++ b/scripts/migrate_hf.py
@@ -8,6 +8,7 @@ so can be used to avoid indexing the same dataset twice under a different platfo
 To be run once (around sometime Nov 2024), likely not needed after that. See also #385, 392.
 """
 import logging
+import os
 import string
 from http import HTTPStatus
 import time
@@ -35,10 +36,14 @@ def fetch_huggingface_metadata() -> list[dict]:
     datasets = []
     while next_url:
         logging.info(f"Counted {len(datasets)} so far.")
+        if token := os.environ.get("HUGGINGFACE_TOKEN"):
+            headers = {"Authorization": f"Bearer {token}"}
+        else:
+            headers = {}
         response = requests.get(
             next_url,
             params={"limit": 1000, "full": "False"},
-            headers={"Authorization": "Bearer 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"},
+            headers=headers,
             timeout=20,
         )
         if response.status_code != HTTPStatus.OK:

--- a/scripts/migrate_hf.py
+++ b/scripts/migrate_hf.py
@@ -10,6 +10,7 @@ To be run once (around sometime Nov 2024), likely not needed after that. See als
 import logging
 import string
 from http import HTTPStatus
+import time
 
 from sqlalchemy import select
 from database.session import DbSession, EngineSingleton
@@ -25,41 +26,73 @@ import requests
 
 
 def main():
+    logging.basicConfig(level=logging.INFO)
     AIoDConcept.metadata.create_all(EngineSingleton().engine, checkfirst=True)
     with DbSession() as session:
         datasets_query = select(Dataset).where(Dataset.platform == PlatformName.huggingface)
         datasets = session.scalars(datasets_query).all()
 
-        for dataset in datasets:
-            if all(c in string.hexdigits for c in dataset.platform_resource_identifier):
-                continue  # entry already updated to use new-style id
+    logging.info(f"Found {len(datasets)} huggingface datasets.")
+    is_old_style_identifier = lambda identifier: any(char not in string.hexdigits for char in identifier)
+    datasets = [
+        dataset for dataset in datasets
+        if is_old_style_identifier(dataset.platform_resource_identifier)
+    ]
+    logging.info(f"Found {len(datasets)} huggingface datasets that need an update.")
 
+    for i, dataset in enumerate(datasets):
+        try:
             response = requests.get(
                 f"https://huggingface.co/api/datasets/{dataset.name}",
                 params={"full": "False"},
                 headers={},
                 timeout=10,
             )
-            if response.status_code != HTTPStatus.OK:
-                logging.warning(f"Dataset {dataset.name} could not be retrieved.")
-                continue
+        except Exception as e:
+            logging.warning(f"Error retrieving dataset {dataset.name}: {e}")
+            continue
 
-            dataset_json = response.json()
-            if dataset.platform_resource_identifier != dataset_json["id"]:
-                logging.info(
-                    f"Dataset {dataset.platform_resource_identifier} moved to {dataset_json['id']}"
-                    "Deleting the old entry. The new entry either already exists or"
-                    "will be added on a later synchronization invocation."
-                )
-                session.delete(dataset)
-                continue
-
-            persistent_id = dataset_json["_id"]
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
             logging.info(
-                f"Setting platform id of {dataset.platform_resource_identifier} to {persistent_id}"
+                f"Did not update dataset {dataset.name} as rate limit was exceeded."
+                "Rerun the script at a later time to correct this dataset's identifier."
             )
-            dataset.platform_resource_identifier = persistent_id
-        session.commit()
+            # I can't find information on the dataset API fetch rate limits, this is for safety.
+            time.sleep(60)
+            continue
+
+        if response.status_code != HTTPStatus.OK:
+            logging.warning(
+                f"Dataset {dataset.name} could not be retrieved."
+                "This is almost always an indication that the dataset is removed, "
+                "so we are removing it from the index."
+            )
+            with DbSession() as session:
+                session.delete(dataset)
+            continue
+
+        dataset_json = response.json()
+        if dataset.platform_resource_identifier != dataset_json["id"]:
+            logging.info(
+                f"Dataset {dataset.platform_resource_identifier} moved to {dataset_json['id']}"
+                "Deleting the old entry. The new entry either already exists or"
+                "will be added on a later synchronization invocation."
+            )
+            with DbSession() as session:
+                session.delete(dataset)
+            continue
+
+        persistent_id = dataset_json["_id"]
+        logging.info(
+            f"Setting platform id of {dataset.platform_resource_identifier} to {persistent_id}"
+        )
+        dataset.platform_resource_identifier = persistent_id
+        with DbSession() as session:
+            session.add(dataset)
+            session.commit()
+
+        if i % 1000 == 0:
+            logging.info(f"Processed {i} of {len(datasets)} entries")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The migration script was painfully slow because it was fetching data from huggingface one by one. Luckily, all the information we need for the migration is available from the batched endpoint, so now we use that instead. The initial fetching of the data takes a while (~5 minutes for me, at 250kish entries), but then updates are near-instant.

Tested the same way the previous PR should be tested. Leaving out instructions for the TRIGGER creation as well as the outdated datasets deletion (it's pretty apparent from the code, but feel free to follow old instructions to verify):

**updated instructions**
First, let's create a version of an "old" style database:

```
docker compose --profile "*" down
git checkout d573673
./scripts/clean.sh
docker compose --env-file=.env --env-file=override.env --profile "huggingface-datasets" up -d
```
That will start populating the `develop` database with huggingface entries, old-style.
Keep track of progress with
```
docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "select COUNT(*) from dataset; select COUNT(*) from ai_asset; select count(*) from ai_resource;"
```
Get any number of entries (I tested with ~2k).
shut down the services:
```
docker compose --profile "*" down
```

Start the services again on the new branch (this may take a little longer):
```
git checkout improve-hf-migration
./scripts/up.sh
```
Let's run our migration script:
```
docker run -it -v $(pwd):/all --network='aiod-rest-api_default' --entrypoint=/bin/bash aiod_metadata_catalogue -c 'python /all/scripts/migrate_hf.py'
```
and let's verify that our HF entries are updated accordingly:
```
docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "select platform_resource_identifier, name from dataset;"
```
