### PR TITLE
Fix/sa warning

### DIFF
--- a/src/database/model/ai_asset/distribution.py
+++ b/src/database/model/ai_asset/distribution.py
@@ -68,6 +68,7 @@ def distribution_factory(table_from: str, distribution_name="distribution") -> T
             ),
         ),
     )
+    # Pydantic will issue a warning for non-default dunder attributes, so we add it after creation
     DistributionORM.__tablename__ = name
     return DistributionORM
 

--- a/src/database/model/ai_asset/distribution.py
+++ b/src/database/model/ai_asset/distribution.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Type
 
+from pydantic import create_model
 from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import Field
 
@@ -52,16 +53,22 @@ class DistributionBase(AIoDConceptBase):
 
 
 def distribution_factory(table_from: str, distribution_name="distribution") -> Type:
-    class DistributionORM(DistributionBase, table=True):  # type: ignore [call-arg]
-        __tablename__ = f"{distribution_name}_{table_from}"
-
-        identifier: int | None = Field(primary_key=True)
-
-        asset_identifier: int | None = Field(
-            sa_column=Column(Integer, ForeignKey(table_from + ".identifier", ondelete="CASCADE"))
-        )
-
-    DistributionORM.__name__ = DistributionORM.__qualname__ = f"{distribution_name}_{table_from}"
+    name = f"{distribution_name}_{table_from}"
+    DistributionORM = create_model(
+        name,
+        __base__=(DistributionBase,),
+        __cls_kwargs__=dict(table=True),
+        identifier=(int | None, Field(primary_key=True)),
+        asset_identifier=(
+            int | None,
+            Field(
+                sa_column=Column(
+                    Integer, ForeignKey(table_from + ".identifier", ondelete="CASCADE")
+                )
+            ),
+        ),
+    )
+    DistributionORM.__tablename__ = name
     return DistributionORM
 
 

--- a/src/database/model/ai_resource/note.py
+++ b/src/database/model/ai_resource/note.py
@@ -1,5 +1,6 @@
 from typing import Type
 
+from pydantic import create_model
 from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import Field, SQLModel
 
@@ -17,15 +18,21 @@ class NoteBase(SQLModel):
 
 
 def note_factory(table_from: str) -> Type:
-    class NoteORM(NoteBase, table=True):  # type: ignore [call-arg]
-        __tablename__ = f"note_{table_from}"
-
-        identifier: int | None = Field(primary_key=True)
-        linked_identifier: int | None = Field(
-            sa_column=Column(Integer, ForeignKey(table_from + ".identifier", ondelete="CASCADE"))
-        )
-
-    NoteORM.__name__ = NoteORM.__qualname__ = f"note_{table_from}"
+    NoteORM = create_model(
+        f"note_{table_from}",
+        __base__=(NoteBase,),
+        __cls_kwargs__=dict(table=True),
+        identifier=(int | None, Field(primary_key=True)),
+        linked_identifier=(
+            int | None,
+            Field(
+                sa_column=Column(
+                    Integer, ForeignKey(table_from + ".identifier", ondelete="CASCADE")
+                )
+            ),
+        ),
+    )
+    NoteORM.__tablename__ = f"note_{table_from}"
     return NoteORM
 
 

--- a/src/database/model/ai_resource/note.py
+++ b/src/database/model/ai_resource/note.py
@@ -32,6 +32,7 @@ def note_factory(table_from: str) -> Type:
             ),
         ),
     )
+    # Pydantic will issue a warning for non-default dunder attributes, so we add it after creation
     NoteORM.__tablename__ = f"note_{table_from}"
     return NoteORM
 

--- a/src/database/model/helper_functions.py
+++ b/src/database/model/helper_functions.py
@@ -42,6 +42,7 @@ def many_to_many_link_factory(
             ),
         ),
     )
+    # Pydantic will issue a warning for non-default dunder attributes, so we add it after creation
     LinkTable.__tablename__ = name
     return LinkTable
 

--- a/src/database/model/helper_functions.py
+++ b/src/database/model/helper_functions.py
@@ -1,5 +1,6 @@
 from typing import Type, TYPE_CHECKING
 
+from pydantic import create_model
 from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import SQLModel, Field
 
