### PR TITLE
[maint] Reduce likelihood of creating dependent tests from fixtures

### DIFF
--- a/src/tests/testutils/default_instances.py
+++ b/src/tests/testutils/default_instances.py
@@ -30,41 +30,58 @@ def draft() -> Status:
 
 
 @pytest.fixture(scope="session")
-def body_concept() -> dict:
+def load_body_concept() -> dict:
     with open(path_test_resources() / "schemes" / "aiod" / "aiod_concept.json", "r") as f:
         return json.load(f)
 
 
+@pytest.fixture()
+def body_concept(load_body_concept: dict) -> dict:
+    return copy.deepcopy(load_body_concept)
+
+
 @pytest.fixture(scope="session")
-def body_resource(body_concept: dict) -> dict:
-    body = copy.copy(body_concept)
+def load_body_resource() -> dict:
     with open(path_test_resources() / "schemes" / "aiod" / "ai_resource.json", "r") as f:
-        resource = json.load(f)
-    body.update(resource)
-    return body
+        return json.load(f)
+
+
+@pytest.fixture()
+def body_resource(body_concept: dict, load_body_resource: dict) -> dict:
+    body = copy.deepcopy(body_concept)
+    body.update(load_body_resource)
+    return copy.deepcopy(body)
 
 
 @pytest.fixture(scope="session")
-def body_asset(body_resource: dict) -> dict:
-    body = copy.copy(body_resource)
+def load_body_asset() -> dict:
     with open(path_test_resources() / "schemes" / "aiod" / "ai_asset.json", "r") as f:
-        asset = json.load(f)
-    body.update(asset)
-    return body
+        return json.load(f)
+
+
+@pytest.fixture()
+def body_asset(body_resource: dict, load_body_asset: dict) -> dict:
+    body = copy.deepcopy(body_resource)
+    body.update(load_body_asset)
+    return copy.deepcopy(body)
 
 
 @pytest.fixture(scope="session")
-def body_agent(body_resource: dict) -> dict:
-    body = copy.copy(body_resource)
+def load_body_agent() -> dict:
     with open(path_test_resources() / "schemes" / "aiod" / "agent.json", "r") as f:
-        agent = json.load(f)
-    body.update(agent)
-    return body
+        return json.load(f)
+
+
+@pytest.fixture()
+def body_agent(body_resource: dict, load_body_agent: dict) -> dict:
+    body = copy.deepcopy(body_resource)
+    body.update(load_body_agent)
+    return copy.deepcopy(body)
 
 
 @pytest.fixture
 def publication(body_asset: dict) -> Publication:
-    body = copy.copy(body_asset)
+    body = copy.deepcopy(body_asset)
     body["permanent_identifier"] = "http://dx.doi.org/10.1093/ajae/aaq063"
     body["isbn"] = "9783161484100"
     body["issn"] = "20493630"
@@ -74,7 +91,7 @@ def publication(body_asset: dict) -> Publication:
 
 @pytest.fixture
 def contact(body_concept, engine: Engine) -> Contact:
-    body = copy.copy(body_concept)
+    body = copy.deepcopy(body_concept)
     body["email"] = ["a@b.com"]
     body["telephone"] = ["0032 XXXX XXXX"]
     body["location"] = [
@@ -88,7 +105,7 @@ def contact(body_concept, engine: Engine) -> Contact:
 
 @pytest.fixture
 def dataset(body_asset: dict) -> Dataset:
-    body = copy.copy(body_asset)
+    body = copy.deepcopy(body_asset)
     body["issn"] = "20493630"
     body["measurement_technique"] = "mass spectrometry"
     body["temporal_coverage"] = "2011/2012"
@@ -96,8 +113,8 @@ def dataset(body_asset: dict) -> Dataset:
 
 
 @pytest.fixture
-def organisation(body_agent) -> Organisation:
-    body = copy.copy(body_agent)
+def organisation(body_agent: dict) -> Organisation:
+    body = copy.deepcopy(body_agent)
     body["date_founded"] = "2022-01-01"
     body["legal_name"] = "Legal Name"
     body["ai_relevance"] = "Description of relevance in AI"
@@ -105,17 +122,16 @@ def organisation(body_agent) -> Organisation:
 
 
 @pytest.fixture
-def person(body_agent) -> Person:
-    body = copy.copy(body_agent)
+def person(body_agent: dict) -> Person:
+    body = copy.deepcopy(body_agent)
     body["expertise"] = ["machine learning"]
     body["language"] = ["eng", "nld"]
     return _create_class_with_body(Person, body)
 
 
 @pytest.fixture
-def experiment(body_asset) -> Experiment:
-    body = copy.copy(body_asset)
-    return _create_class_with_body(Experiment, body)
+def experiment(body_asset: dict) -> Experiment:
+    return _create_class_with_body(Experiment, body_asset)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
Restructure the fixtures around the default json objects to reduce the chance of accidentally creating dependent tests. In the current situation:

 - some of the fixtures are session scoped, which means the same result is used for multiple tests, but
 - that result can be modified since the dictionary is mutable
 
 This means that if you're not careful, you can end up modifying the state for other tests.
 Now, we separate out loading from disk (once per session) to creating the dictionary (once per test), removing the ability to persist state across tests. Note that a single test can still (indirectly) request the same fixture twice, in which case there still needs to be a precaution not to modify the dicts directly.

## How to Test
<!-- Describe a way to test the change of this PR -->
Run the tests, think things through. Alternatively, the following tests will pass on develop but not on this branch:
```python
def test_a(body_concept):
    body_concept["marker"] = 1  # marker is not normally present on the body_concept fixture
    
def test_b(body_concept):
    assert "marker" in body_concept
```
if `test_a` runs before `test_b`, then `test_b` will pass (on develop). If `test_a` isn't run, or run after `test_b`, then it fails (on develop). On this branch `test_b` will always fail, since `body_concept` is now a function-level fixture.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


