### PR TITLE
Rename AbstractAIResource to AIResource to match naming convention

### DIFF
--- a/src/database/model/agent/agent.py
+++ b/src/database/model/agent/agent.py
@@ -4,7 +4,7 @@ from sqlmodel import Field, Relationship
 
 from database.model.agent.agent_table import AgentTable
 from database.model.ai_resource.resource import AIResourceBase
-from database.model.ai_resource.resource import AbstractAIResource
+from database.model.ai_resource.resource import AIResource
 from database.model.relationships import OneToOne
 from database.model.serializers import AttributeSerializer
 
@@ -17,7 +17,7 @@ class AgentBase(AIResourceBase):
     """
 
 
-class Agent(AgentBase, AbstractAIResource):
+class Agent(AgentBase, AIResource):
     agent_id: int | None = Field(foreign_key=AgentTable.__tablename__ + ".identifier", index=True)
     agent_identifier: AgentTable | None = Relationship()
 
@@ -32,7 +32,7 @@ class Agent(AgentBase, AbstractAIResource):
         cls.update_relationships(relationships)
         cls.__sqlmodel_relationships__.update(relationships)
 
-    class RelationshipConfig(AbstractAIResource.RelationshipConfig):
+    class RelationshipConfig(AIResource.RelationshipConfig):
         agent_identifier: int | None = OneToOne(
             identifier_name="agent_id",
             _serializer=AttributeSerializer("identifier"),

--- a/src/database/model/agent/agent.py
+++ b/src/database/model/agent/agent.py
@@ -3,8 +3,7 @@ import copy
 from sqlmodel import Field, Relationship
 
 from database.model.agent.agent_table import AgentTable
-from database.model.ai_resource.resource import AIResourceBase
-from database.model.ai_resource.resource import AIResource
+from database.model.ai_resource.resource import AIResourceBase, AIResource
 from database.model.relationships import OneToOne
 from database.model.serializers import AttributeSerializer
 

--- a/src/database/model/agent/team.py
+++ b/src/database/model/agent/team.py
@@ -5,8 +5,7 @@ from sqlmodel import Field, Relationship
 
 from database.model.agent.organisation import Organisation
 from database.model.agent.person import Person
-from database.model.ai_resource.resource import AIResourceBase
-from database.model.ai_resource.resource import AIResource
+from database.model.ai_resource.resource import AIResourceBase, AIResource
 from database.model.helper_functions import many_to_many_link_factory
 from database.model.relationships import ManyToOne, ManyToMany
 from database.model.serializers import AttributeSerializer, FindByIdentifierDeserializerList

--- a/src/database/model/agent/team.py
+++ b/src/database/model/agent/team.py
@@ -6,7 +6,7 @@ from sqlmodel import Field, Relationship
 from database.model.agent.organisation import Organisation
 from database.model.agent.person import Person
 from database.model.ai_resource.resource import AIResourceBase
-from database.model.ai_resource.resource import AbstractAIResource
+from database.model.ai_resource.resource import AIResource
 from database.model.helper_functions import many_to_many_link_factory
 from database.model.relationships import ManyToOne, ManyToMany
 from database.model.serializers import AttributeSerializer, FindByIdentifierDeserializerList
@@ -25,7 +25,7 @@ class TeamBase(AIResourceBase):
     )
 
 
-class Team(TeamBase, AbstractAIResource, table=True):  # type: ignore [call-arg]
+class Team(TeamBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "team"
 
     organisation_identifier: int | None = Field(
@@ -36,7 +36,7 @@ class Team(TeamBase, AbstractAIResource, table=True):  # type: ignore [call-arg]
         link_model=many_to_many_link_factory("team", Person.__tablename__, "member"),
     )
 
-    class RelationshipConfig(AbstractAIResource.RelationshipConfig):
+    class RelationshipConfig(AIResource.RelationshipConfig):
         organisation: int | None = ManyToOne(
             description="The organisation of which this team is a part.",
             identifier_name="organisation_identifier",

--- a/src/database/model/ai_asset/ai_asset.py
+++ b/src/database/model/ai_asset/ai_asset.py
@@ -8,7 +8,7 @@ from sqlmodel import Field, Relationship
 from database.model.ai_asset.ai_asset_table import AIAssetTable
 from database.model.ai_asset.distribution import Distribution, distribution_factory
 from database.model.ai_asset.license import License
-from database.model.ai_resource.resource import AIResourceBase, AbstractAIResource
+from database.model.ai_resource.resource import AIResourceBase, AIResource
 from database.model.field_length import NORMAL
 from database.model.helper_functions import many_to_many_link_factory
 from database.model.models_and_experiments.runnable_distribution import (
@@ -37,7 +37,7 @@ class AIAssetBase(AIResourceBase, metaclass=abc.ABCMeta):
     )
 
 
-class AIAsset(AIAssetBase, AbstractAIResource, metaclass=abc.ABCMeta):
+class AIAsset(AIAssetBase, AIResource, metaclass=abc.ABCMeta):
     ai_asset_id: int | None = Field(
         foreign_key=AIAssetTable.__tablename__ + ".identifier", unique=True, index=True
     )
@@ -61,7 +61,7 @@ class AIAsset(AIAssetBase, AbstractAIResource, metaclass=abc.ABCMeta):
             cls.update_relationships_asset(relationships)
         cls.__sqlmodel_relationships__.update(relationships)
 
-    class RelationshipConfig(AbstractAIResource.RelationshipConfig):
+    class RelationshipConfig(AIResource.RelationshipConfig):
         ai_asset_identifier: int | None = OneToOne(
             identifier_name="ai_asset_id",
             _serializer=AttributeSerializer("identifier"),

--- a/src/database/model/ai_resource/resource.py
+++ b/src/database/model/ai_resource/resource.py
@@ -57,7 +57,7 @@ class AIResourceBase(AIoDConceptBase, metaclass=abc.ABCMeta):
     )
 
 
-class AbstractAIResource(AIResourceBase, AIoDConcept, metaclass=abc.ABCMeta):
+class AIResource(AIResourceBase, AIoDConcept, metaclass=abc.ABCMeta):
     ai_resource_id: int | None = Field(
         foreign_key="ai_resource.identifier", index=True, unique=True
     )
@@ -87,8 +87,8 @@ class AbstractAIResource(AIResourceBase, AIoDConcept, metaclass=abc.ABCMeta):
         The latter cannot be done in the class variables, because it depends on the table-name of
         the child class.
         """
