### PR TITLE
Feat/reviewqueue

### DIFF
--- a/docs/developer/schema/index.md
+++ b/docs/developer/schema/index.md
@@ -19,6 +19,9 @@ following figure:
 
 ![AIoD Metadata model](../../media/AIoD_Metadata_Model.drawio.png)
 
+In addition to the implementation of the metadata schema, we maintain some metadata about that metadata.
+Specifically, a system which stores users, permissions, and reviews that relate to the metadata assets uploaded to AIoD.
+More on this can be found in the ["User Model"](../users.md) documentation.
 
 ## Reading the Conceptual Metadata Schema
 Tools and documentation on how to read the conceptual metadata model are currently being written.

--- a/docs/developer/users.md
+++ b/docs/developer/users.md
@@ -1,0 +1,43 @@
+# User Model
+
+The user model in AIoD allows users to maintain and share ownership over assets, 
+and to allow a review process for new assets.
+The components of this user model are defined in [src/database/authorization.py](https://github.com/aiondemand/AIOD-rest-api/blob/develop/src/database/authorization.py)
+and [src/database/review.py](https://github.com/aiondemand/AIOD-rest-api/blob/develop/src/database/review.py).
+
+[//]: # (Add a diagram overview once the model is more final, e.g., groups are added)
+
+## Users
+User credentials are kept in keycloak or by identity providers, in any case the user is uniquely identified
+by the unique "sub" key that keycloak provides in its token.
+In our user model we keep as little information about the user as we can.
+This avoids a scenario were data is kept twice and may desynchronize, and also respects the users' privacy.
+Currently, that is only the "sub", but in the future we may consider adding e.g., usernames.
+
+## Permissions
+A user may have certain permissions for an asset, these are: 
+ 
+ - read: a user may retrieve this metadata asset.
+ - write: a user may modify this metadata asset.
+ - admin: a user may delete this metadata asset, submit it for review, and grant other users permissions for the asset.
+
+The only notion of "ownership" over a particular metadata asset is having administrator rights.
+When user A uploads an asset and assigns user B administrator rights, they have completely equal rights.
+There is no special privilege for user A, and this also means that e.g., user B may remove administrator rights from user A.
+
+## Reviews
+An asset uploaded by a user is by default in `draft` state.
+The user may request the asset to be `published` by submitting it for review through the REST API.
+To do this, they submit the identifier of the asset to the `ASSET_TYPE/submit/v1/{identifier}` endpoint.
+When it is submitted for review, reviewers will be able to see the request and make a decision.
+As long as no decision has been made, the user may retract their submission from review using the `ASSET_TYPE/retract/v1/{identifier}`
+endpoint.
+Each asset may only have one concurrent review request, and the asset may not be modified while it is under review.
+
+Reviewers can find pending submissions using the `submissions/v1` endpoint,
+and get information on a particular submission with the `submissions/v1/{identifier}` endpoint, 
+where the identifier denotes the identifier of the submission (i.e., review request).
+Reviewers can submit a review using the `ASSET_TYPE/review/v1/{identifier}` endpoint.
+
+If the submission is accepted, the asset will be published without further action from the original uploader.
+If the submission is rejected, the asset will move back to `draft` state and may be submitted again.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -17,6 +17,7 @@ nav:
   - 'Developer Resources':
       - developer/index.md
       - 'Authentication': developer/authentication.md
+      - 'User Model': developer/users.md
       - 'Metadata Schema':
           - developer/schema/index.md
           - 'Attributes': developer/schema/attributes.md

--- a/src/database/authorization.py
+++ b/src/database/authorization.py
@@ -65,11 +65,14 @@ def register_user(kc_user: KeycloakUser, session: Session) -> User:
 
 
 def add_administrator(user: KeycloakUser, resource: AIoDConcept, session: Session):
-    permission = Permission(
-        type_=PermissionType.ADMIN,
-        user_identifier=user._subject_identifier,
-        aiod_entry=resource.aiod_entry,
-    )
+    query = select(Permission).where(User.subject_identifier == user._subject_identifier)
+    permission = session.scalars(query).first()
+    if permission is None:
+        permission = Permission(
+            user_identifier=user._subject_identifier,
+            aiod_entry=resource.aiod_entry,
+        )
+    permission.type_ = PermissionType.ADMIN
     session.add(permission)
 
 

--- a/src/database/review.py
+++ b/src/database/review.py
@@ -30,6 +30,7 @@ class Review(SQLModel, table=True):  # type: ignore [call-arg]
 
     reviewer_identifier: str = Field(
         foreign_key="user.subject_identifier",
+        exclude=True,
     )
     submission_identifier: int = Field(
         foreign_key="submission.identifier",
@@ -56,7 +57,9 @@ class Submission(SQLModel, table=True):  # type: ignore [call-arg]
     # We do not want the review to be deleted when the original requestee is deleted,
     # there could be e.g., shared ownership in which case the review data should be preserved.
     requestee_identifier: str | None = Field(
-        foreign_key="user.subject_identifier", ondelete="SET NULL"
+        foreign_key="user.subject_identifier",
+        ondelete="SET NULL",
+        exclude=True,
     )
 
     # On the other hand, if the entry corresponding to the thing it reviews is removed,

--- a/src/main.py
+++ b/src/main.py
@@ -12,14 +12,12 @@ import pkg_resources
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
-from pydantic import BaseModel
 from sqlmodel import select, SQLModel
 
 from authentication import get_user_or_raise, KeycloakUser
 from config import KEYCLOAK_CONFIG
 from database.deletion.triggers import create_delete_triggers
 import database.authorization  # noqa  # Trigger registration of User, Permission -> likely obsolete when couple with aiod_entry is done
-from database.model.concept.aiod_entry import EntryStatus
 from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
@@ -29,14 +27,6 @@ from error_handling import http_exception_handler
 from routers import resource_routers, parent_routers, enum_routers, uploader_routers
 from routers import search_routers
 from setup_logger import setup_logger
-
-
-class EntryStatusChangeRequest(BaseModel):
-    """Used for"""
-
-    concept_identifier: int
-    requested_status: EntryStatus
-    comment: str | None = None
 
 
 def _parse_args() -> argparse.Namespace:

--- a/src/main.py
+++ b/src/main.py
@@ -12,12 +12,14 @@ import pkg_resources
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
 from sqlmodel import select, SQLModel
 
 from authentication import get_user_or_raise, KeycloakUser
 from config import KEYCLOAK_CONFIG
 from database.deletion.triggers import create_delete_triggers
 import database.authorization  # noqa  # Trigger registration of User, Permission -> likely obsolete when couple with aiod_entry is done
+from database.model.concept.aiod_entry import EntryStatus
 from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
@@ -27,6 +29,14 @@ from error_handling import http_exception_handler
 from routers import resource_routers, parent_routers, enum_routers, uploader_routers
 from routers import search_routers
 from setup_logger import setup_logger
+
+
+class EntryStatusChangeRequest(BaseModel):
+    """Used for"""
+
+    concept_identifier: int
+    requested_status: EntryStatus
+    comment: str | None = None
 
 
 def _parse_args() -> argparse.Namespace:

--- a/src/main.py
+++ b/src/main.py
@@ -24,8 +24,14 @@ from database.model.platform.platform_names import PlatformName
 from database.session import EngineSingleton, DbSession
 from database.setup import create_database, database_exists
 from error_handling import http_exception_handler
-from routers import resource_routers, parent_routers, enum_routers, uploader_routers
-from routers import search_routers
+from routers import (
+    resource_routers,
+    parent_routers,
+    enum_routers,
+    uploader_routers,
+    search_routers,
+    review_router,
+)
 from setup_logger import setup_logger
 
 
@@ -95,6 +101,7 @@ def add_routes(app: FastAPI, url_prefix=""):
         + enum_routers.router_list
         + search_routers.router_list
         + uploader_routers.router_list
+        + [review_router]
     ):
         app.include_router(router.create(url_prefix))
 

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -33,10 +33,11 @@ def _get_single_submission(
     *, which: Literal[ListMode.NEWEST, ListMode.OLDEST]
 ) -> Submission | None:
     with DbSession() as session:
+        has_review = select(1).where(Submission.identifier == Review.submission_identifier).exists()
         order = Submission.request_date
         if which == ListMode.NEWEST:
             order = Submission.request_date.desc()  # type: ignore[attr-defined]
-        query = select(Submission).order_by(order)
+        query = select(Submission).order_by(order).where(~has_review)
         return session.scalars(query).first()
 
 

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -1,3 +1,6 @@
+import enum
+from typing import Sequence
+
 from fastapi import APIRouter
 from sqlmodel import select
 
@@ -10,7 +13,7 @@ def create(url_prefix: str) -> APIRouter:
     version = "v1"
 
     router.get(
-        f"{url_prefix}/submissions/{version}",
+        f"{url_prefix}/submissions/{version}/",
         tags=["Reviewing"],
         description="List all assets submitted for review.",
     )(list_submissions)
@@ -18,7 +21,25 @@ def create(url_prefix: str) -> APIRouter:
     return router
 
 
-def list_submissions():
+class ListMode(enum.StrEnum):
+    OLDEST = enum.auto()
+    NEWEST = enum.auto()
+    ALL = enum.auto()
+    PENDING = enum.auto()
+    COMPLETED = enum.auto()
+
+
+def list_submissions(mode: ListMode = ListMode.NEWEST) -> Sequence[Submission]:
     with DbSession() as session:
-        submissions = select(Submission)
-        return session.scalars(submissions).first()
+        submissions = select(Submission).order_by(Submission.request_date)
+        match mode:
+            case ListMode.OLDEST:
+                return [session.scalars(submissions).first()]
+            case ListMode.ALL:
+                return session.scalars(submissions).all()
+            case ListMode.PENDING:
+                raise NotImplementedError()
+            case ListMode.COMPLETED:
+                raise NotImplementedError()
+            case _:
+                return [session.scalars(submissions).first()]

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -34,12 +34,18 @@ def list_submissions(mode: ListMode = ListMode.NEWEST) -> Sequence[Submission]:
         submissions = select(Submission).order_by(Submission.request_date)
         match mode:
             case ListMode.OLDEST:
-                return [session.scalars(submissions).first()]
+                rval = session.scalars(submissions).first()
             case ListMode.ALL:
-                return session.scalars(submissions).all()
+                rval = session.scalars(submissions).all()
             case ListMode.PENDING:
                 raise NotImplementedError()
             case ListMode.COMPLETED:
                 raise NotImplementedError()
             case _:
-                return [session.scalars(submissions).first()]
+                rval = session.scalars(submissions).first()
+
+    if rval is None:
+        return []
+    if not isinstance(rval, Sequence):
+        return [rval]
+    return rval

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -1,7 +1,8 @@
 import enum
+from http import HTTPStatus
 from typing import Sequence, Literal
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from sqlmodel import select
 
 from database.session import DbSession
@@ -18,6 +19,13 @@ def create(url_prefix: str) -> APIRouter:
         description="List all assets submitted for review.",
     )(list_submissions)
 
+    router.get(
+        f"{url_prefix}/submissions/{version}/{{identifier}}",
+        tags=["Reviewing"],
+        description="Retrieve a specific submission.",
+    )(get_submission)
+
+    # Add MiddleWare which requires authentication as reviewer role
     return router
 
 
@@ -61,3 +69,15 @@ def list_submissions(mode: ListMode = ListMode.NEWEST) -> Sequence[Submission]:
     if mode in [ListMode.PENDING, ListMode.COMPLETED]:
         return _get_submissions_by_state(which=mode)  # type: ignore[arg-type]
     raise ValueError(f"`mode` should be one of {ListMode!r} but is {mode!r}.")
+
+
+def get_submission(identifier: int) -> Submission:
+    with DbSession() as session:
+        query = select(Submission).where(Submission.identifier == identifier)
+        submission = session.scalars(query).first()
+    if submission:
+        return submission
+    raise HTTPException(
+        status_code=HTTPStatus.NOT_FOUND,
+        detail=f"No submission with identifier {identifier} found.",
+    )

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter
+from sqlmodel import select
+
+from database.session import DbSession
+from database.review import Submission
+
+
+def create(url_prefix: str) -> APIRouter:
+    router = APIRouter()
+    version = "v1"
+
+    router.get(
+        f"{url_prefix}/submissions/{version}",
+        tags=["Reviewing"],
+        description="List all assets submitted for review.",
+    )(list_submissions)
+
+    return router
+
+
+def list_submissions():
+    with DbSession() as session:
+        submissions = select(Submission)
+        return session.scalars(submissions).first()

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -1,11 +1,11 @@
 import enum
-from typing import Sequence
+from typing import Sequence, Literal
 
 from fastapi import APIRouter
 from sqlmodel import select
 
 from database.session import DbSession
-from database.review import Submission
+from database.review import Submission, Review
 
 
 def create(url_prefix: str) -> APIRouter:
@@ -29,23 +29,34 @@ class ListMode(enum.StrEnum):
     COMPLETED = enum.auto()
 
 
-def list_submissions(mode: ListMode = ListMode.NEWEST) -> Sequence[Submission]:
+def _get_single_submission(
+    *, which: Literal[ListMode.NEWEST, ListMode.OLDEST]
+) -> Submission | None:
     with DbSession() as session:
-        submissions = select(Submission).order_by(Submission.request_date)
-        match mode:
-            case ListMode.OLDEST:
-                rval = session.scalars(submissions).first()
-            case ListMode.ALL:
-                rval = session.scalars(submissions).all()
-            case ListMode.PENDING:
-                raise NotImplementedError()
-            case ListMode.COMPLETED:
-                raise NotImplementedError()
-            case _:
-                rval = session.scalars(submissions).first()
+        order = Submission.request_date
+        if which == ListMode.NEWEST:
+            order = Submission.request_date.desc()  # type: ignore[attr-defined]
+        query = select(Submission).order_by(order)
+        return session.scalars(query).first()
 
-    if rval is None:
-        return []
-    if not isinstance(rval, Sequence):
-        return [rval]
-    return rval
+
+def _get_submissions_by_state(
+    *, which: Literal[ListMode.COMPLETED, ListMode.PENDING]
+) -> Sequence[Submission]:
+    with DbSession() as session:
+        has_review = select(1).where(Submission.identifier == Review.submission_identifier).exists()
+        if which == ListMode.PENDING:
+            submissions = select(Submission).where(~has_review)
+        if which == ListMode.COMPLETED:
+            submissions = select(Submission).where(has_review)
+        return session.scalars(submissions).all()
+
+
+def list_submissions(mode: ListMode = ListMode.NEWEST) -> Sequence[Submission]:
+    # mypy does not do type narrowing properly: https://github.com/python/mypy/issues/12535
+    if mode in [ListMode.NEWEST, ListMode.OLDEST]:
+        submission = _get_single_submission(which=mode)  # type: ignore[arg-type]
+        return [submission] if submission else []
+    if mode in [ListMode.PENDING, ListMode.COMPLETED]:
+        return _get_submissions_by_state(which=mode)  # type: ignore[arg-type]
+    raise ValueError(f"`mode` should be one of {ListMode!r} but is {mode!r}.")

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -232,10 +232,7 @@ def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser, status: EntryS
         session.commit()
 
         register_user(owner, session)
-        try:
-            add_administrator(owner, asset, session)
-        except:  # noqa: E722
-            pass
+        add_administrator(owner, asset, session)
 
         asset.aiod_entry.status = status
         if status in [EntryStatus.SUBMITTED, EntryStatus.PUBLISHED, EntryStatus.REJECTED]:

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -158,6 +158,35 @@ def test_an_published_asset_is_not_pending_for_review(client, publication):
         assert len(queue.json()) == 1, "After publication, the review request is completed."
 
 
+def test_retrieving_single_submission_works(client, publication_factory):
+    publication = publication_factory()
+    oldest = publication_factory()
+    oldest.platform_resource_identifier = "OLDEST"
+    newest = publication_factory()
+    newest.platform_resource_identifier = "NEWEST"
+
+    register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
+    register_asset(oldest, owner=ALICE, status=EntryStatus.SUBMITTED)
+    register_asset(newest, owner=ALICE, status=EntryStatus.SUBMITTED)
+
+    with logged_in_user(REVIEWER):
+        queue = client.get(
+            f"/submissions/v1?mode={ListMode.OLDEST}", headers={"Authorization": "Fake token"}
+        )
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert (
+            queue.json()[0]["aiod_entry_identifier"] == 2
+        ), "The oldest pending submission is the second one."
+
+        queue = client.get(
+            f"/submissions/v1?mode={ListMode.NEWEST}", headers={"Authorization": "Fake token"}
+        )
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert (
+            queue.json()[0]["aiod_entry_identifier"] == 3
+        ), "The newest pending submission is the third one."
+
+
 def test_user_can_retract_assets(client, publication):
     identifier = register_asset(publication, owner=ALICE, status=EntryStatus.SUBMITTED)
     with logged_in_user(ALICE):
@@ -203,7 +232,10 @@ def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser, status: EntryS
         session.commit()
 
         register_user(owner, session)
-        add_administrator(owner, asset, session)
+        try:
+            add_administrator(owner, asset, session)
+        except:  # noqa: E722
+            pass
 
         asset.aiod_entry.status = status
         if status in [EntryStatus.SUBMITTED, EntryStatus.PUBLISHED, EntryStatus.REJECTED]:

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -13,7 +13,7 @@ from database.model.concept.aiod_entry import EntryStatus
 from database.model.concept.concept import AIoDConcept
 from database.review import Review, Decision, ReviewCreate, Submission
 from database.session import DbSession
-
+from routers.review_router import ListMode
 
 ALICE = KeycloakUser("Alice", {"edit_aiod_resources"}, "alice-sub")
 BOB = KeycloakUser("Bob", {"edit_aiod_resources"}, "bob-sub")
@@ -121,15 +121,58 @@ def test_user_can_not_submit_other_for_review(client, publication):
         assert len(queue.json()) == 0, "A rejected request should not result in a submission."
 
 
+def test_a_draft_is_not_pending_for_review(client, publication):
+    register_asset(publication, owner=ALICE, status=EntryStatus.DRAFT)
+
+    with logged_in_user(REVIEWER):
+        queue = client.get("/submissions/v1", headers={"Authorization": "Fake token"})
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert len(queue.json()) == 0, "An asset is only pending for review after submission."
+
+
+def test_a_submitted_asset_is_pending_for_review(client, publication):
+    register_asset(publication, owner=ALICE, status=EntryStatus.SUBMITTED)
+
+    with logged_in_user(REVIEWER):
+        queue = client.get("/submissions/v1", headers={"Authorization": "Fake token"})
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert len(queue.json()) == 1, "A submitted asset should be pending until a review is done."
+
+
+def test_an_published_asset_is_not_pending_for_review(client, publication):
+    register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
+
+    with logged_in_user(REVIEWER):
+        queue = client.get(
+            f"/submissions/v1?mode={ListMode.PENDING}", headers={"Authorization": "Fake token"}
+        )
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert (
+            len(queue.json()) == 0
+        ), "After publication, the submission is no longer pending a review."
+
+        queue = client.get(
+            f"/submissions/v1?mode={ListMode.COMPLETED}", headers={"Authorization": "Fake token"}
+        )
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert len(queue.json()) == 1, "After publication, the review request is completed."
+
+
 def test_user_can_retract_assets(client, publication):
     identifier = register_asset(publication, owner=ALICE, status=EntryStatus.SUBMITTED)
-
     with logged_in_user(ALICE):
         response = client.post(
             f"/publications/retract/v1/{identifier}", headers={"Authorization": "Fake token"}
         )
         assert "review_identifier" in response.json()
         assert Decision.RETRACTED == response.json()["decision"]
+
+    with logged_in_user(REVIEWER):
+        queue = client.get(
+            f"/submissions/v1?mode={ListMode.PENDING}", headers={"Authorization": "Fake token"}
+        )
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert len(queue.json()) == 0, "A retracted request should not remain pending."
 
 
 def test_other_user_can_not_retract_assets(client, publication):

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -98,6 +98,11 @@ def test_user_can_submit_draft_for_review(client, publication):
         assert submission.status_code == HTTPStatus.OK, submission.json()
         assert "submission_identifier" in submission.json()
 
+    with logged_in_user(REVIEWER):
+        queue = client.get("/submissions/v1", headers={"Authorization": "Fake token"})
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert len(queue.json()) == 1, queue.json()
+
 
 def test_user_can_not_submit_other_for_review(client, publication):
     identifier = register_asset(publication, owner=ALICE, status=EntryStatus.DRAFT)

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -101,7 +101,8 @@ def test_user_can_submit_draft_for_review(client, publication):
     with logged_in_user(REVIEWER):
         queue = client.get("/submissions/v1", headers={"Authorization": "Fake token"})
         assert queue.status_code == HTTPStatus.OK, queue.json()
-        assert len(queue.json()) == 1, queue.json()
+        assert len(queue.json()) == 1, "A successful request should result in a submission."
+        assert "requestee_identifier" not in queue.json()
 
 
 def test_user_can_not_submit_other_for_review(client, publication):
@@ -114,9 +115,15 @@ def test_user_can_not_submit_other_for_review(client, publication):
         )
         assert submission.status_code == HTTPStatus.FORBIDDEN, submission.json()
 
+    with logged_in_user(REVIEWER):
+        queue = client.get("/submissions/v1", headers={"Authorization": "Fake token"})
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert len(queue.json()) == 0, "A rejected request should not result in a submission."
+
 
 def test_user_can_retract_assets(client, publication):
     identifier = register_asset(publication, owner=ALICE, status=EntryStatus.SUBMITTED)
+
     with logged_in_user(ALICE):
         response = client.post(
             f"/publications/retract/v1/{identifier}", headers={"Authorization": "Fake token"}

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -139,6 +139,31 @@ def test_a_submitted_asset_is_pending_for_review(client, publication):
         assert len(queue.json()) == 1, "A submitted asset should be pending until a review is done."
 
 
+def test_get_submission_by_id(client, publication):
+    register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
+
+    with logged_in_user(REVIEWER):
+        queue = client.get("/submissions/v1/1", headers={"Authorization": "Fake token"})
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert queue.json()["identifier"] == 1
+
+
+def test_unknown_submission_raises_404(client):
+    with logged_in_user(REVIEWER):
+        queue = client.get("/submissions/v1/1", headers={"Authorization": "Fake token"})
+        assert queue.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.skip("Requiring reviewer role to be added through middleware")
+def test_getting_submission_requires_review_role(client):
+    queue = client.get("/submissions/v1/1")
+    assert queue.status_code == HTTPStatus.UNAUTHORIZED
+
+    with logged_in_user(ALICE):
+        queue = client.get("/submissions/v1/1", headers={"Authorization": "Fake token"})
+        assert queue.status_code == HTTPStatus.FORBIDDEN
+
+
 def test_an_published_asset_is_not_pending_for_review(client, publication):
     register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
 

--- a/src/tests/testutils/default_instances.py
+++ b/src/tests/testutils/default_instances.py
@@ -6,6 +6,8 @@ This way you have easy access to, for instance, an AIoDDataset filled with defau
 
 import copy
 import json
+from functools import partial
+from typing import Callable
 
 import pytest
 from sqlalchemy.engine import Engine
@@ -56,14 +58,23 @@ def body_agent(body_resource: dict) -> dict:
     return body
 
 
-@pytest.fixture
-def publication(body_asset: dict) -> Publication:
+def make_publication(body_asset: dict) -> Publication:
     body = copy.copy(body_asset)
     body["permanent_identifier"] = "http://dx.doi.org/10.1093/ajae/aaq063"
     body["isbn"] = "9783161484100"
     body["issn"] = "20493630"
     body["type"] = "journal"
     return _create_class_with_body(Publication, body)
+
+
+@pytest.fixture
+def publication(body_asset: dict) -> Publication:
+    return make_publication(body_asset)
+
+
+@pytest.fixture
+def publication_factory(body_asset: dict) -> Callable[[], Publication]:
+    return partial(make_publication, body_asset)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
Adds convenience functions for reviewers through a review router.
Reviewers can use its endpoints to either get a list of pending submission, or get a specific one.

In a follow up PR we will add conveniences for the user (getting review status for assets, let them read review notes)

## How to Test
<!-- Describe a way to test the change of this PR -->
If your keycloak instance lacks a reviewer account, make sure to recreate your kc:
```
./scripts/down.sh
./scripts/clean.sh
./scripts/up.sh
```
Keycloak then has both the regular user, as well as a reviewer user (username: reviewer, password: password).
You can submit a new asset for review as a regular user, and check, approve or reject the submission as a reviewer, and use the new endpoints to get insight into the pending/completed reviews.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


