### PR TITLE
Add support for read/write lookup and direct permission comparison

### DIFF
--- a/src/database/authorization.py
+++ b/src/database/authorization.py
@@ -82,17 +82,21 @@ def register_user(kc_user: KeycloakUser, session: Session) -> User:
 
 
 def add_administrator(user: KeycloakUser, resource: AIoDConcept, session: Session):
-    query = select(Permission).where(
-        and_(
-            Permission.user_identifier == user._subject_identifier,
-            Permission.aiod_entry_identifier == resource.aiod_entry_identifier,
-        )
-    )
-    permission = session.scalars(query).first()
+    add_permission(user, resource, session, type_=PermissionType.ADMIN)
+
+
+def add_permission(
+    user: KeycloakUser, resource: AIoDConcept, session: Session, *, type_: PermissionType
+):
+    key = {
+        "user_identifier": user._subject_identifier,
+        "aiod_entry_identifier": resource.aiod_entry_identifier,
+    }
+    permission = session.get(Permission, key)
     if permission is None:
         permission = Permission(
             user_identifier=user._subject_identifier,
             aiod_entry=resource.aiod_entry,
         )
-    permission.type_ = PermissionType.ADMIN
+    permission.type_ = type_
     session.add(permission)

--- a/src/database/authorization.py
+++ b/src/database/authorization.py
@@ -81,11 +81,11 @@ def register_user(kc_user: KeycloakUser, session: Session) -> User:
     return user
 
 