-        cls.__annotations__.update(AbstractAIResource.__annotations__)
-        relationships = copy.deepcopy(AbstractAIResource.__sqlmodel_relationships__)
+        cls.__annotations__.update(AIResource.__annotations__)
+        relationships = copy.deepcopy(AIResource.__sqlmodel_relationships__)
         is_not_abstract = cls.__tablename__ not in ("aiasset", "agent", "knowledgeasset")
         if is_not_abstract:
             cls.update_relationships(relationships)
@@ -117,7 +117,7 @@ class AbstractAIResource(AIResourceBase, AIoDConcept, metaclass=abc.ABCMeta):
             default_factory_pydantic=list,
             on_delete_trigger_orphan_deletion=lambda: [
                 f"{a.__tablename__}_alternate_name_link"
-                for a in non_abstract_subclasses(AbstractAIResource)
+                for a in non_abstract_subclasses(AIResource)
             ],
         )
         keyword: list[str] = ManyToMany(
@@ -128,8 +128,7 @@ class AbstractAIResource(AIResourceBase, AIoDConcept, metaclass=abc.ABCMeta):
             example=["keyword1", "keyword2"],
             default_factory_pydantic=list,
             on_delete_trigger_orphan_deletion=lambda: [
-                f"{a.__tablename__}_keyword_link"
-                for a in non_abstract_subclasses(AbstractAIResource)
+                f"{a.__tablename__}_keyword_link" for a in non_abstract_subclasses(AIResource)
             ],
         )
         relevant_link: list[str] = ManyToMany(
@@ -144,8 +143,7 @@ class AbstractAIResource(AIResourceBase, AIoDConcept, metaclass=abc.ABCMeta):
             ],
             default_factory_pydantic=list,
             on_delete_trigger_orphan_deletion=lambda: [
-                f"{a.__tablename__}_relevant_link_link"
-                for a in non_abstract_subclasses(AbstractAIResource)
+                f"{a.__tablename__}_relevant_link_link" for a in non_abstract_subclasses(AIResource)
             ],
         )
         application_area: list[str] = ManyToMany(

--- a/src/database/model/educational_resource/educational_resource.py
+++ b/src/database/model/educational_resource/educational_resource.py
@@ -3,7 +3,7 @@ from sqlmodel import Field, Relationship
 
 from database.model.agent.language import Language
 from database.model.agent.location import Location, LocationORM
-from database.model.ai_resource.resource import AbstractAIResource, AIResourceBase
+from database.model.ai_resource.resource import AIResource, AIResourceBase
 from database.model.ai_resource.text import TextORM, Text
 from database.model.educational_resource.access_mode import AccessMode
 from database.model.educational_resource.educational_level import EducationalLevel
@@ -32,7 +32,7 @@ class EducationalResourceBase(AIResourceBase):
     )
 
 
