### PR TITLE
Add authentication checks to avoid leaking submission data

### DIFF
--- a/src/authentication.py
+++ b/src/authentication.py
@@ -57,6 +57,10 @@ class KeycloakUser:
     def has_any_role(self, *roles: str) -> bool:
         return bool(set(roles) & self.roles)
 
+    @property
+    def is_reviewer(self):
+        return "reviewer" in self.roles
+
 
 async def _get_user(token) -> KeycloakUser:
     """

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -631,7 +631,7 @@ class ResourceRouter(abc.ABC):
             review: ReviewCreate,
             user: KeycloakUser = Depends(get_user_or_raise),
         ):
-            if "reviewer" not in user.roles:
+            if not user.is_reviewer:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="You must have reviewing privileges to use this endpoint.",

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -3,8 +3,9 @@ from http import HTTPStatus
 from typing import Sequence, Literal
 
 from fastapi import APIRouter, HTTPException, Depends
-from sqlmodel import select
+from sqlmodel import select, Session
 
+from authentication import KeycloakUser, get_user_or_raise
 from database.session import DbSession, get_session
 from database.review import Submission, Review, SubmissionView, SubmissionBase
 
@@ -40,19 +41,26 @@ class ListMode(enum.StrEnum):
 
 
 def _get_single_submission(
-    *, which: Literal[ListMode.NEWEST, ListMode.OLDEST]
+    *,
+    which: Literal[ListMode.NEWEST, ListMode.OLDEST],
+    from_requestee: str | None = None,
 ) -> Submission | None:
     with DbSession() as session:
         has_review = select(1).where(Submission.identifier == Review.submission_identifier).exists()
-        order = Submission.request_date
+        query = select(Submission).where(~has_review)
+
         if which == ListMode.NEWEST:
-            order = Submission.request_date.desc()  # type: ignore[attr-defined]
-        query = select(Submission).order_by(order).where(~has_review)
+            query = query.order_by(Submission.request_date.desc())  # type: ignore[attr-defined]
+        if from_requestee is not None:
+            query = query.where(Submission.requestee_identifier == from_requestee)
+
         return session.scalars(query).first()
 
 
 def _get_submissions_by_state(
-    *, which: Literal[ListMode.COMPLETED, ListMode.PENDING]
+    *,
+    which: Literal[ListMode.COMPLETED, ListMode.PENDING],
+    from_requestee: str | None = None,
 ) -> Sequence[Submission]:
     with DbSession() as session:
         has_review = select(1).where(Submission.identifier == Review.submission_identifier).exists()
@@ -60,25 +68,39 @@ def _get_submissions_by_state(
             submissions = select(Submission).where(~has_review)
         if which == ListMode.COMPLETED:
             submissions = select(Submission).where(has_review)
+        if from_requestee is not None:
+            submissions = submissions.where(Submission.requestee_identifier == from_requestee)
         return session.scalars(submissions).all()
 
 
-def list_submissions(mode: ListMode = ListMode.NEWEST) -> Sequence[Submission]:
+def list_submissions(
+    mode: ListMode = ListMode.NEWEST, user: KeycloakUser = Depends(get_user_or_raise)
+) -> Sequence[Submission]:
     # mypy does not do type narrowing properly: https://github.com/python/mypy/issues/12535
+    user_filter = None if "reviewer" in user.roles else user._subject_identifier
     if mode in [ListMode.NEWEST, ListMode.OLDEST]:
-        submission = _get_single_submission(which=mode)  # type: ignore[arg-type]
+        submission = _get_single_submission(which=mode, from_requestee=user_filter)  # type: ignore[arg-type]
         return [submission] if submission else []
     if mode in [ListMode.PENDING, ListMode.COMPLETED]:
-        return _get_submissions_by_state(which=mode)  # type: ignore[arg-type]
+        return _get_submissions_by_state(which=mode, from_requestee=user_filter)  # type: ignore[arg-type]
     raise ValueError(f"`mode` should be one of {ListMode!r} but is {mode!r}.")
 
 
-def get_submission(identifier: int, session=Depends(get_session)) -> Submission:
+def get_submission(
+    identifier: int,
+    user: KeycloakUser = Depends(get_user_or_raise),
+    session: Session = Depends(get_session),
+) -> Submission:
     query = select(Submission).where(Submission.identifier == identifier)
     submission = session.scalars(query).first()
-    if submission:
-        return submission
-    raise HTTPException(
-        status_code=HTTPStatus.NOT_FOUND,
-        detail=f"No submission with identifier {identifier} found.",
-    )
+    if not submission:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"No submission with identifier {identifier} found.",
+        )
+    if "reviewer" not in user.roles and submission.requestee_identifier != user._subject_identifier:
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN,
+            detail=f"You do not have permission to view submission with identifier {identifier}.",
+        )
+    return submission

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -28,7 +28,6 @@ def create(url_prefix: str) -> APIRouter:
         response_model=SubmissionView,
     )(get_submission)
 
-    # Add MiddleWare which requires authentication as reviewer role
     return router
 
 
@@ -77,7 +76,7 @@ def list_submissions(
     mode: ListMode = ListMode.NEWEST, user: KeycloakUser = Depends(get_user_or_raise)
 ) -> Sequence[Submission]:
     # mypy does not do type narrowing properly: https://github.com/python/mypy/issues/12535
-    user_filter = None if "reviewer" in user.roles else user._subject_identifier
+    user_filter = None if user.is_reviewer else user._subject_identifier
     if mode in [ListMode.NEWEST, ListMode.OLDEST]:
         submission = _get_single_submission(which=mode, from_requestee=user_filter)  # type: ignore[arg-type]
         return [submission] if submission else []
@@ -98,7 +97,7 @@ def get_submission(
             status_code=HTTPStatus.NOT_FOUND,
             detail=f"No submission with identifier {identifier} found.",
         )
-    if "reviewer" not in user.roles and submission.requestee_identifier != user._subject_identifier:
+    if not user.is_reviewer and submission.requestee_identifier != user._subject_identifier:
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN,
             detail=f"You do not have permission to view submission with identifier {identifier}.",

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from unittest.mock import Mock
 
 import pytest
+from starlette.testclient import TestClient
 
 from authentication import keycloak_openid, KeycloakUser
 from database.authorization import (
@@ -178,6 +179,21 @@ def test_get_submission_by_id(client, publication):
         publication_json = json.loads(publication.json())
         assert asset == publication_json
 
+def test_get_submission_by_id_must_be_reviewer_or_owner(client, publication):
+    register_asset(publication, owner=ALICE, status=EntryStatus.SUBMITTED)
+    _register_user_in_db(REVIEWER)
+    _register_user_in_db(BOB)
+
+    for allowed_user in [REVIEWER, ALICE]:
+        with logged_in_user(allowed_user):
+            submission = client.get("/submissions/v1/1", headers={"Authorization": "Fake token"})
+            assert submission.status_code == HTTPStatus.OK, submission.json()
+
+    with logged_in_user(BOB):
+        submission = client.get("/submissions/v1/1", headers={"Authorization": "Fake token"})
+        # Probably should be changed to Administrators of the asset instead of just submitter.
+        assert submission.status_code == HTTPStatus.FORBIDDEN, "Only reviewer and submitter should be able to see the review."
+
 
 def test_unknown_submission_raises_404(client):
     with logged_in_user(REVIEWER):
@@ -185,15 +201,27 @@ def test_unknown_submission_raises_404(client):
         assert queue.status_code == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.skip("Requiring reviewer role to be added through middleware")
-def test_getting_submission_requires_review_role(client):
-    queue = client.get("/submissions/v1/1")
-    assert queue.status_code == HTTPStatus.UNAUTHORIZED
+@pytest.mark.parametrize(
+    ("user", "mode", "assets", "reason"),
+    [
+        (REVIEWER, ListMode.PENDING, [2, 3], "Reviewer can see all pending reviews."),
+        (REVIEWER, ListMode.COMPLETED, [1], "Reviewer can see all completed reviews."),
+        (ALICE, ListMode.PENDING, [2], "Alice has one pending submission and can not see Bob's."),
+        (ALICE, ListMode.COMPLETED, [1], "Alice only has one completed submission."),
+        (BOB, ListMode.PENDING, [3], "Bob has one pending submission and can not see Alice's."),
+        (BOB, ListMode.COMPLETED, [], "Bob has no completed submission."),
+    ]
+)
+def test_submission_by_state_respects_privacy(user: KeycloakUser, mode: ListMode, assets: list[int], reason: str, client: TestClient, publication):
+    register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
+    register_asset(publication, owner=ALICE, status=EntryStatus.SUBMITTED)
+    register_asset(publication, owner=BOB, status=EntryStatus.SUBMITTED)
 
-    with logged_in_user(ALICE):
-        queue = client.get("/submissions/v1/1", headers={"Authorization": "Fake token"})
-        assert queue.status_code == HTTPStatus.FORBIDDEN
-
+    with logged_in_user(user):
+        queue = client.get(f"/submissions/v1?mode={mode}", headers={"Authorization": "Fake token"})
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        returned_submissions = [submission["identifier"] for submission in queue.json()]
+        assert returned_submissions == assets, f"{reason} Response: {queue.json()}"
 
 def test_an_published_asset_is_not_pending_for_review(client, publication):
     register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
@@ -214,7 +242,18 @@ def test_an_published_asset_is_not_pending_for_review(client, publication):
         assert len(queue.json()) == 1, "After publication, the review request is completed."
 
 
-def test_retrieving_single_submission_works(client, publication_factory):
+@pytest.mark.parametrize(
+    ("user", "mode", "asset", "reason"),
+    [
+        (REVIEWER, ListMode.OLDEST, 2,"Reviewer can see both Alice and Bob's submission." ),
+        (REVIEWER, ListMode.NEWEST, 3, "Reviewer can see both Alice and Bob's submission."),
+        (ALICE, ListMode.OLDEST, 2, "Alice only has one pending submission."),
+        (ALICE, ListMode.NEWEST, 2,"Alice only has one pending submission."),
+        (BOB, ListMode.OLDEST, 3,"Bob only has one pending submission." ),
+        (BOB, ListMode.NEWEST, 3,"Bob only has one pending submission."),
+    ]
+)
+def test_retrieving_single_submission_works(user: KeycloakUser, mode: ListMode, asset: int, reason: str, client: TestClient, publication_factory):
     publication = publication_factory()
     oldest = publication_factory()
     oldest.platform_resource_identifier = "OLDEST"
@@ -223,24 +262,12 @@ def test_retrieving_single_submission_works(client, publication_factory):
 
     register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
     register_asset(oldest, owner=ALICE, status=EntryStatus.SUBMITTED)
-    register_asset(newest, owner=ALICE, status=EntryStatus.SUBMITTED)
+    register_asset(newest, owner=BOB, status=EntryStatus.SUBMITTED)
 
-    with logged_in_user(REVIEWER):
-        queue = client.get(
-            f"/submissions/v1?mode={ListMode.OLDEST}", headers={"Authorization": "Fake token"}
-        )
+    with logged_in_user(user):
+        queue = client.get(f"/submissions/v1?mode={mode}", headers={"Authorization": "Fake token"})
         assert queue.status_code == HTTPStatus.OK, queue.json()
-        assert (
-            queue.json()[0]["aiod_entry_identifier"] == 2
-        ), "The oldest pending submission is the second one."
-
-        queue = client.get(
-            f"/submissions/v1?mode={ListMode.NEWEST}", headers={"Authorization": "Fake token"}
-        )
-        assert queue.status_code == HTTPStatus.OK, queue.json()
-        assert (
-            queue.json()[0]["aiod_entry_identifier"] == 3
-        ), "The newest pending submission is the third one."
+        assert queue.json()[0]["aiod_entry_identifier"] == asset, reason
 
 
 def test_user_can_retract_assets(client, publication):


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
Adds authentication checks to the endpoints which allows you to list submitted review requests:

 * Reviewers can still see all submissions.
 * Regular users can only see submissions they made.
 * Unauthenticated users are given an error (UNAUTHORIZED).
 * Introduces a property to check for the reviewer role, to make things easier to read and reduce the risk of typos.

## How to Test
<!-- Describe a way to test the change of this PR -->
Covered by the updated tests, can test this through regular interaction with the API.
Documentation is not added as this was the initially planned behavior, and general documentation of the review process will be added later.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