-def add_administrator(user: KeycloakUser, resource: AIoDConcept, session: Session):
-    add_permission(user, resource, session, type_=PermissionType.ADMIN)
+def set_administrator(user: KeycloakUser, resource: AIoDConcept, session: Session):
+    set_permission(user, resource, session, type_=PermissionType.ADMIN)
 
 
-def add_permission(
+def set_permission(
     user: KeycloakUser, resource: AIoDConcept, session: Session, *, type_: PermissionType
 ):
     key = {

--- a/src/database/authorization.py
+++ b/src/database/authorization.py
@@ -1,11 +1,12 @@
 import enum
+import functools
 
 import sqlalchemy
 from sqlalchemy import Column
 from sqlmodel import SQLModel, Field, Relationship, select, Session, and_
 
 from authentication import KeycloakUser
-from database.model.concept.aiod_entry import AIoDEntryORM
+from database.model.concept.aiod_entry import AIoDEntryORM, EntryStatus
 from database.model.concept.concept import AIoDConcept
 
 
@@ -16,10 +17,19 @@ class User(SQLModel, table=True):  # type: ignore [call-arg]
     subject_identifier: str = Field(primary_key=True)
 
 
-class PermissionType(enum.StrEnum):
-    READ = enum.auto()
-    WRITE = enum.auto()
-    ADMIN = enum.auto()
+@functools.total_ordering
+class PermissionType(enum.Enum):
+    # Enum instead of StrEnum because we *never* want to do str-comparison.
+    # Definition order is important: permissions defined later include earlier ones
+    READ: str = "read"
+    WRITE: str = "write"
+    ADMIN: str = "admin"
+
+    def __lt__(self, other: "PermissionType") -> bool:
+        if not isinstance(other, PermissionType):
+            return NotImplemented
+        # _sort_order_ is definition order: https://github.com/python/cpython/blob/main/Lib/enum.py
+        return self._sort_order_ < other._sort_order_  # type: ignore[attr-defined]
 
 
 class Permission(SQLModel, table=True):  # type: ignore [call-arg]
@@ -43,16 +53,23 @@ class Permission(SQLModel, table=True):  # type: ignore [call-arg]
     )
 
 
+def _user_has_permission(
+    user: KeycloakUser, aiod_entry: AIoDEntryORM, *, at_least: PermissionType
+) -> bool:
+    return any(
+        permission.user_identifier == user._subject_identifier and permission.type_ >= at_least
+        for permission in aiod_entry.permissions
+    )
+
+
 def user_can_read(user: KeycloakUser, aiod_entry) -> bool:
-    # TODO:
-    #  - [ ] add option for private entries
-    #  - [ ] check if any permissions exist (read is least permissive)
-    return True
+    if aiod_entry.status == EntryStatus.PUBLISHED:
+        return True
+    return _user_has_permission(user, aiod_entry, at_least=PermissionType.READ)
 
 
-def user_can_write(user: KeycloakUser, aiod_entry) -> bool:
-    # TODO: check for write or admin permission
-    return False
+user_can_write = functools.partial(_user_has_permission, at_least=PermissionType.WRITE)
+user_can_administer = functools.partial(_user_has_permission, at_least=PermissionType.ADMIN)
 
 
 def register_user(kc_user: KeycloakUser, session: Session) -> User:
@@ -79,11 +96,3 @@ def add_administrator(user: KeycloakUser, resource: AIoDConcept, session: Sessio
         )
     permission.type_ = PermissionType.ADMIN
     session.add(permission)
-
-
-def user_can_administer(user: KeycloakUser, aiod_entry: AIoDEntryORM) -> bool:
-    return any(
-        permission.user_identifier == user._subject_identifier
-        and permission.type_ == PermissionType.ADMIN
-        for permission in aiod_entry.permissions
-    )

--- a/src/database/authorization.py
+++ b/src/database/authorization.py
@@ -81,10 +81,6 @@ def register_user(kc_user: KeycloakUser, session: Session) -> User:
     return user
 
 
-def set_administrator(user: KeycloakUser, resource: AIoDConcept, session: Session):
-    set_permission(user, resource, session, type_=PermissionType.ADMIN)
-
-
 def set_permission(
     user: KeycloakUser, resource: AIoDConcept, session: Session, *, type_: PermissionType
 ):

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -15,7 +15,7 @@ from starlette.responses import JSONResponse
 from authentication import KeycloakUser, get_user_or_none, get_user_or_raise
 from config import KEYCLOAK_CONFIG
 from converters.schema_converters.schema_converter import SchemaConverter
-from database.authorization import user_can_administer, add_administrator, register_user
+from database.authorization import user_can_administer, set_administrator, register_user
 from database.model.ai_resource.resource import AIResource
 from database.model.concept.aiod_entry import AIoDEntryORM, EntryStatus
 from database.model.concept.concept import AIoDConcept
@@ -413,7 +413,7 @@ class ResourceRouter(abc.ABC):
                     try:
                         resource = self.create_resource(session, resource_create)
                         register_user(user, session)
-                        add_administrator(user, resource, session)
+                        set_administrator(user, resource, session)
                         session.commit()
                         return self._wrap_with_headers({"identifier": resource.identifier})
                     except Exception as e:

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -15,7 +15,12 @@ from starlette.responses import JSONResponse
 from authentication import KeycloakUser, get_user_or_none, get_user_or_raise
 from config import KEYCLOAK_CONFIG
 from converters.schema_converters.schema_converter import SchemaConverter
-from database.authorization import user_can_administer, set_administrator, register_user
+from database.authorization import (
+    user_can_administer,
+    set_permission,
+    register_user,
+    PermissionType,
+)
 from database.model.ai_resource.resource import AIResource
 from database.model.concept.aiod_entry import AIoDEntryORM, EntryStatus
 from database.model.concept.concept import AIoDConcept
@@ -413,7 +418,7 @@ class ResourceRouter(abc.ABC):
                     try:
                         resource = self.create_resource(session, resource_create)
                         register_user(user, session)
-                        set_administrator(user, resource, session)
+                        set_permission(user, resource, session, type_=PermissionType.ADMIN)
                         session.commit()
                         return self._wrap_with_headers({"identifier": resource.identifier})
                     except Exception as e:

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -9,7 +9,7 @@ from starlette.testclient import TestClient
 from authentication import keycloak_openid, KeycloakUser
 from database.authorization import (
     register_user,
-    add_administrator, PermissionType,
+    set_administrator, PermissionType, user_can_read, user_can_write, user_can_administer,
 )
 from database.model.concept.aiod_entry import EntryStatus
 from database.model.concept.concept import AIoDConcept
@@ -318,7 +318,7 @@ def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser, status: EntryS
         session.commit()
 
         register_user(owner, session)
-        add_administrator(owner, asset, session)
+        set_administrator(owner, asset, session)
 
         asset.aiod_entry.status = status
         if status in [EntryStatus.SUBMITTED, EntryStatus.PUBLISHED, EntryStatus.REJECTED]:

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -15,6 +15,7 @@ from database.model.concept.aiod_entry import EntryStatus
 from database.model.concept.concept import AIoDConcept
 from database.review import Review, Decision, ReviewCreate, Submission
 from database.session import DbSession
+from database.model.knowledge_asset.publication import Publication
 from routers.review_router import ListMode
 
 ALICE = KeycloakUser("Alice", {"edit_aiod_resources"}, "alice-sub")
@@ -440,3 +441,42 @@ def test_permission_type_order():
     assert PermissionType.ADMIN > PermissionType.WRITE
     assert PermissionType.ADMIN > PermissionType.READ
     assert PermissionType.WRITE > PermissionType.READ
+
+
+@pytest.mark.parametrize(
+    "owner", [ALICE, BOB, REVIEWER]
+)
+def test_user_can_read(owner, publication):
+    identifier = register_asset(publication, owner=owner, status=EntryStatus.PUBLISHED)
+    # `user_can_*` require object to be in session (or eagerly loaded)
+    with DbSession() as session:
+        asset = session.get(Publication, identifier)
+
+        users = [ALICE, BOB, REVIEWER]
+        assert all(user_can_read(user, asset.aiod_entry) for user in users), "Published assets are public"
+
+
+@pytest.mark.parametrize(
+    "owner", [ALICE, BOB, REVIEWER]
+)
+def test_user_can_write(owner, publication):
+    identifier = register_asset(publication, owner=owner, status=EntryStatus.PUBLISHED)
+    with DbSession() as session:
+        asset = session.get(Publication, identifier)
+
+        assert user_can_write(owner, asset.aiod_entry)
+        others = [u for u in [ALICE, BOB, REVIEWER] if u != owner]
+        assert not any(user_can_write(non_owner, asset.aiod_entry) for non_owner in others)
+
+
+@pytest.mark.parametrize(
+    "owner", [ALICE, BOB, REVIEWER]
+)
+def test_user_can_administer(owner, publication):
+    identifier = register_asset(publication, owner=owner, status=EntryStatus.PUBLISHED)
+    with DbSession() as session:
+        asset = session.get(Publication, identifier)
+
+        assert user_can_administer(owner, asset.aiod_entry)
+        others = [u for u in [ALICE, BOB, REVIEWER] if u != owner]
+        assert not any(user_can_administer(non_owner, asset.aiod_entry) for non_owner in others)

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -9,7 +9,7 @@ from starlette.testclient import TestClient
 from authentication import keycloak_openid, KeycloakUser
 from database.authorization import (
     register_user,
-    set_administrator, PermissionType, user_can_read, user_can_write, user_can_administer,
+    set_permission, PermissionType, user_can_read, user_can_write, user_can_administer,
 )
 from database.model.concept.aiod_entry import EntryStatus
 from database.model.concept.concept import AIoDConcept
@@ -319,7 +319,7 @@ def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser, status: EntryS
         session.commit()
 
         register_user(owner, session)
-        set_administrator(owner, asset, session)
+        set_permission(owner, asset, session, type_=PermissionType.ADMIN)
 
         asset.aiod_entry.status = status
         if status in [EntryStatus.SUBMITTED, EntryStatus.PUBLISHED, EntryStatus.REJECTED]:

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -9,7 +9,7 @@ from starlette.testclient import TestClient
 from authentication import keycloak_openid, KeycloakUser
 from database.authorization import (
     register_user,
-    add_administrator,
+    add_administrator, PermissionType,
 )
 from database.model.concept.aiod_entry import EntryStatus
 from database.model.concept.concept import AIoDConcept
@@ -430,3 +430,13 @@ def test_reviewer_cannot_approve_own_submission(publication, client):
             headers={"Authorization": "Fake token"},
         )
         assert response.status_code == HTTPStatus.FORBIDDEN, response.json()
+
+
+def test_permission_type_order():
+    permissions = {PermissionType.READ, PermissionType.WRITE, PermissionType.ADMIN}
+    please_update_msg = "Test needs to be updated when PermissionTypes are added or removed."
+    assert set(PermissionType) == permissions, please_update_msg
+
+    assert PermissionType.ADMIN > PermissionType.WRITE
+    assert PermissionType.ADMIN > PermissionType.READ
+    assert PermissionType.WRITE > PermissionType.READ


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
 * Allow setting of any permission type (not just admin)
 * Allow comparisons between permission types (ADMIN>WRITE>READ)
 * Implement `can_read` and `can_write`.

## How to Test
<!-- Describe a way to test the change of this PR -->

This PR does not yet use this in the REST endpoints yet.
In follow-up PRs I will make sure the endpoints respect permissions.
The changes to PermissionType are covered by unit tests, though.
Development documentation included as comments, overall process documentation will follow in a separate PR.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


