### PR TITLE
Enh/log requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us fix it!
+title: ''
+labels: bug, triage
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Error Reference**
+Please indicate which server you were connecting to (e.g., api.aiod.eu).
+If the server provided a reference code, please provide it (a hexidecimal string, like `d47cb85f6cf64c158dbb65e1a891903f`).
+
+**To Reproduce**
+Please provide a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example). Preferably a (set of) complete queries which do not behave as expected.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/docs/developer/troubleshooting.md
+++ b/docs/developer/troubleshooting.md
@@ -1,0 +1,26 @@
+## Logging
+The REST API uses the built-in [`logging`](https://docs.python.org/3/library/logging.html) module for its logging.
+The [log level](https://docs.python.org/3/library/logging.html#logging-levels) for the configuration can be configured
+in the `src/config.override.toml` file, as `dev.log_level`.
+
+## Navigating the logs
+The REST API will provide an error reference with each exception it raises.
+For example, trying to access a dataset that does not exist may result in:
+
+```json
+{
+  'detail': "Dataset '42' not found in the database.",
+  'reference': 'd47cb85f6cf64c158dbb65e1a891903f'
+}
+```
+
+To figure out what lead to this error, you can reference the logs.
+Unexpected errors, i.e., uncaught ones, are logged at `logging.ERROR` level.
+Other errors, such as the one above, are logged at `logging.DEBUG` level.
+By default, logging output is at `logging.INFO` level, so if you want to capture all warnings you
+must first set it to `logging.DEBUG`.
+
+You can find the error in the docker logs as `docker logs CONTAINER_NAME 2>&1 | grep -e "REFERENCE"`,
+e.g.,`docker logs apiserver 2>&1 | grep -e "d47cb85f6cf64c158dbb65e1a891903f"`. The log message will 
+contain information about the type of request (`GET`) the path and query (`/datasets/v1/42`), and 
+the body content (in the case of requests that have one).

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -26,6 +26,7 @@ nav:
       - 'Elastic Search': developer/elastic_search.md
       - 'Scripts': developer/scripts.md
       - 'Release Workflow': developer/releases.md
+      - 'Troubleshooting': developer/troubleshooting.md
   - 'Contributing': contributing.md
 
 markdown_extensions:

--- a/src/config.default.toml
+++ b/src/config.default.toml
@@ -13,6 +13,7 @@ password = "ok"
 [dev]
 reload = true
 request_timeout = 10  # seconds
+log_level = "INFO"  # Python log levels: https://docs.python.org/3/library/logging.html#logging-levels
 
 # Authentication and authorization
 [keycloak]

--- a/src/error_handling/__init__.py
+++ b/src/error_handling/__init__.py
@@ -1,1 +1,1 @@
-from error_handling.error_handling import as_http_exception  # noqa:F401
+from error_handling.error_handling import as_http_exception, http_exception_handler  # noqa:F401

--- a/src/error_handling/error_handling.py
+++ b/src/error_handling/error_handling.py
@@ -32,18 +32,22 @@ async def http_exception_handler(request, exc):
     error = ErrorSchema(detail=exc.detail, reference=reference)
     content = error.dict()
 
-    body = await request.body()
-    log_level = logging.DEBUG
-    if exc.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
-        log_level = logging.WARNING
+    body_content = "<Data Stream with unknown content>"
+    if not request._stream_consumed:
+        body = await request.body()
+        body_content = json.dumps(json.loads(body)) if body else ""
+        
     log_message = str(
         dict(
             reference=reference,
             exception=f"{str(exc)!r}",
             method=request.scope["method"],
             path=request.scope["path"],
-            body=json.dumps(json.loads(body)),
+            body=body_content,
         )
     )
+    log_level = logging.DEBUG
+    if exc.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
+        log_level = logging.WARNING
     logging.log(log_level, log_message)
     return JSONResponse(content, status_code=exc.status_code)

--- a/src/error_handling/error_handling.py
+++ b/src/error_handling/error_handling.py
@@ -36,7 +36,7 @@ async def http_exception_handler(request, exc):
     if not request._stream_consumed:
         body = await request.body()
         body_content = json.dumps(json.loads(body)) if body else ""
-        
+
     log_message = str(
         dict(
             reference=reference,

--- a/src/error_handling/error_handling.py
+++ b/src/error_handling/error_handling.py
@@ -1,5 +1,12 @@
+import json
+import logging
 import traceback
+import uuid
+from http import HTTPStatus
+
 from fastapi import HTTPException, status
+from pydantic import BaseModel
+from starlette.responses import JSONResponse
 
 
 def as_http_exception(exception: Exception) -> HTTPException:
@@ -13,3 +20,30 @@ def as_http_exception(exception: Exception) -> HTTPException:
             f"{exception}"
         ),
     )
+
+
+class ErrorSchema(BaseModel):
+    detail: str
+    reference: str
+
+
+async def http_exception_handler(request, exc):
+    reference = uuid.uuid4().hex
+    error = ErrorSchema(detail=exc.detail, reference=reference)
+    content = error.dict()
+
+    body = await request.body()
+    log_level = logging.DEBUG
+    if exc.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
+        log_level = logging.WARNING
+    log_message = str(
+        dict(
+            reference=reference,
+            exception=f"{str(exc)!r}",
+            method=request.scope["method"],
+            path=request.scope["path"],
+            body=json.dumps(json.loads(body)),
+        )
+    )
+    logging.log(log_level, log_message)
+    return JSONResponse(content, status_code=exc.status_code)

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ import logging
 
 import pkg_resources
 import uvicorn
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from sqlmodel import select
 
@@ -22,6 +22,7 @@ from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
 from database.session import EngineSingleton, DbSession
 from database.setup import create_database, database_exists
+from routers.resource_router import http_exception_handler
 from routers import resource_routers, parent_routers, enum_routers, uploader_routers
 from routers import search_routers
 from setup_logger import setup_logger
@@ -120,6 +121,7 @@ def create_app() -> FastAPI:
             "scopes": KEYCLOAK_CONFIG.get("scopes"),
         },
     )
