### PR TITLE
Only set to published when the asset has an aiod entry

### DIFF
--- a/src/connectors/example/resources/resource/events.json
+++ b/src/connectors/example/resources/resource/events.json
@@ -100,8 +100,7 @@
         "version": "1.1.0",
         "pid": "https://doi.org/10.1000/182",
         "aiod_entry": {
-            "editor": [],
-            "status": "draft"
+            "editor": []
         },
         "alternate_name": [
             "alias 1",
@@ -192,8 +191,7 @@
         "version": "1.1.0",
         "pid": "https://doi.org/10.1000/182",
         "aiod_entry": {
-            "editor": [],
-            "status": "draft"
+            "editor": []
         },
         "alternate_name": [
             "alias 1",

--- a/src/connectors/synchronization.py
+++ b/src/connectors/synchronization.py
@@ -165,7 +165,8 @@ def _create_or_fetch_related_objects(session: Session, item: ResourceWithRelatio
 
 
 def publish_resource(session: Session, item: AIoDConcept):
-    item.aiod_entry.status = EntryStatus.PUBLISHED
+    if hasattr(item, "aiod_entry"):
+        item.aiod_entry.status = EntryStatus.PUBLISHED
     session.add(item)
     session.commit()
     return item


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
At one point I made some changes to allow connectors to bypass the review mechanisms, but introduced a bug.
If the asset did not have an aiod entry, the connector crashes. This is only used for the example connector so far, as far as I know. This PR avoids that by only setting the aiod entry when one is available.

Additionally, setting the status through the endpoint is no longer allowed, and is handled internally by the review process, so it can no longer be supplied. I removed it from the example upload json.

## How to Test
<!-- Describe a way to test the change of this PR -->
Before the PR, the example connector would crash. After the PR, it runs successfully.

Tests for checking that status cannot be uploaded is already included in the suite, it's just that the example connector is not run in CI. We could consider adding that at some point but it will require significantly slower CI times (running the containers), which I do not think currently is in balance with the benefit.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