-class EducationalResource(EducationalResourceBase, AbstractAIResource, table=True):  # type: ignore [call-arg]
+class EducationalResource(EducationalResourceBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "educational_resource"
 
     type_identifier: int | None = Field(
@@ -78,7 +78,7 @@ class EducationalResource(EducationalResourceBase, AbstractAIResource, table=Tru
         )
     )
 
-    class RelationshipConfig(AbstractAIResource.RelationshipConfig):
+    class RelationshipConfig(AIResource.RelationshipConfig):
         type: Optional[str] = ManyToOne(
             description="The type of educational resource.",
             identifier_name="type_identifier",

--- a/src/database/model/event/event.py
+++ b/src/database/model/event/event.py
@@ -5,7 +5,7 @@ from sqlmodel import Field, Relationship
 
 from database.model.agent.agent_table import AgentTable
 from database.model.agent.location import LocationORM, Location
-from database.model.ai_resource.resource import AIResourceBase, AbstractAIResource
+from database.model.ai_resource.resource import AIResourceBase, AIResource
 from database.model.ai_resource.text import TextORM, Text
 from database.model.event.event_mode import EventMode
 from database.model.event.event_status import EventStatus
@@ -49,7 +49,7 @@ class EventBase(AIResourceBase):
     # Did not add duration here: it can be described using start_date and end_date
 
 
-class Event(EventBase, AbstractAIResource, table=True):  # type: ignore [call-arg]
+class Event(EventBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "event"
 
     content_identifier: int | None = Field(
@@ -74,7 +74,7 @@ class Event(EventBase, AbstractAIResource, table=True):  # type: ignore [call-ar
     mode_identifier: int | None = Field(foreign_key=EventMode.__tablename__ + ".identifier")
     mode: Optional[EventMode] = Relationship()
 
-    class RelationshipConfig(AbstractAIResource.RelationshipConfig):
+    class RelationshipConfig(AIResource.RelationshipConfig):
         content: Optional[Text] = OneToOne(
             deserializer=CastDeserializer(TextORM),
             on_delete_trigger_deletion_by="content_identifier",

--- a/src/database/model/news/news.py
+++ b/src/database/model/news/news.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from sqlmodel import Field, Relationship
 
-from database.model.ai_resource.resource import AbstractAIResource, AIResourceBase
+from database.model.ai_resource.resource import AIResource, AIResourceBase
 from database.model.ai_resource.text import TextORM, Text
 from database.model.field_length import NORMAL, LONG
 from database.model.helper_functions import many_to_many_link_factory
@@ -35,7 +35,7 @@ class NewsBase(AIResourceBase):
     )
 
 
-class News(NewsBase, AbstractAIResource, table=True):  # type: ignore [call-arg]
+class News(NewsBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "news"
 
     category: list[NewsCategory] = Relationship(
@@ -51,7 +51,7 @@ class News(NewsBase, AbstractAIResource, table=True):  # type: ignore [call-arg]
         sa_relationship_kwargs=dict(foreign_keys="[News.content_identifier]")
     )
 
-    class RelationshipConfig(AbstractAIResource.RelationshipConfig):
+    class RelationshipConfig(AIResource.RelationshipConfig):
         category: list[str] = ManyToMany(
             description="News categories related to this item.",
             _serializer=AttributeSerializer("name"),

--- a/src/database/model/project/project.py
+++ b/src/database/model/project/project.py
@@ -6,8 +6,7 @@ from sqlmodel import Field, Relationship
 
 from database.model.agent.organisation import Organisation
 from database.model.ai_asset.ai_asset_table import AIAssetTable
-from database.model.ai_resource.resource import AIResourceBase
-from database.model.ai_resource.resource import AIResource
+from database.model.ai_resource.resource import AIResourceBase, AIResource
 from database.model.helper_functions import many_to_many_link_factory
 from database.model.relationships import ManyToMany, ManyToOne
 from database.model.serializers import (

--- a/src/database/model/project/project.py
+++ b/src/database/model/project/project.py
@@ -7,7 +7,7 @@ from sqlmodel import Field, Relationship
 from database.model.agent.organisation import Organisation
 from database.model.ai_asset.ai_asset_table import AIAssetTable
 from database.model.ai_resource.resource import AIResourceBase
-from database.model.ai_resource.resource import AbstractAIResource
+from database.model.ai_resource.resource import AIResource
 from database.model.helper_functions import many_to_many_link_factory
 from database.model.relationships import ManyToMany, ManyToOne
 from database.model.serializers import (
@@ -34,7 +34,7 @@ class ProjectBase(AIResourceBase):
     )
 
 
-class Project(ProjectBase, AbstractAIResource, table=True):  # type: ignore [call-arg]
+class Project(ProjectBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "project"
 
     funder: list[Organisation] = Relationship(
@@ -62,7 +62,7 @@ class Project(ProjectBase, AbstractAIResource, table=True):  # type: ignore [cal
         ),
     )
 
-    class RelationshipConfig(AbstractAIResource.RelationshipConfig):
+    class RelationshipConfig(AIResource.RelationshipConfig):
         funder: list[int] = ManyToMany(
             description="Identifiers of organizations that support this project through some kind "
             "of financial contribution. ",

--- a/src/database/model/service/service.py
+++ b/src/database/model/service/service.py
@@ -1,6 +1,6 @@
 from sqlmodel import Field
 
-from database.model.ai_resource.resource import AIResourceBase, AbstractAIResource
+from database.model.ai_resource.resource import AIResourceBase, AIResource
 from database.model.field_length import NORMAL, LONG
 
 
@@ -21,8 +21,8 @@ class ServiceBase(AIResourceBase):
     )
 
 
-class Service(ServiceBase, AbstractAIResource, table=True):  # type: ignore [call-arg]
+class Service(ServiceBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "service"
 
-    class RelationshipConfig(AbstractAIResource.RelationshipConfig):
+    class RelationshipConfig(AIResource.RelationshipConfig):
         pass

--- a/src/routers/parent_routers/ai_resource_router.py
+++ b/src/routers/parent_routers/ai_resource_router.py
@@ -1,6 +1,6 @@
 from typing import Type
 
-from database.model.ai_resource.resource import AbstractAIResource
+from database.model.ai_resource.resource import AIResource
 from database.model.ai_resource.resource_table import AIResourceORM
 from routers.parent_router import ParentRouter
 
@@ -15,8 +15,8 @@ class AIResourceRouter(ParentRouter):
         return "ai_resources"
 
     @property
-    def parent_class(self) -> Type[AbstractAIResource]:
-        return AbstractAIResource
+    def parent_class(self) -> Type[AIResource]:
+        return AIResource
 
     @property
     def parent_class_table(self) -> Type[AIResourceORM]:

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -16,7 +16,7 @@ from authentication import KeycloakUser, get_user_or_none, get_user_or_raise
 from config import KEYCLOAK_CONFIG
 from converters.schema_converters.schema_converter import SchemaConverter
 from database.authorization import user_can_administer, add_administrator, register_user
-from database.model.ai_resource.resource import AbstractAIResource
+from database.model.ai_resource.resource import AIResource
 from database.model.concept.aiod_entry import AIoDEntryORM, EntryStatus
 from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
@@ -32,7 +32,7 @@ from dependencies.filtering import ResourceFilters, ResourceFiltersParams
 from dependencies.pagination import Pagination, PaginationParams
 from error_handling import as_http_exception
 
-RESOURCE = TypeVar("RESOURCE", bound=AbstractAIResource)
+RESOURCE = TypeVar("RESOURCE", bound=AIResource)
 RESOURCE_CREATE = TypeVar("RESOURCE_CREATE", bound=SQLModel)
 RESOURCE_READ = TypeVar("RESOURCE_READ", bound=SQLModel)
 RESOURCE_MODEL = TypeVar("RESOURCE_MODEL", bound=SQLModel)


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
All other classes which define the (database) relationships are just named after their conceptual model's counterpart, e.g., AIoDConcept, AIAsset, Publication. This seems to be the exception with no apparent reason. Changing the name to match the convention of the rest of the project should make it easier to understand the role of the class.

## How to Test
<!-- Describe a way to test the change of this PR -->
Covered by CI. Can check the diff, renaming was done through IDE.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