@@ -18,21 +19,30 @@ def many_to_many_link_factory(
     sides.
     """
     prefix = "" if table_prefix is None else f"{table_prefix}_"
-
-    class LinkTable(SQLModel, table=True):  # type: ignore [call-arg]
-        __tablename__ = f"{prefix}{table_from}_{table_to}_link"
-        from_identifier: int = Field(
-            sa_column=Column(
-                Integer,
-                ForeignKey(f"{table_from}.{table_from_identifier}", ondelete="CASCADE"),
+    name = f"{prefix}{table_from}_{table_to}_link"
+    LinkTable = create_model(
+        name,
+        __base__=(SQLModel,),
+        __cls_kwargs__=dict(table=True),
+        from_identifier=(
+            int,
+            Field(
+                sa_column=Column(
+                    Integer,
+                    ForeignKey(f"{table_from}.{table_from_identifier}", ondelete="CASCADE"),
+                    primary_key=True,
+                )
+            ),
+        ),
+        linked_identifier=(
+            int,
+            Field(
+                foreign_key=f"{table_to}.{table_to_identifier}",
                 primary_key=True,
-            )
-        )
-        linked_identifier: int = Field(
-            foreign_key=f"{table_to}.{table_to_identifier}", primary_key=True
-        )
-
-    LinkTable.__name__ = LinkTable.__qualname__ = LinkTable.__tablename__
+            ),
+        ),
+    )
+    LinkTable.__tablename__ = name
     return LinkTable
 
 

--- a/src/database/model/models_and_experiments/runnable_distribution.py
+++ b/src/database/model/models_and_experiments/runnable_distribution.py
@@ -90,9 +90,7 @@ def runnable_distribution_factory(table_from: str, distribution_name="distributi
             ),
         ),
     )
-    # Pydantic will issue a warning for non-default dunder attributes, e.g.
-    # https://github.com/pydantic/pydantic/issues/7841
-    # So we set it after class creation instead.
+    # Pydantic will issue a warning for non-default dunder attributes, so we add it after creation
     RunnableDistributionORM.__tablename__ = f"{distribution_name}_{table_from}"
     return RunnableDistributionORM
 

--- a/src/database/model/models_and_experiments/runnable_distribution.py
+++ b/src/database/model/models_and_experiments/runnable_distribution.py
@@ -1,5 +1,6 @@
 from typing import Type
 
+from pydantic import create_model
 from sqlalchemy import Column, Integer, ForeignKey
 from sqlmodel import Field
 
@@ -75,18 +76,24 @@ class RunnableDistributionBase(DistributionBase):
 
 
 def runnable_distribution_factory(table_from: str, distribution_name="distribution") -> Type:
-    class RunnableDistributionORM(RunnableDistributionBase, table=True):  # type: ignore [call-arg]
-        __tablename__ = f"{distribution_name}_{table_from}"
-
-        identifier: int | None = Field(primary_key=True)
-
-        asset_identifier: int | None = Field(
-            sa_column=Column(Integer, ForeignKey(table_from + ".identifier", ondelete="CASCADE"))
-        )
-
-    RunnableDistributionORM.__name__ = RunnableDistributionORM.__qualname__ = (
-        f"{distribution_name}_{table_from}"
+    RunnableDistributionORM = create_model(
+        f"{distribution_name}_{table_from}",
+        __base__=(RunnableDistributionBase,),
+        __cls_kwargs__=dict(table=True),
+        identifier=(int | None, Field(primary_key=True)),
+        asset_identifier=(
+            int | None,
+            Field(
+                sa_column=Column(
+                    Integer, ForeignKey(table_from + ".identifier", ondelete="CASCADE")
+                )
+            ),
+        ),
     )
+    # Pydantic will issue a warning for non-default dunder attributes, e.g.
+    # https://github.com/pydantic/pydantic/issues/7841
+    # So we set it after class creation instead.
+    RunnableDistributionORM.__tablename__ = f"{distribution_name}_{table_from}"
     return RunnableDistributionORM
 
 


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
Use a different method to dynamically create SQLModel classes.
The benefit is that they are generated with a different name, so they no longer issue the following warning:

> /usr/local/lib/python3.11/site-packages/sqlmodel/main.py:638: SAWarning: This declarative base already contains a class with the same class name and module name as database.model.models_and_experiments.runnable_distribution.RunnableDistributionORM, and will be replaced in the string-lookup table.


## How to Test
<!-- Describe a way to test the change of this PR -->
Covered by unit tests -- if model definitions changed, they would fail.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


