### PR TITLE
Add any missing platforms on startup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -152,8 +152,9 @@ def build_database(args):
         for trigger in triggers:
             session.execute(trigger)
         existing_platforms = session.scalars(select(Platform)).all()
-        if not any(existing_platforms):
-            session.add_all([Platform(name=name) for name in PlatformName])
+        missing_platforms = set(PlatformName) - {p.name for p in existing_platforms}
+        if any(missing_platforms):
+            session.add_all([Platform(name=name) for name in missing_platforms])
             session.commit()
 
 


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
Now add any newly added platform to the database on startup.
Previously platforms would only be added if _no_ platforms existed.

## How to Test
<!-- Describe a way to test the change of this PR -->
Checkout e261d2b522e1b2b93793871b11d9009b40ade209, a commit before the aibuilder platform was added.
Create a clean database with that commit. This should result in aibuilder not being a platform in your database:
 `docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "select * from platform"`

Checkout develop and restart the containers (technically shouldn't be needed to restart due to reload), you will see that the aibuilder platform is not added to the database (command above) despite it being defined in PlatformNames.

Checkout this branch and reload/restart the container and try again, aibuilder should be added.

You can also see the effect of this if you try to run the aibuilder connector on develop branch without first having the aibuilder platform in the database: it will fail to register any models due to violating the foreign key constraint (aibuilder platform does not exist when creating the entry).

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
         - I am not sure how to test this in an automated way.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
         - I think this is expected behavior.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