+    app.add_exception_handler(HTTPException, http_exception_handler)
     if args.build_db == "never":
         if not database_exists():
             logging.warning(

--- a/src/main.py
+++ b/src/main.py
@@ -102,26 +102,6 @@ def create_app() -> FastAPI:
     """Create the FastAPI application, complete with routes."""
     setup_logger()
     args = _parse_args()
-    pyproject_toml = pkg_resources.get_distribution("aiod_metadata_catalogue")
-    app = FastAPI(
-        openapi_url=f"{args.url_prefix}/openapi.json",
-        docs_url=f"{args.url_prefix}/docs",
-        title="AIoD Metadata Catalogue",
-        description="This is the Swagger documentation of the AIoD Metadata Catalogue. For the "
-        "Changelog, refer to "
-        '<a href="https://github.com/aiondemand/AIOD-rest-api/releases">https'
-        "://github.com/aiondemand/AIOD-rest-api/releases</a>.",
-        version=pyproject_toml.version,
-        swagger_ui_oauth2_redirect_url=f"{args.url_prefix}/docs/oauth2-redirect",
-        swagger_ui_init_oauth={
-            "clientId": KEYCLOAK_CONFIG.get("client_id_swagger"),
-            "realm": KEYCLOAK_CONFIG.get("realm"),
-            "appName": "AIoD Metadata Catalogue",
-            "usePkceWithAuthorizationCodeGrant": True,
-            "scopes": KEYCLOAK_CONFIG.get("scopes"),
-        },
-    )
-    app.add_exception_handler(HTTPException, http_exception_handler)
     if args.build_db == "never":
         if not database_exists():
             logging.warning(
@@ -131,21 +111,49 @@ def create_app() -> FastAPI:
                 "this likely means that you will get errors or undefined behavior."
             )
     else:
+        build_database(args)
 
-        drop_database = args.build_db == "drop-then-build"
-        create_database(delete_first=drop_database)
-        AIoDConcept.metadata.create_all(EngineSingleton().engine, checkfirst=True)
-        with DbSession() as session:
-            triggers = create_delete_triggers(AIoDConcept)
-            for trigger in triggers:
-                session.execute(trigger)
-            existing_platforms = session.scalars(select(Platform)).all()
-            if not any(existing_platforms):
-                session.add_all([Platform(name=name) for name in PlatformName])
-                session.commit()
-
-    add_routes(app, url_prefix=args.url_prefix)
+    pyproject_toml = pkg_resources.get_distribution("aiod_metadata_catalogue")
+    app = build_app(args.url_prefix, pyproject_toml.version)
     return app
+
+
+def build_app(url_prefix: str = "", version: str = "dev"):
+    app = FastAPI(
+        openapi_url=f"{url_prefix}/openapi.json",
+        docs_url=f"{url_prefix}/docs",
+        title="AIoD Metadata Catalogue",
+        description="This is the Swagger documentation of the AIoD Metadata Catalogue. For the "
+        "Changelog, refer to "
+        '<a href="https://github.com/aiondemand/AIOD-rest-api/releases">https'
+        "://github.com/aiondemand/AIOD-rest-api/releases</a>.",
+        version=version,
+        swagger_ui_oauth2_redirect_url=f"{url_prefix}/docs/oauth2-redirect",
+        swagger_ui_init_oauth={
+            "clientId": KEYCLOAK_CONFIG.get("client_id_swagger"),
+            "realm": KEYCLOAK_CONFIG.get("realm"),
+            "appName": "AIoD Metadata Catalogue",
+            "usePkceWithAuthorizationCodeGrant": True,
+            "scopes": KEYCLOAK_CONFIG.get("scopes"),
+        },
+    )
+    add_routes(app, url_prefix=url_prefix)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    return app
+
+
+def build_database(args):
+    drop_database = args.build_db == "drop-then-build"
+    create_database(delete_first=drop_database)
+    AIoDConcept.metadata.create_all(EngineSingleton().engine, checkfirst=True)
+    with DbSession() as session:
+        triggers = create_delete_triggers(AIoDConcept)
+        for trigger in triggers:
+            session.execute(trigger)
+        existing_platforms = session.scalars(select(Platform)).all()
+        if not any(existing_platforms):
+            session.add_all([Platform(name=name) for name in PlatformName])
+            session.commit()
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,7 @@ from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
 from database.session import EngineSingleton, DbSession
 from database.setup import create_database, database_exists
-from routers.resource_router import http_exception_handler
+from error_handling import http_exception_handler
 from routers import resource_routers, parent_routers, enum_routers, uploader_routers
 from routers import search_routers
 from setup_logger import setup_logger

--- a/src/routers/resource_ai_asset_router.py
+++ b/src/routers/resource_ai_asset_router.py
@@ -72,7 +72,7 @@ class ResourceAIAssetRouter(ResourceRouter):
                     detail=(
                         "Multiple distributions encountered. "
                         "Use another endpoint indicating the distribution index `distribution_idx` "
-                        "at the end of the url for a specific distribution.",
+                        "at the end of the url for a specific distribution."
                     ),
                 )
             elif distribution_idx >= len(distributions):

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -1,5 +1,6 @@
 import abc
 import datetime
