### PR TITLE
Feat/review with submission

### DIFF
--- a/src/database/review.py
+++ b/src/database/review.py
@@ -46,28 +46,32 @@ class ReviewCreate(BaseModel):
     )
 
 
-class Submission(SQLModel, table=True):  # type: ignore [call-arg]
+class SubmissionBase(SQLModel):
     """A review request, requested by a user to publish an asset/change."""
-
-    __tablename__ = "submission"
 
     identifier: int = Field(primary_key=True, default=None)
     request_date: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
+    # If the entry corresponding to the thing it reviews is removed,
+    # then we also want to permanently remove the review data.
+    aiod_entry_identifier: int = Field(foreign_key="aiod_entry.identifier", ondelete="CASCADE")
+
+
+class Submission(SubmissionBase, table=True):  # type: ignore [call-arg]
+    __tablename__ = "submission"
     # We do not want the review to be deleted when the original requestee is deleted,
     # there could be e.g., shared ownership in which case the review data should be preserved.
     requestee_identifier: str | None = Field(
         foreign_key="user.subject_identifier",
         ondelete="SET NULL",
-        exclude=True,
     )
-
-    # On the other hand, if the entry corresponding to the thing it reviews is removed,
-    # then we also want to permanently remove the review data.
-    aiod_entry_identifier: int = Field(foreign_key="aiod_entry.identifier", ondelete="CASCADE")
 
     reviews: list[Review] = Relationship(back_populates="submission")
 
     @property
     def is_pending(self):
         return len(self.reviews) < REQUIRED_NUMBER_OF_REVIEWS
+
+
+class SubmissionWithReviews(SubmissionBase):
+    reviews: list[Review] = Field(default_factory=list)

--- a/src/database/session.py
+++ b/src/database/session.py
@@ -41,12 +41,15 @@ def db_url(including_db=True):
 def DbSession(autoflush: bool = True) -> Session:
     """
     Returning a SQLModel session bound to the (configured) database engine.
-
-    Alternatively, we could have used FastAPI Depends, but that only works for FastAPI - while
-    the synchronization, for instance, also needs a Session, but doesn't use FastAPI.
+    For usage with FastAPI, use `get_session`.
     """
     session = Session(EngineSingleton().engine, autoflush=autoflush)
     try:
         yield session
     finally:
         session.close()
+
+
+def get_session():
+    with DbSession() as session:
+        yield session

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -2,11 +2,11 @@ import enum
 from http import HTTPStatus
 from typing import Sequence, Literal
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from sqlmodel import select
 
-from database.session import DbSession
-from database.review import Submission, Review
+from database.session import DbSession, get_session
+from database.review import Submission, Review, SubmissionWithReviews, SubmissionBase
 
 
 def create(url_prefix: str) -> APIRouter:
@@ -17,12 +17,14 @@ def create(url_prefix: str) -> APIRouter:
         f"{url_prefix}/submissions/{version}/",
         tags=["Reviewing"],
         description="List all assets submitted for review.",
+        response_model=Sequence[SubmissionBase],
     )(list_submissions)
 
     router.get(
         f"{url_prefix}/submissions/{version}/{{identifier}}",
         tags=["Reviewing"],
         description="Retrieve a specific submission.",
+        response_model=SubmissionWithReviews,
     )(get_submission)
 
     # Add MiddleWare which requires authentication as reviewer role
@@ -71,10 +73,9 @@ def list_submissions(mode: ListMode = ListMode.NEWEST) -> Sequence[Submission]:
     raise ValueError(f"`mode` should be one of {ListMode!r} but is {mode!r}.")
 
 
-def get_submission(identifier: int) -> Submission:
-    with DbSession() as session:
-        query = select(Submission).where(Submission.identifier == identifier)
-        submission = session.scalars(query).first()
+def get_submission(identifier: int, session=Depends(get_session)) -> Submission:
+    query = select(Submission).where(Submission.identifier == identifier)
+    submission = session.scalars(query).first()
     if submission:
         return submission
     raise HTTPException(

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -138,14 +138,30 @@ def test_a_submitted_asset_is_pending_for_review(client, publication):
         assert queue.status_code == HTTPStatus.OK, queue.json()
         assert len(queue.json()) == 1, "A submitted asset should be pending until a review is done."
 
-
 def test_get_submission_by_id(client, publication):
     register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
 
     with logged_in_user(REVIEWER):
-        queue = client.get("/submissions/v1/1", headers={"Authorization": "Fake token"})
-        assert queue.status_code == HTTPStatus.OK, queue.json()
-        assert queue.json()["identifier"] == 1
+        submission = client.get("/submissions/v1/1", headers={"Authorization": "Fake token"})
+        assert submission.status_code == HTTPStatus.OK, submission.json()
+
+        submission_dict = submission.json()
+        submission_date = submission_dict.pop("request_date")
+        review_date = submission_dict["reviews"][0].pop("decision_date")
+        assert submission_date < review_date
+        assert submission_dict == {
+            "identifier": 1,
+            "aiod_entry_identifier": 1,
+            "reviews": [
+                {
+                    "identifier": 1,
+                    "decision": "accepted",
+                    "comment": "foo",
+                    "submission_identifier": 1,
+                }
+            ],
+        }
+
 
 
 def test_unknown_submission_raises_404(client):
@@ -271,6 +287,7 @@ def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser, status: EntryS
                 review = Review(
                     decision=Decision.ACCEPTED,
                     reviewer_identifier=REVIEWER._subject_identifier,
+                    comment="foo",
                 )
                 review.submission = submission
                 session.add(review)


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
When retrieving a submission by ID its reviews will also be returned.
I abstained from also adding it to the listing endpoint which returns multiple submissions.
I figured the main purpose for those calls is to find submissions which need a review, so it felt unnecessary.
We can easily add it later if it turns out to be used in use cases where people want the review too.

## How to Test
<!-- Describe a way to test the change of this PR -->
A new unit test is introduced that covers this.
To test it manually, process an asset through the review pipeline, and then request the submission using the `submissions/v1/{identifier}` endpoint.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained. -> Documentation is auto-generated. Doesn't seem to warrant a mention in the general docs.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->

Closes #457 

