### PR TITLE
Require aiod_entry instead of concept

### DIFF
--- a/src/database/authorization.py
+++ b/src/database/authorization.py
@@ -82,17 +82,14 @@ def register_user(kc_user: KeycloakUser, session: Session) -> User:
 
 
 def set_permission(
-    user: KeycloakUser, resource: AIoDConcept, session: Session, *, type_: PermissionType
+    user: KeycloakUser, resource: AIoDEntryORM, session: Session, *, type_: PermissionType
 ):
     key = {
         "user_identifier": user._subject_identifier,
-        "aiod_entry_identifier": resource.aiod_entry_identifier,
+        "aiod_entry_identifier": resource.identifier,
     }
     permission = session.get(Permission, key)
     if permission is None:
-        permission = Permission(
-            user_identifier=user._subject_identifier,
-            aiod_entry=resource.aiod_entry,
-        )
+        permission = Permission(user_identifier=user._subject_identifier, aiod_entry=resource)
     permission.type_ = type_
     session.add(permission)

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -418,7 +418,9 @@ class ResourceRouter(abc.ABC):
                     try:
                         resource = self.create_resource(session, resource_create)
                         register_user(user, session)
-                        set_permission(user, resource, session, type_=PermissionType.ADMIN)
+                        set_permission(
+                            user, resource.aiod_entry, session, type_=PermissionType.ADMIN
+                        )
                         session.commit()
                         return self._wrap_with_headers({"identifier": resource.identifier})
                     except Exception as e:

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -325,7 +325,7 @@ def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser, status: EntryS
         session.commit()
 
         register_user(owner, session)
-        set_permission(owner, asset, session, type_=PermissionType.ADMIN)
+        set_permission(owner, asset.aiod_entry, session, type_=PermissionType.ADMIN)
 
         asset.aiod_entry.status = status
         if status in [EntryStatus.SUBMITTED, EntryStatus.PUBLISHED, EntryStatus.REJECTED]:


### PR DESCRIPTION

## Change
<!-- Briefly describe the change of this PR -->
Make `set_permission` request the `AIoDEntryORM` directly because that's all it needs.
Technically the identifier is already sufficient, but I'm not sure if that pushes the knowledge too much upwards.

## How to Test
<!-- Describe a way to test the change of this PR -->
This change is internal and does not change behavior so its covered by existing tests and documentation.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