+import json
 import logging
 import traceback
 from functools import partial
@@ -9,6 +10,7 @@ from wsgiref.handlers import format_date_time
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
 from fastapi.encoders import jsonable_encoder
+from pydantic import BaseModel
 from sqlalchemy import and_, func
 from sqlalchemy.sql.operators import is_
 from sqlmodel import SQLModel, Session, select
@@ -32,12 +34,6 @@ from dependencies.filtering import ResourceFilters, ResourceFiltersParams
 from dependencies.pagination import Pagination, PaginationParams
 from error_handling import as_http_exception
 
-
-from typing import Callable
-
-from fastapi import Request, Response
-from fastapi.routing import APIRoute
-
 import uuid
 
 RESOURCE = TypeVar("RESOURCE", bound=AbstractAIResource)
@@ -46,30 +42,31 @@ RESOURCE_READ = TypeVar("RESOURCE_READ", bound=SQLModel)
 RESOURCE_MODEL = TypeVar("RESOURCE_MODEL", bound=SQLModel)
 
 
-class ValidationErrorLoggingRoute(APIRoute):
-    def get_route_handler(self) -> Callable:
-        original_route_handler = super().get_route_handler()
+class ErrorSchema(BaseModel):
+    detail: str
+    reference: str
 
-        async def custom_route_handler(request: Request) -> Response:
-            try:
-                return await original_route_handler(request)
-            except HTTPException as exc:
-                body = await request.body()
-                log_level = (
-                    logging.WARNING
-                    if exc.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-                    else logging.DEBUG
-                )
-                reference = uuid.uuid4().hex
-                msg = (
-                    f"Error {reference}: {exc!r} for path '{request.scope['method']!r}'"
-                    f" {request.scope['path']!r} and body {body.decode()!r}."
-                )
-                logging.log(log_level, msg)
-                #     exc.detail += f" Reference {reference}."
-                raise exc
 
