### PR TITLE
Add links to documentation pages from the REST API page

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -132,10 +132,11 @@ def build_app(url_prefix: str = "", version: str = "dev"):
         openapi_url=f"{url_prefix}/openapi.json",
         docs_url=f"{url_prefix}/docs",
         title="AIoD Metadata Catalogue",
-        description="This is the Swagger documentation of the AIoD Metadata Catalogue. For the "
-        "Changelog, refer to "
-        '<a href="https://github.com/aiondemand/AIOD-rest-api/releases">https'
-        "://github.com/aiondemand/AIOD-rest-api/releases</a>.",
+        description="This is the REST API documentation of the AIoD Metadata Catalogue. "
+        "See also our general "
+        '<a href="https://aiondemand.github.io/AIOD-rest-api/">metadata catalogue documentation</a>, '
+        "and our "
+        '<a href="https://github.com/aiondemand/AIOD-rest-api/releases">changelog</a>.',
         version=version,
         swagger_ui_oauth2_redirect_url=f"{url_prefix}/docs/oauth2-redirect",
         swagger_ui_init_oauth={


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
Adds a link to the general documentation pages which provide more context and also usage examples.

## How to Test
<!-- Describe a way to test the change of this PR -->
Visit the API docs, look at the text at the top of the page.
Note that the link is to the GitHub pages, it does not reflect local changes to the documentation.
I guess we could do this through a configuration variable, but that seems unnecessary to me since we are currently not hosting our own pages (instead we use GitHub pages). When that changes (e.g., also to support dev docs), we can update.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
closes #452

