### PR TITLE
Share common definitions in Review and ReviewCreate

### DIFF
--- a/src/database/review.py
+++ b/src/database/review.py
@@ -6,6 +6,7 @@ from pydantic.main import BaseModel
 from sqlalchemy import Column
 from sqlmodel import SQLModel, Field, Relationship
 
+from database.model.field_length import NORMAL, LONG
 
 REQUIRED_NUMBER_OF_REVIEWS = 1
 
@@ -16,34 +17,37 @@ class Decision(enum.StrEnum):
     RETRACTED = enum.auto()
 
 
-class Review(SQLModel, table=True):  # type: ignore [call-arg]
+class ReviewBase(SQLModel):
     """A review (which may be pending), requested by a user to publish an asset/change."""
 
+    comment: str = Field(
+        description="Motivation for the decision.",
+        max_length=LONG,
+        default="",
+        schema_extra={"example": "The organization's contact information is invalid."},
+    )
+    decision: Decision = Field(
+        description="The decision made by the reviewer.",
+        sa_column=Column(sqlalchemy.Enum(Decision)),
+    )
+    submission_identifier: int = Field(
+        description="The identifier of the submission (review request)."
+    )
+
+
+class ReviewCreate(ReviewBase):
+    pass
+
+
+class Review(ReviewBase, table=True):  # type: ignore [call-arg]
     __tablename__ = "review"
 
     identifier: int = Field(primary_key=True, default=None)
     decision_date: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
-    # Not sure if size should be limited, especially if we want to use this for structured data.
-    comment: str | None = Field()
-    decision: Decision = Field(sa_column=Column(sqlalchemy.Enum(Decision)))
-
-    reviewer_identifier: str = Field(
-        foreign_key="user.subject_identifier",
-        exclude=True,
-    )
-    submission_identifier: int = Field(
-        foreign_key="submission.identifier",
-    )
+    reviewer_identifier: str = Field(foreign_key="user.subject_identifier", exclude=True)
+    submission_identifier: int = Field(foreign_key="submission.identifier")
     submission: "Submission" = Relationship(back_populates="reviews")
-
-
-class ReviewCreate(BaseModel):
-    comment: str | None = Field(description="Motivation for the decision.")
-    decision: Decision = Field(description="The decision made by the reviewer.")
-    submission_identifier: int = Field(
-        description="The identifier of the submission (review request)."
-    )
 
 
 class SubmissionBase(SQLModel):
@@ -51,6 +55,12 @@ class SubmissionBase(SQLModel):
 
     identifier: int = Field(primary_key=True, default=None)
     request_date: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    comment: str = Field(
+        description="A subdivision of the country. Not necessary for most countries. ",
+        max_length=NORMAL,
+        default="",
+        schema_extra={"example": "California"},
+    )
 
     # If the entry corresponding to the thing it reviews is removed,
     # then we also want to permanently remove the review data.

--- a/src/database/review.py
+++ b/src/database/review.py
@@ -2,7 +2,6 @@ import enum
 from datetime import datetime, timezone
 
 import sqlalchemy
-from pydantic.main import BaseModel
 from sqlalchemy import Column
 from sqlmodel import SQLModel, Field, Relationship
 
@@ -50,17 +49,22 @@ class Review(ReviewBase, table=True):  # type: ignore [call-arg]
     submission: "Submission" = Relationship(back_populates="reviews")
 
 
-class SubmissionBase(SQLModel):
+class SubmissionCreate(SQLModel):
+    """User provided information to submit a review request."""
+
+    comment: str = Field(
+        description="Optional. Comment to the reviewer to motivate the submission or provide clarification.",
+        max_length=NORMAL,
+        default="",
+        schema_extra={"example": "'IA' is not a typo, it's for L'intelligence artificielle."},
+    )
+
+
+class SubmissionBase(SubmissionCreate):
     """A review request, requested by a user to publish an asset/change."""
 
     identifier: int = Field(primary_key=True, default=None)
     request_date: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    comment: str = Field(
-        description="A subdivision of the country. Not necessary for most countries. ",
-        max_length=NORMAL,
-        default="",
-        schema_extra={"example": "California"},
-    )
 
     # If the entry corresponding to the thing it reviews is removed,
     # then we also want to permanently remove the review data.

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -26,7 +26,7 @@ from database.model.resource_read_and_create import (
     resource_read,
 )
 from database.model.serializers import deserialize_resource_relationships
-from database.review import Decision, Review, Submission, ReviewCreate
+from database.review import Decision, Review, Submission, ReviewCreate, SubmissionCreate
 from database.session import DbSession
 from dependencies.filtering import ResourceFilters, ResourceFiltersParams
 from dependencies.pagination import Pagination, PaginationParams
@@ -544,6 +544,7 @@ class ResourceRouter(abc.ABC):
 
         def submit_resource(
             identifier: str,
+            submission: SubmissionCreate | None = None,
             user: KeycloakUser = Depends(get_user_or_raise),
         ):
             with DbSession() as session:
@@ -565,6 +566,7 @@ class ResourceRouter(abc.ABC):
                 review_request = Submission(
                     requestee_identifier=user._subject_identifier,
                     aiod_entry_identifier=resource.aiod_entry.identifier,
+                    comment=submission.comment if submission else "",
                 )
                 session.add(review_request)
                 session.commit()

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -152,6 +152,7 @@ def test_get_submission_by_id(client, publication):
         assert submission_dict == {
             "identifier": 1,
             "aiod_entry_identifier": 1,
+            "comment": "",
             "reviews": [
                 {
                     "identifier": 1,

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -88,12 +88,18 @@ def test_drafts_are_private(
     # with and without authentication
 
 
-def test_user_can_submit_draft_for_review(client, publication):
+@pytest.mark.parametrize(
+    "comment", [None, "foo"]
+)
+def test_user_can_submit_draft_for_review(comment, client, publication):
     identifier = register_asset(publication, owner=ALICE, status=EntryStatus.DRAFT)
+    content = f'{{"comment": "{comment}"}}' if comment else None
+
     with logged_in_user(ALICE):
         submission = client.post(
             f"/publications/submit/v1/{identifier}",
             headers={"Authorization": "Fake token"},
+            content=content,
         )
         assert submission.status_code == HTTPStatus.OK, submission.json()
         assert "submission_identifier" in submission.json()
@@ -102,7 +108,9 @@ def test_user_can_submit_draft_for_review(client, publication):
         queue = client.get("/submissions/v1", headers={"Authorization": "Fake token"})
         assert queue.status_code == HTTPStatus.OK, queue.json()
         assert len(queue.json()) == 1, "A successful request should result in a submission."
-        assert "requestee_identifier" not in queue.json()
+        [sub] = queue.json()
+        assert "requestee_identifier" not in sub, "Submissions should not review who submitted."
+        assert sub["comment"] == (comment if comment else ""), "Comment should be stored."
 
 
 def test_user_can_not_submit_other_for_review(client, publication):


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
Refactor class hierarchy to allow Review and ReviewCreate share common definitions, s.t. we only need to define examples or limits once.
Also limit the maximum length of review to `LONG` (1800 chars).
I think that should be enough for most asset reviews, and it's easier to expand the limit than to shrink it.

## How to Test
<!-- Describe a way to test the change of this PR -->
Changes are under unit test. Affected endpoints is `RESOURCE/review/v1/` if you want to manually test or inspect updated documentation.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


