### PR TITLE
Only index items with status "published" in ES

### DIFF
--- a/src/routers/search_router.py
+++ b/src/routers/search_router.py
@@ -256,7 +256,8 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
         resource = read_class(**kwargs)
         resource.aiod_entry = AIoDEntryRead(
             date_modified=resource_dict["date_modified"],
-            status=EntryStatus.PUBLISHED,
+            # ES should only ever index PUBLISHED assets, so we can set it directly.
+            status=resource_dict.get("status", EntryStatus.PUBLISHED),
         )
         resource.description = {
             "plain": resource_dict["description_plain"],

--- a/src/routers/search_router.py
+++ b/src/routers/search_router.py
@@ -7,7 +7,7 @@ from pydantic.generics import GenericModel
 from sqlmodel import SQLModel, select, Field
 from starlette import status
 
-from database.model.concept.aiod_entry import AIoDEntryRead
+from database.model.concept.aiod_entry import AIoDEntryRead, EntryStatus
 from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
 from database.model.resource_read_and_create import resource_read
@@ -256,7 +256,7 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
         resource = read_class(**kwargs)
         resource.aiod_entry = AIoDEntryRead(
             date_modified=resource_dict["date_modified"],
-            status=resource_dict["status"],
+            status=EntryStatus.PUBLISHED,
         )
         resource.description = {
             "plain": resource_dict["description_plain"],

--- a/src/setup/logstash_setup/templates/sql_init.py
+++ b/src/setup/logstash_setup/templates/sql_init.py
@@ -9,5 +9,5 @@ FROM aiod.{{entity_name}}
 INNER JOIN aiod.aiod_entry ON aiod.{{entity_name}}.aiod_entry_identifier=aiod.aiod_entry.identifier
 LEFT JOIN aiod.text ON aiod.{{entity_name}}.description_identifier\
 =aiod.text.identifier{{linked_joins}}
-WHERE aiod.{{entity_name}}.date_deleted IS NULL{{group_by}}
+WHERE aiod.{{entity_name}}.date_deleted IS NULL AND aiod.aiod_entry.status='PUBLISHED'{{group_by}}
 """

--- a/src/setup/logstash_setup/templates/sql_rm.py
+++ b/src/setup/logstash_setup/templates/sql_rm.py
@@ -2,6 +2,9 @@ TEMPLATE_SQL_RM = """SELECT
     {{entity_name}}.identifier,
     {{entity_name}}.date_deleted
 FROM aiod.{{entity_name}}
-WHERE aiod.{{entity_name}}.date_deleted IS NOT NULL
+INNER JOIN aiod.aiod_entry ON aiod.{{entity_name}}.aiod_entry_identifier=aiod.aiod_entry.identifier
+WHERE (
+aiod.{{entity_name}}.date_deleted IS NOT NULL
 AND aiod.{{entity_name}}.date_deleted > :sql_last_value
+) OR aiod.aiod_entry.status!='PUBLISHED'
 """

--- a/src/setup/logstash_setup/templates/sql_sync.py
+++ b/src/setup/logstash_setup/templates/sql_sync.py
@@ -10,5 +10,6 @@ INNER JOIN aiod.aiod_entry ON aiod.{{entity_name}}.aiod_entry_identifier=aiod.ai
 LEFT JOIN aiod.text ON aiod.{{entity_name}}.description_identifier\
 =aiod.text.identifier{{linked_joins}}
 WHERE aiod.{{entity_name}}.date_deleted IS NULL \
-AND aiod.aiod_entry.date_modified > :sql_last_value{{group_by}}
+AND aiod.aiod_entry.date_modified > :sql_last_value\
+AND aiod.aiod_entry.status='PUBLISHED'{{group_by}}
 """

--- a/src/setup/logstash_setup/templates/sql_sync.py
+++ b/src/setup/logstash_setup/templates/sql_sync.py
@@ -10,6 +10,6 @@ INNER JOIN aiod.aiod_entry ON aiod.{{entity_name}}.aiod_entry_identifier=aiod.ai
 LEFT JOIN aiod.text ON aiod.{{entity_name}}.description_identifier\
 =aiod.text.identifier{{linked_joins}}
 WHERE aiod.{{entity_name}}.date_deleted IS NULL \
-AND aiod.aiod_entry.date_modified > :sql_last_value\
+AND aiod.aiod_entry.date_modified > :sql_last_value \
 AND aiod.aiod_entry.status='PUBLISHED'{{group_by}}
 """


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->

## Change
<!-- Briefly describe the change of this PR -->
With changes to the upload process, we only want to expose assets that passed review, i.e., those that are marked "published". For that reason, I changed ES to only index those assets which are "published" and drop entries that are not.


## How to Test
<!-- Describe a way to test the change of this PR -->
Upload some assets, e.g., with the huggingface connector. Make sure they are marked published. Verify they show up in ES. Change their status (in the database). Verify they no longer show up.

I do not think this needs additional documentation.
Automatic tests for indexing behavior would require a running ES server, which are tests currently do not yet use.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Towards the new uploads with review process (#411, #426).

