### PR TITLE
Do not allow manual overwriting of entry status. Make connectors upload as "published".

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,5 +1,6 @@
 services:
   app:
+    stdin_open: true
     volumes:
       - ./src:/app:ro
     command: >

--- a/src/connectors/aibuilder/aibuilder_mlmodel_connector.py
+++ b/src/connectors/aibuilder/aibuilder_mlmodel_connector.py
@@ -178,9 +178,7 @@ class AIBuilderMLModelConnector(ResourceConnectorByDate[MLModel]):
             same_as=url,  # TODO: Review the concept of having the TOKEN inside the url!!!
             is_accessible_for_free=True,
             version=version,
-            aiod_entry=AIoDEntryCreate(
-                status="published",
-            ),
+            aiod_entry=AIoDEntryCreate(),
             description=description,
             distribution=distribution,
             keyword=tags,

--- a/src/connectors/example/resources/resource/case_studies.json
+++ b/src/connectors/example/resources/resource/case_studies.json
@@ -9,8 +9,7 @@
       "version": "1.1.0",
       "pid": "https://doi.org/10.1000/182",
       "aiod_entry": {
-        "editor": [],
-        "status": "draft"
+        "editor": []
       },
       "alternate_name": [
         "alias 1",

--- a/src/connectors/example/resources/resource/computational_assets.json
+++ b/src/connectors/example/resources/resource/computational_assets.json
@@ -9,8 +9,7 @@
       "version": "1.1.0",
       "pid": "https://doi.org/10.1000/182",
       "aiod_entry": {
-        "editor": [],
-        "status": "draft"
+        "editor": []
       },
       "alternate_name": [
         "alias 1",

--- a/src/connectors/example/resources/resource/contacts.json
+++ b/src/connectors/example/resources/resource/contacts.json
@@ -3,8 +3,7 @@
       "platform": "example",
       "platform_resource_identifier": "1",
       "aiod_entry": {
-        "editor": [],
-        "status": "draft"
+        "editor": []
       },
       "email": ["a@b.com"],
       "telephone": ["0032 XXXX XXXX"],

--- a/src/connectors/example/resources/resource/datasets.json
+++ b/src/connectors/example/resources/resource/datasets.json
@@ -11,8 +11,7 @@
     "measurement_technique": "mass spectrometry",
     "temporal_coverage": "2011/2012",
     "aiod_entry": {
-      "editor": [],
-      "status": "draft"
+      "editor": []
     },
     "alternate_name": [
       "alias 1",

--- a/src/connectors/example/resources/resource/educational_resources.json
+++ b/src/connectors/example/resources/resource/educational_resources.json
@@ -9,8 +9,7 @@
       "version": "1.1.0",
       "pid": "https://doi.org/10.1000/182",
       "aiod_entry": {
-        "editor": [],
-        "status": "draft"
+        "editor": []
       },
       "access_mode": ["textual"],
       "alternate_name": [

--- a/src/connectors/example/resources/resource/events.json
+++ b/src/connectors/example/resources/resource/events.json
@@ -9,8 +9,7 @@
       "version": "1.1.0",
       "pid": "https://doi.org/10.1000/182",
       "aiod_entry": {
-        "editor": [],
-        "status": "draft"
+        "editor": []
       },
       "alternate_name": [
         "alias 1",

--- a/src/connectors/example/resources/resource/experiments.json
+++ b/src/connectors/example/resources/resource/experiments.json
@@ -12,8 +12,7 @@
       "execution_settings": "string",
       "reproducibility_explanation": "string",
       "aiod_entry": {
-        "editor": [],
-        "status": "draft"
+        "editor": []
       },
       "alternate_name": [
         "alias 1",

--- a/src/connectors/example/resources/resource/ml_models.json
+++ b/src/connectors/example/resources/resource/ml_models.json
@@ -9,8 +9,7 @@
       "version": "1.1.0",
       "pid": "https://doi.org/10.1000/182",
       "aiod_entry": {
-        "editor": [],
-        "status": "draft"
+        "editor": []
       },
       "alternate_name": [
         "alias 1",

--- a/src/connectors/example/resources/resource/news.json
+++ b/src/connectors/example/resources/resource/news.json
@@ -9,8 +9,7 @@
       "version": "1.1.0",
       "pid": "https://doi.org/10.1000/182",
       "aiod_entry": {
-        "editor": [],
-        "status": "draft"
+        "editor": []
       },
       "alternate_name": [
         "alias 1",

--- a/src/connectors/example/resources/resource/organisations.json
+++ b/src/connectors/example/resources/resource/organisations.json
@@ -10,8 +10,7 @@
     "legal_name": "The legal Organisation Name",
     "ai_relevance": "Part of CLAIRE, focussing on explainable AI.",
     "aiod_entry": {
-      "editor": [],
-      "status": "draft"
+      "editor": []
     },
     "alternate_name": [
       "alias 1",

--- a/src/connectors/example/resources/resource/persons.json
+++ b/src/connectors/example/resources/resource/persons.json
@@ -9,8 +9,7 @@
     "date_published": "2022-01-01T15:15:00.000",
     "same_as": "https://www.example.com/resource/this_resource",
     "aiod_entry": {
-      "editor": [],
-      "status": "draft"
+      "editor": []
     },
     "alternate_name": [
       "alias 1",

--- a/src/connectors/example/resources/resource/projects.json
+++ b/src/connectors/example/resources/resource/projects.json
@@ -9,8 +9,7 @@
       "version": "1.1.0",
       "pid": "https://doi.org/10.1000/182",
       "aiod_entry": {
-        "editor": [],
-        "status": "draft"
+        "editor": []
       },
       "alternate_name": [
         "alias 1",

--- a/src/connectors/example/resources/resource/publications.json
+++ b/src/connectors/example/resources/resource/publications.json
@@ -11,8 +11,7 @@
   "isbn": "9783161484100",
   "issn": "20493630",
   "aiod_entry": {
-    "editor": [],
-    "status": "draft"
+    "editor": []
   },
   "alternate_name": [
     "alias 1",

--- a/src/connectors/example/resources/resource/services.json
+++ b/src/connectors/example/resources/resource/services.json
@@ -9,8 +9,7 @@
   "slogan": "Making your Smart Paradigm Shifts more Disruptive",
   "terms_of_service": "Your use of this service is subject to the following terms: [...].",
   "aiod_entry": {
-    "editor": [],
-    "status": "draft"
+    "editor": []
   },
   "alternate_name": [
     "alias 1",

--- a/src/connectors/example/resources/resource/teams.json
+++ b/src/connectors/example/resources/resource/teams.json
@@ -7,8 +7,7 @@
     "platform": "example",
     "platform_resource_identifier": "1",
     "aiod_entry": {
-      "editor": [],
-      "status": "draft"
+      "editor": []
     },
     "alternate_name": [
       "alias 1",

--- a/src/connectors/huggingface/huggingface_dataset_connector.py
+++ b/src/connectors/huggingface/huggingface_dataset_connector.py
@@ -119,7 +119,7 @@ class HuggingFaceDatasetConnector(ResourceConnectorOnStartUp[Dataset]):
 
         return ResourceWithRelations[pydantic_class](  # type:ignore
             resource=pydantic_class(
-                aiod_entry=AIoDEntryCreate(status="published"),
+                aiod_entry=AIoDEntryCreate(),
                 platform_resource_identifier=dataset._id,  # see #385, 392
                 platform=self.platform_name,
                 name=dataset.id,
@@ -148,11 +148,7 @@ class HuggingFaceDatasetConnector(ResourceConnectorOnStartUp[Dataset]):
                 parsed_citations = bibtexparser.loads(raw_citation + "}").entries
             elif len(parsed_citations) == 0 and len(raw_citation) <= field_length.NORMAL:
                 # Sometimes dataset.citation is not a bibtex field, but just the title of an article
-                return [
-                    pydantic_class_publication(
-                        name=raw_citation, aiod_entry=AIoDEntryCreate(status="published")
-                    )
-                ]
+                return [pydantic_class_publication(name=raw_citation, aiod_entry=AIoDEntryCreate())]
             return [
                 pydantic_class_publication(
                     # The platform and platform_resource_identifier should be None: this publication
@@ -164,7 +160,7 @@ class HuggingFaceDatasetConnector(ResourceConnectorOnStartUp[Dataset]):
                     description=Text(plain=f"By {citation['author']}")
                     if "author" in citation
                     else None,
-                    aiod_entry=AIoDEntryCreate(status="published"),
+                    aiod_entry=AIoDEntryCreate(),
                 )
                 for citation in parsed_citations
             ]

--- a/src/connectors/openml/openml_dataset_connector.py
+++ b/src/connectors/openml/openml_dataset_connector.py
@@ -80,9 +80,7 @@ class OpenMlDatasetConnector(ResourceConnectorById[Dataset]):
         if "NumberOfInstances" in qualities_json:
             size = DatasetSize(value=_as_int(qualities_json["NumberOfInstances"]), unit="instances")
         return pydantic_class(
-            aiod_entry=AIoDEntryCreate(
-                status="published",
-            ),
+            aiod_entry=AIoDEntryCreate(),
             platform_resource_identifier=identifier,
             platform=self.platform_name,
             name=dataset_json["name"],

--- a/src/connectors/openml/openml_mlmodel_connector.py
+++ b/src/connectors/openml/openml_mlmodel_connector.py
@@ -73,9 +73,7 @@ class OpenMlMLModelConnector(ResourceConnectorById[MLModel]):
 
         pydantic_class = resource_create(MLModel)
         mlmodel = pydantic_class(
-            aiod_entry=AIoDEntryCreate(
-                status="published",
-            ),
+            aiod_entry=AIoDEntryCreate(),
             platform_resource_identifier=identifier,
             platform=self.platform_name,
             name=mlmodel_json["name"],

--- a/src/connectors/synchronization.py
+++ b/src/connectors/synchronization.py
@@ -13,8 +13,9 @@ from connectors.abstract.resource_connector import ResourceConnector, RESOURCE
 from connectors.record_error import RecordError
 from connectors.resource_with_relations import ResourceWithRelations
 from database.model.concept.concept import AIoDConcept
+from database.model.platform.platform_names import PlatformName
 from database.session import DbSession
-from database.setup import _create_or_fetch_related_objects, _get_existing_resource
+from database.setup import _get_existing_resource
 from routers import ResourceRouter, resource_routers, enum_routers
 from setup_logger import setup_logger
 
@@ -117,6 +118,49 @@ def save_to_database(
     return None
 
 
+def _create_or_fetch_related_objects(session: Session, item: ResourceWithRelations):
+    """
+    For all resources in the `related_resources`, get the identifier, by either
+    inserting them in the database, or retrieving the existing values, and put the identifiers
+    into the item.resource.[field_name]
+    """
+    for field_name, related_resource_or_list in item.related_resources.items():
+        if isinstance(related_resource_or_list, AIoDConcept):
+            resources = [related_resource_or_list]
+        else:
+            resources = related_resource_or_list
+        identifiers = []
+        for resource in resources:
+            if (
+                resource.platform is not None
+                and resource.platform != PlatformName.aiod
+                and resource.platform_resource_identifier is not None
+            ):
+                # Get the router of this resource. The difficulty is, that the resource will be a
+                # ResourceRead (e.g. a DatasetRead). So we search for the router for which the
+                # resource name starts with the research-read-name
+
+                resource_read_str = type(resource).__name__  # E.g. DatasetRead
+                (router,) = [
+                    router
+                    for router in resource_routers.router_list
+                    if resource_read_str.startswith(router.resource_class.__name__)
+                    # E.g. "DatasetRead".startswith("Dataset")
+                ]
+                existing = _get_existing_resource(session, resource, router.resource_class)
+                if existing is None:
+                    created_resource = router.create_resource(session, resource)
+                    identifiers.append(created_resource.identifier)
+                else:
+                    identifiers.append(existing.identifier)
+
+        if isinstance(related_resource_or_list, AIoDConcept):
+            (id_,) = identifiers
+            item.resource.__setattr__(field_name, id_)  # E.g. Dataset.license_identifier = 1
+        else:
+            item.resource.__setattr__(field_name, identifiers)  # E.g. Dataset.keywords = [1, 4]
+
+
 def main():
     args = _parse_args()
 
@@ -177,7 +221,7 @@ def main():
                         error_cleaned = "".join(
                             c if c.isalnum() or c == "" else "_" for c in str(error.error)
                         )
-                        f.write(f'"{error.identifier}","{error_cleaned}"\n')
+                        f.write(f'"{error.identifier}","{error_cleaned}"\n')  # noqa: E231
             if args.save_every and i > 0 and i % args.save_every == 0:
                 logging.info(f"Saving state after handling {i}th result: {json.dumps(state)}")
                 with open(state_path, "w") as f:

--- a/src/connectors/synchronization.py
+++ b/src/connectors/synchronization.py
@@ -12,6 +12,7 @@ from sqlmodel import select, Session
 from connectors.abstract.resource_connector import ResourceConnector, RESOURCE
 from connectors.record_error import RecordError
 from connectors.resource_with_relations import ResourceWithRelations
+from database.model.concept.aiod_entry import EntryStatus
 from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform_names import PlatformName
 from database.session import DbSession
@@ -102,7 +103,8 @@ def save_to_database(
         )
         # TODO: if not None, update (https://github.com/aiondemand/AIOD-rest-api/issues/131)
         if existing is None:
-            router.create_resource(session, resource_create_instance)
+            resource = router.create_resource(session, resource_create_instance)
+            publish_resource(session, resource)
 
     except Exception as e:
         session.rollback()
@@ -150,6 +152,7 @@ def _create_or_fetch_related_objects(session: Session, item: ResourceWithRelatio
                 existing = _get_existing_resource(session, resource, router.resource_class)
                 if existing is None:
                     created_resource = router.create_resource(session, resource)
+                    publish_resource(session, created_resource)
                     identifiers.append(created_resource.identifier)
                 else:
                     identifiers.append(existing.identifier)
@@ -159,6 +162,13 @@ def _create_or_fetch_related_objects(session: Session, item: ResourceWithRelatio
             item.resource.__setattr__(field_name, id_)  # E.g. Dataset.license_identifier = 1
         else:
             item.resource.__setattr__(field_name, identifiers)  # E.g. Dataset.keywords = [1, 4]
+
+
+def publish_resource(session: Session, item: AIoDConcept):
+    item.aiod_entry.status = EntryStatus.PUBLISHED
+    session.add(item)
+    session.commit()
+    return item
 
 
 def main():

--- a/src/connectors/zenodo/zenodo_dataset_connector.py
+++ b/src/connectors/zenodo/zenodo_dataset_connector.py
@@ -200,7 +200,7 @@ class ZenodoDatasetConnector(ResourceConnectorByDate[Dataset]):
 
         pydantic_class = resource_create(Dataset)
         dataset = pydantic_class(
-            aiod_entry=AIoDEntryCreate(status="published"),
+            aiod_entry=AIoDEntryCreate(),
             platform="zenodo",
             platform_resource_identifier=identifier,
             name=title,

--- a/src/database/model/concept/aiod_entry.py
+++ b/src/database/model/concept/aiod_entry.py
@@ -21,6 +21,9 @@ class AIoDEntryBase(SQLModel):
     """Metadata of the metadata: when was the metadata last updated, with what identifiers is it
     known on other platforms, etc."""
 
+    class Config:
+        extra = "forbid"
+
 
 class EntryStatus(enum.StrEnum):
     DRAFT = enum.auto()

--- a/src/database/model/concept/aiod_entry.py
+++ b/src/database/model/concept/aiod_entry.py
@@ -57,11 +57,6 @@ class AIoDEntryCreate(AIoDEntryBase):
         default_factory=list,
         schema_extra={"example": []},
     )
-    status: EntryStatus = Field(
-        description="Status of the entry. One of {', '.join(EntryStatus)}.",
-        default=EntryStatus.DRAFT,
-        schema_extra={"example": EntryStatus.DRAFT},
-    )
 
 
 class AIoDEntryRead(AIoDEntryBase):

--- a/src/database/setup.py
+++ b/src/database/setup.py
@@ -9,12 +9,9 @@ from sqlmodel import SQLModel, select
 from sqlalchemy.exc import OperationalError
 
 from config import DB_CONFIG
-from connectors.resource_with_relations import ResourceWithRelations
 from database.model.concept.concept import AIoDConcept
 from database.model.named_relation import NamedRelation
-from database.model.platform.platform_names import PlatformName
 from database.session import db_url
-from routers import resource_routers
 
 
 def create_database(*, delete_first: bool):
@@ -59,46 +56,3 @@ def _get_existing_resource(
             )
         )
     return session.scalars(query).first()
-
-
-def _create_or_fetch_related_objects(session: sqlmodel.Session, item: ResourceWithRelations):
-    """
-    For all resources in the `related_resources`, get the identifier, by either
-    inserting them in the database, or retrieving the existing values, and put the identifiers
-    into the item.resource.[field_name]
-    """
-    for field_name, related_resource_or_list in item.related_resources.items():
-        if isinstance(related_resource_or_list, AIoDConcept):
-            resources = [related_resource_or_list]
-        else:
-            resources = related_resource_or_list
-        identifiers = []
-        for resource in resources:
-            if (
-                resource.platform is not None
-                and resource.platform != PlatformName.aiod
-                and resource.platform_resource_identifier is not None
-            ):
-                # Get the router of this resource. The difficulty is, that the resource will be a
-                # ResourceRead (e.g. a DatasetRead). So we search for the router for which the
-                # resource name starts with the research-read-name
-
-                resource_read_str = type(resource).__name__  # E.g. DatasetRead
-                (router,) = [
-                    router
-                    for router in resource_routers.router_list
-                    if resource_read_str.startswith(router.resource_class.__name__)
-                    # E.g. "DatasetRead".startswith("Dataset")
-                ]
-                existing = _get_existing_resource(session, resource, router.resource_class)
-                if existing is None:
-                    created_resource = router.create_resource(session, resource)
-                    identifiers.append(created_resource.identifier)
-                else:
-                    identifiers.append(existing.identifier)
-
-        if isinstance(related_resource_or_list, AIoDConcept):
-            (id_,) = identifiers
-            item.resource.__setattr__(field_name, id_)  # E.g. Dataset.license_identifier = 1
-        else:
-            item.resource.__setattr__(field_name, identifiers)  # E.g. Dataset.keywords = [1, 4]

--- a/src/tests/authorization/test_status_update.py
+++ b/src/tests/authorization/test_status_update.py
@@ -40,7 +40,7 @@ def test_entry_status_can_update_on_put(
     )
     assert response.status_code == 200, response.json()
 
-    # Status is updated to published
+    # Status is not updated to published
     response = client.get(f"/publications/v1/{identifier}")
     assert response.status_code == 200, response.json()
-    assert response.json()["aiod_entry"]["status"] == EntryStatus.PUBLISHED
+    assert response.json()["aiod_entry"]["status"] == EntryStatus.DRAFT

--- a/src/tests/authorization/test_status_update.py
+++ b/src/tests/authorization/test_status_update.py
@@ -1,4 +1,5 @@
 import copy
+from http import HTTPStatus
 from unittest.mock import Mock
 
 import pytest
@@ -8,7 +9,7 @@ from database.model.concept.aiod_entry import EntryStatus
 
 
 @pytest.fixture()
-def dataset_body(body_asset: dict) -> dict:
+def publication_body(body_asset: dict) -> dict:
     body = copy.deepcopy(body_asset)
     body["permanent_identifier"] = "http://dx.doi.org/10.1093/ajae/aaq063"
     body["isbn"] = "9783161484100"
@@ -21,10 +22,10 @@ def dataset_body(body_asset: dict) -> dict:
 def test_entry_status_can_update_on_put(
     client: TestClient,
     mocked_privileged_token: Mock,
-    dataset_body: dict,
+    publication_body: dict,
 ):
     response = client.post(
-        "/publications/v1", json=dataset_body, headers={"Authorization": "Fake token"}
+        "/publications/v1", json=publication_body, headers={"Authorization": "Fake token"}
     )
     assert response.status_code == 200, response.json()
 
@@ -34,11 +35,13 @@ def test_entry_status_can_update_on_put(
     assert response.json()["aiod_entry"]["status"] == EntryStatus.DRAFT
     identifier = response.json()["identifier"]
 
-    dataset_body["aiod_entry"]["status"] = EntryStatus.PUBLISHED
+    publication_body["aiod_entry"]["status"] = EntryStatus.PUBLISHED
     response = client.put(
-        f"/publications/v1/{identifier}", json=dataset_body, headers={"Authorization": "Fake token"}
+        f"/publications/v1/{identifier}",
+        json=publication_body,
+        headers={"Authorization": "Fake token"},
     )
-    assert response.status_code == 200, response.json()
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
 
     # Status is not updated to published
     response = client.get(f"/publications/v1/{identifier}")

--- a/src/tests/authorization/test_status_update.py
+++ b/src/tests/authorization/test_status_update.py
@@ -1,0 +1,46 @@
+import copy
+from unittest.mock import Mock
+
+import pytest
+from starlette.testclient import TestClient
+
+from database.model.concept.aiod_entry import EntryStatus
+
+
+@pytest.fixture()
+def dataset_body(body_asset: dict) -> dict:
+    body = copy.deepcopy(body_asset)
+    body["permanent_identifier"] = "http://dx.doi.org/10.1093/ajae/aaq063"
+    body["isbn"] = "9783161484100"
+    body["issn"] = "20493630"
+    body["type"] = "journal"
+    body["content"] = {"plain": "plain content"}
+    return body
+
+
+def test_entry_status_can_update_on_put(
+    client: TestClient,
+    mocked_privileged_token: Mock,
+    dataset_body: dict,
+):
+    response = client.post(
+        "/publications/v1", json=dataset_body, headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == 200, response.json()
+
+    # Default is DRAFT
+    response = client.get("/publications/v1/1")
+    assert response.status_code == 200, response.json()
+    assert response.json()["aiod_entry"]["status"] == EntryStatus.DRAFT
+    identifier = response.json()["identifier"]
+
+    dataset_body["aiod_entry"]["status"] = EntryStatus.PUBLISHED
+    response = client.put(
+        f"/publications/v1/{identifier}", json=dataset_body, headers={"Authorization": "Fake token"}
+    )
+    assert response.status_code == 200, response.json()
+
+    # Status is updated to published
+    response = client.get(f"/publications/v1/{identifier}")
+    assert response.status_code == 200, response.json()
+    assert response.json()["aiod_entry"]["status"] == EntryStatus.PUBLISHED

--- a/src/tests/connectors/huggingface/test_huggingface_dataset_connector.py
+++ b/src/tests/connectors/huggingface/test_huggingface_dataset_connector.py
@@ -127,7 +127,6 @@ def test_incorrect_citation():
         resources_with_relations = list(connector.fetch())
     (related_resources,) = [r.related_resources for r in resources_with_relations]
     (citation,) = related_resources["citation"]
-    assert citation.aiod_entry.status == "published"
     assert (
         citation.name == "ArCOV-19: The First Arabic COVID-19 Twitter Dataset with Propagation "
         "Networks"

--- a/src/tests/resources/schemes/aiod/aiod_concept.json
+++ b/src/tests/resources/schemes/aiod/aiod_concept.json
@@ -2,6 +2,5 @@
     "platform": "example",
     "platform_resource_identifier": "1",
     "aiod_entry": {
-        "status": "draft"
     }
 }

--- a/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
+++ b/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
@@ -37,7 +37,6 @@ def test_happy_path(
 
     body = copy.deepcopy(body_asset)
     body["aiod_entry"]["editor"] = [1]
-    body["aiod_entry"]["status"] = "published"
     body["contact"] = [1]
     body["creator"] = [1]
     body["citation"] = [1]
@@ -246,7 +245,7 @@ def test_post_editors(
             "platform": "example",
             "platform_resource_identifier": id_,
             "name": "How user evaluation changed in times of COVID-19",
-            "aiod_entry": {"editor": editors, "status": "published"},
+            "aiod_entry": {"editor": editors},
         }
         response = client.post("/events/v1", json=body, headers=headers)
         assert response.status_code == 200, response.json()

--- a/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
+++ b/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
@@ -14,7 +14,7 @@ from database.model.agent.contact import Contact
 from database.model.agent.organisation import Organisation
 from database.model.agent.person import Person
 from database.model.annotations import datatype_of_field
-from database.model.concept.aiod_entry import AIoDEntryORM
+from database.model.concept.aiod_entry import AIoDEntryORM, EntryStatus
 from database.model.dataset.dataset import Dataset
 from database.model.knowledge_asset.publication import Publication
 from database.model.news.news import News
@@ -60,7 +60,7 @@ def test_happy_path(
     assert response_json["platform"] == "example"
     assert response_json["platform_resource_identifier"] == "1"
     assert response_json["aiod_entry"]["editor"] == [1]
-    assert response_json["aiod_entry"]["status"] == "published"
+    assert response_json["aiod_entry"]["status"] == EntryStatus.DRAFT
     date_created = dateutil.parser.parse(response_json["aiod_entry"]["date_created"] + "Z")
     date_modified = dateutil.parser.parse(response_json["aiod_entry"]["date_modified"] + "Z")
     assert 0 < (date_created - datetime_create_request).total_seconds() < 0.2
@@ -278,14 +278,23 @@ def test_create_aiod_entry(client: TestClient, mocked_privileged_token: Mock):
     assert resource_json["ai_resource_identifier"] == 1
 
 
-def test_update_aiod_entry(client: TestClient, mocked_privileged_token: Mock):
+def test_update_aiod_entry(
+    client: TestClient,
+    mocked_privileged_token: Mock,
+    person: Person,
+):
+    with DbSession() as session:
+        session.add(person)
+        session.commit()
+        identifier = person.identifier
+
     body = {"name": "news"}
     start = datetime.now(pytz.utc)
     response = client.post("/news/v1", json=body, headers={"Authorization": "Fake token"})
     end = datetime.now(pytz.utc)
     assert response.status_code == 200, response.json()
 
-    put_body = {"name": "news", "aiod_entry": {"status": "published"}}
+    put_body = {"name": "news", "aiod_entry": {"editor": [identifier]}}
     response = client.put("/news/v1/1", json=put_body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
 
@@ -298,10 +307,10 @@ def test_update_aiod_entry(client: TestClient, mocked_privileged_token: Mock):
     assert start < date_created < end
     assert end < date_modified
 
-    assert resource_json["aiod_entry"]["status"] == "published"
+    assert resource_json["aiod_entry"]["editor"] == [identifier]
     with DbSession() as session:
         entries = session.scalars(select(AIoDEntryORM)).all()
-        assert len(entries) == 1
+        assert len(entries) == 2
 
 
 def assert_distributions(client: TestClient, *content_urls: str):

--- a/src/tests/uploader/zenodo/test_dataset_uploader.py
+++ b/src/tests/uploader/zenodo/test_dataset_uploader.py
@@ -281,7 +281,6 @@ def test_attempt_to_upload_published_resource(
     """
     body = copy.deepcopy(body_no_dist)
     body["distribution"] = distribution_from_zenodo(FILE1, is_published=True)
-    body["aiod_entry"]["status"] = "published"
 
     with DbSession() as session:
         # Needed because `body_no_dist` references a Person.

--- a/src/tests/uploader/zenodo/test_dataset_uploader.py
+++ b/src/tests/uploader/zenodo/test_dataset_uploader.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from unittest.mock import Mock
 
 from fastapi import HTTPException, status
+from sqlalchemy import select
 from starlette.testclient import TestClient
 
 from database.model.agent.contact import Contact
@@ -14,6 +15,8 @@ from database.model.agent.person import Person
 
 from database.model.platform.platform_names import PlatformName
 from database.session import DbSession
+from database.model.concept.aiod_entry import AIoDEntryORM, EntryStatus
+from database.model.dataset.dataset import Dataset
 
 from tests.testutils.paths import path_test_resources
 
@@ -272,15 +275,16 @@ def test_attempt_to_upload_published_resource(
     person: Person,
 ):
     """
-    Test attempt to upload a file to a resource that has already been published.
-    This must raise an conflict error 409 and return a message stating
-    that the process can't be concluded.
+    Test attempt to upload a file to a resource that has already been published in Zenodo.
+    This must raise a conflict error 409 and return a message stating that the process can't
+    be concluded, since content already on Zenodo must be edited there and not on AIoD.
     """
     body = copy.deepcopy(body_no_dist)
     body["distribution"] = distribution_from_zenodo(FILE1, is_published=True)
     body["aiod_entry"]["status"] = "published"
 
     with DbSession() as session:
+        # Needed because `body_no_dist` references a Person.
         person.name = "Alice Lewis"
         contact.person = person
         session.add(contact)
@@ -288,6 +292,14 @@ def test_attempt_to_upload_published_resource(
 
     response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == status.HTTP_200_OK, response.json()
+
+    with DbSession() as session:
+        dataset = session.scalars(select(Dataset)).first()
+        entry = session.scalars(
+            select(AIoDEntryORM).where(AIoDEntryORM.identifier == dataset.aiod_entry_identifier)
+        ).first()
+        entry.status = EntryStatus.PUBLISHED
+        session.commit()
 
     with responses.RequestsMock() as mocked_requests:
         zenodo.mock_get_repo_metadata(mocked_requests, is_published=True)

--- a/src/uploaders/zenodo_uploader.py
+++ b/src/uploaders/zenodo_uploader.py
@@ -58,7 +58,7 @@ class ZenodoUploader(Uploader):
                 repo_id = platform_resource_id.split(":")[-1]
                 zenodo_metadata = self._get_metadata_from_zenodo(repo_id, token)
 
-                if dataset.aiod_entry.status and dataset.aiod_entry.status == "published":
+                if dataset.aiod_entry.status == EntryStatus.PUBLISHED:
                     raise HTTPException(
                         status_code=status.HTTP_409_CONFLICT,
                         detail=(


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
New assets are have the entry status set to "draft".
Connectors still add assets as "published".
Forbid manual setting of entry status while uploading or modifying an asset.

 * In a follow up PR, I will add a review workflow which will allow for (indirectly) publishing assets.
 * In a separate follow up PR, I will modify the elastic search logic to only index published assets.

## How to Test
<!-- Describe a way to test the change of this PR -->
Unit tests have been updated. Manual verification can be done by:

 * Spinning up the containers and a connector (e.g., `./scripts/up.sh huggingface-datasets`)
 * Use the REST API to verify indexed datasets are "published"
 * Manually upload an asset (e.g., case study), using the Swagger doc page. Verify it is "draft".
 * Try a POST/PUT call which directly sets the aiod entry status to "published". This should result in an error.
 *
## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Builds on #411 as part of the larger effort to introduce a review process and granular edit permissions.


