### PR TITLE
Remove unnecessary "conflict" with resource.py:AIResourceBase

### DIFF
--- a/src/database/model/ai_resource/resource_table.py
+++ b/src/database/model/ai_resource/resource_table.py
@@ -17,11 +17,7 @@ class AIResourceRelevantLink(SQLModel, table=True):  # type: ignore [call-arg]
     relevant_identifier: int = Field(foreign_key="ai_resource.identifier", primary_key=True)
 
 
-class AIResourceBase(SQLModel):
-    pass
-
-
-class AIResourceORM(AIResourceBase, table=True):  # type: ignore [call-arg]
+class AIResourceORM(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "ai_resource"
     identifier: int = Field(default=None, primary_key=True)
     type: str = Field(default="will be overwritten by resource_router")


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
This definition was never used independently of its child class, and created confusion through using the same name as a different often used [class defined in resource.py](https://github.com/aiondemand/AIOD-rest-api/blob/1a38d7dc09d902d2a38ec2022f00ab70da43343d/src/database/model/ai_resource/resource.py#L40)

## How to Test
<!-- Describe a way to test the change of this PR -->
Covered by unit test, just check the diff.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