-        return custom_route_handler
+async def http_exception_handler(request, exc):
+    reference = uuid.uuid4().hex
+    error = ErrorSchema(detail=exc.detail, reference=reference)
+    content = error.dict()
+
+    body = await request.body()
+    log_level = logging.DEBUG
+    if exc.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
+        log_level = logging.WARNING
+    log_message = str(
+        dict(
+            reference=reference,
+            exception=f"{str(exc)!r}",
+            method=request.scope["method"],
+            path=request.scope["path"],
+            body=json.dumps(json.loads(body)),
+        )
+    )
+    logging.log(log_level, log_message)
+    return JSONResponse(content, status_code=exc.status_code)
 
 
 class ResourceRouter(abc.ABC):
@@ -140,7 +137,6 @@ class ResourceRouter(abc.ABC):
 
     def create(self, url_prefix: str) -> APIRouter:
         router = APIRouter()
-        router.route_class = ValidationErrorLoggingRoute
         version = f"v{self.version}"
         default_kwargs = {
             "response_model_exclude_none": True,

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -1,7 +1,9 @@
 import abc
 import datetime
+import logging
 import traceback
 from functools import partial
+from http import HTTPStatus
 from typing import Annotated, Any, Literal, Sequence, Type, TypeVar, Union
 from wsgiref.handlers import format_date_time
 
@@ -30,10 +32,44 @@ from dependencies.filtering import ResourceFilters, ResourceFiltersParams
 from dependencies.pagination import Pagination, PaginationParams
 from error_handling import as_http_exception
 
+
+from typing import Callable
+
+from fastapi import Request, Response
+from fastapi.routing import APIRoute
+
+import uuid
+
 RESOURCE = TypeVar("RESOURCE", bound=AbstractAIResource)
 RESOURCE_CREATE = TypeVar("RESOURCE_CREATE", bound=SQLModel)
 RESOURCE_READ = TypeVar("RESOURCE_READ", bound=SQLModel)
 RESOURCE_MODEL = TypeVar("RESOURCE_MODEL", bound=SQLModel)
+
+
+class ValidationErrorLoggingRoute(APIRoute):
+    def get_route_handler(self) -> Callable:
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request) -> Response:
+            try:
+                return await original_route_handler(request)
+            except HTTPException as exc:
+                body = await request.body()
+                log_level = (
+                    logging.WARNING
+                    if exc.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+                    else logging.DEBUG
+                )
+                reference = uuid.uuid4().hex
+                msg = (
+                    f"Error {reference}: {exc!r} for path '{request.scope['method']!r}'"
+                    f" {request.scope['path']!r} and body {body.decode()!r}."
+                )
+                logging.log(log_level, msg)
+                #     exc.detail += f" Reference {reference}."
+                raise exc
+
+        return custom_route_handler
 
 
 class ResourceRouter(abc.ABC):
@@ -104,6 +140,7 @@ class ResourceRouter(abc.ABC):
 
     def create(self, url_prefix: str) -> APIRouter:
         router = APIRouter()
+        router.route_class = ValidationErrorLoggingRoute
         version = f"v{self.version}"
         default_kwargs = {
             "response_model_exclude_none": True,

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -1,16 +1,12 @@
 import abc
 import datetime
-import json
-import logging
 import traceback
 from functools import partial
-from http import HTTPStatus
 from typing import Annotated, Any, Literal, Sequence, Type, TypeVar, Union
 from wsgiref.handlers import format_date_time
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
 from fastapi.encoders import jsonable_encoder
-from pydantic import BaseModel
 from sqlalchemy import and_, func
 from sqlalchemy.sql.operators import is_
 from sqlmodel import SQLModel, Session, select
@@ -34,39 +30,10 @@ from dependencies.filtering import ResourceFilters, ResourceFiltersParams
 from dependencies.pagination import Pagination, PaginationParams
 from error_handling import as_http_exception
 
-import uuid
-
 RESOURCE = TypeVar("RESOURCE", bound=AbstractAIResource)
 RESOURCE_CREATE = TypeVar("RESOURCE_CREATE", bound=SQLModel)
 RESOURCE_READ = TypeVar("RESOURCE_READ", bound=SQLModel)
 RESOURCE_MODEL = TypeVar("RESOURCE_MODEL", bound=SQLModel)
-
-
-class ErrorSchema(BaseModel):
-    detail: str
-    reference: str
-
-
-async def http_exception_handler(request, exc):
-    reference = uuid.uuid4().hex
-    error = ErrorSchema(detail=exc.detail, reference=reference)
-    content = error.dict()
-
-    body = await request.body()
-    log_level = logging.DEBUG
-    if exc.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
-        log_level = logging.WARNING
-    log_message = str(
-        dict(
-            reference=reference,
-            exception=f"{str(exc)!r}",
-            method=request.scope["method"],
-            path=request.scope["path"],
-            body=json.dumps(json.loads(body)),
-        )
-    )
-    logging.log(log_level, log_message)
-    return JSONResponse(content, status_code=exc.status_code)
 
 
 class ResourceRouter(abc.ABC):

--- a/src/setup_logger.py
+++ b/src/setup_logger.py
@@ -1,5 +1,8 @@
+# ruff: noqa: S101  # We want early fail on startup if logging is not configured correctly
 import logging
 from importlib.metadata import version
+
+from config import CONFIG
 
 format_string = (
     f"v{version('aiod_metadata_catalogue')}"
@@ -7,9 +10,21 @@ format_string = (
 )
 
 
-def setup_logger():
+def setup_logger(config: dict | None = None):
+    config = config or CONFIG
+    assert "dev" in config, "There should be a [dev] section in the configuration.toml file."
+    assert (
+        "log_level" in config["dev"]
+    ), "Missing `log_level` setting in the [dev] section of the configuration.toml file."
+
+    log_level: str = config["dev"]["log_level"]
+    levels = logging.getLevelNamesMapping()
+    assert (
+        isinstance(log_level, str) and log_level.upper() in levels
+    ), f"The `dev.log_level` is set to {log_level!r} but should be one of {set(levels)!r}."
+
     logging.basicConfig(
-        level=logging.INFO,
+        level=levels[log_level],
         format=format_string,
         datefmt="%Y-%m-%d %H:%M:%S",
     )

--- a/src/tests/routers/ai_asset_routers/test_router_aiassets_retrieve_content.py
+++ b/src/tests/routers/ai_asset_routers/test_router_aiassets_retrieve_content.py
@@ -160,11 +160,11 @@ def test_endpoints_when_two_distributions(
 
     response = client.get(SAMPLE_ENDPOINT, allow_redirects=False)
     assert response.status_code == status.HTTP_409_CONFLICT, response.content
-    assert response.json()["detail"] == [
+    assert response.json()["detail"] == (
         "Multiple distributions encountered. "
         "Use another endpoint indicating the distribution index `distribution_idx` "
         "at the end of the url for a specific distribution."
-    ], response.content
+    ), response.content
 
     response0 = client.get(SAMPLE_ENDPOINT + "/0", allow_redirects=False)
     assert response0.status_code == status.HTTP_303_SEE_OTHER, response0.content

--- a/src/tests/test_error_response.py
+++ b/src/tests/test_error_response.py
@@ -1,0 +1,11 @@
+import logging
+
+
+def test_reference_json_and_log_match(client, caplog):
+    url_raises_because_dataset_does_not_exist = "/datasets/v1/42"
+    with caplog.at_level(logging.DEBUG):
+        response = client.get(url_raises_because_dataset_does_not_exist).json()
+
+    assert "reference" in response, response
+    reference_in_log = response["reference"] in caplog.text
+    assert reference_in_log, "The reference provided to the user should be in the log."

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -17,7 +17,7 @@ from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
 from database.session import EngineSingleton
-from main import add_routes
+from main import build_app
 from tests.testutils.test_resource import RouterTestResource, factory
 
 
@@ -92,9 +92,8 @@ def client(engine: Engine) -> TestClient:
     """
     Create a TestClient that can be used to mock sending requests to our application
     """
-    app = FastAPI()
-    add_routes(app)
-    return TestClient(app, base_url="http://localhost")
+    app = build_app(version="unittest")
+    yield TestClient(app, base_url="http://localhost")
 
 
 @pytest.fixture(scope="session")

--- a/src/tests/uploader/zenodo/test_dataset_uploader.py
+++ b/src/tests/uploader/zenodo/test_dataset_uploader.py
@@ -311,10 +311,10 @@ def test_attempt_to_upload_published_resource(
             )
 
         assert response.status_code == status.HTTP_409_CONFLICT, response.json()
-        assert response.json()["detail"] == [
+        assert response.json()["detail"] == (
             "This resource is already public and can't be edited with this endpoint. "
             f"You can access and modify it at {zenodo.HTML_URL}/{zenodo.RESOURCE_ID}"
-        ], response.json()
+        ), response.json()
 
     response_json = client.get("datasets/v1/1").json()
     assert response_json["distribution"] == body["distribution"], response_json

--- a/src/uploaders/zenodo_uploader.py
+++ b/src/uploaders/zenodo_uploader.py
@@ -64,7 +64,7 @@ class ZenodoUploader(Uploader):
                         detail=(
                             "This resource is already public and can't be edited with this "
                             "endpoint. You can access and modify it at "
-                            f"{zenodo_metadata['links']['html']}",
+                            f"{zenodo_metadata['links']['html']}"
                         ),
                     )
                 self._update_zenodo_metadata(metadata, repo_id, token)


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
 * Add logging of errors to the server
 * add a "reference" field to error responses, so that it's easier to look up errors in a log later
 * make log level of application configurable

## How to Test
<!-- Describe a way to test the change of this PR -->
Start the services, browse to the web, make some errors.
By default, only the internal server errors are logged at warning (since those are unexpected), others at debug. 
Currently none of the logging handlers save debug logs (I think). So to test, create an internal server error or change the log level by setting the `log_level` in the `[dev]` section of the `src/configuration.override.toml` file.

To create an internal server error, authenticate, then submit an asset (e.g., case study) where one of the research areas is very long. For example:

```json
{"platform": "example", "platform_resource_identifier": "21", "name": "The name of this resource", "date_published": "2022-01-01T15:15:00.000", "same_as": "https://www.example.com/resource/this_resource", "is_accessible_for_free": true, "version": "1.1.0", "aiod_entry": {"editor": []}, "alternate_name": ["alias 1", "alias 2"], "application_area": ["Fraud Prevention", "Voice Assistance", "Disease Classification"], "citation": [], "contact": [], "creator": [], "description": {"plain": "Plain text.", "html": "<p>Text with <strong>html formatting</strong>.</p>"}, "distribution": [], "has_part": [], "industrial_sector": ["Finance", "eCommerce", "Healthcare"], "is_part_of": [], "keyword": ["keyword1", "keyword2"], "license": "https://creativecommons.org/share-your-work/public-domain/cc0/", "media": [], "note": [], "relevant_link": ["https://www.example.com/a_relevant_link", "https://www.example.com/another_relevant_link"], "relevant_resource": [], "relevant_to": [], "research_area": ["Explainable AI", "Physical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical Physical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AIPhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical APhysical AA"], "scientific_domain": ["Anomaly Detection", "Voice Recognition", "Computer Vision."]}
```
You should get a response similar to:

```json
{
  "detail": "Unexpected exception while processing your request. Please contact the maintainers: (MySQLdb.IntegrityError) (1048, \"Column 'name' cannot be null\")\n[SQL: INSERT INTO research_area (name) VALUES (%s)]\n[parameters: (None,)]\n(Background on this error at: https://sqlalche.me/e/20/gkpj)",
  "reference": "d1839724796c425f8fb4b9a8318b3f3c"
}
```

You can then see the request from the server logs: `docker logs apiserver 2>&1 | grep -e "REFERENCE"`

To test it for a 404 error, enable `DEBUG` logging, restart the server, and then
```
curl http://localhost/datasets/v1/12345  # Some dataset that does not exist
docker logs apiserver 
```
should show an error similar to
```
v1.3.20241030 2025-02-10 15:51:18.776 DEBUG error_handling - http_exception_handler: {'reference': '132d3221f85c4f4e8b1ef63364b96e79', 'exception': '"404: Dataset \'422\' not found in the database."', 'method': 'GET', 'path': '/datasets/v1/422', 'body': ''}
INFO:     172.18.0.8:38916 - "GET /datasets/v1/422 HTTP/1.0" 404 Not Found
```

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
n/a

