### PR TITLE
Feat/read permissions

### DIFF
--- a/src/database/authorization.py
+++ b/src/database/authorization.py
@@ -3,11 +3,10 @@ import functools
 
 import sqlalchemy
 from sqlalchemy import Column
-from sqlmodel import SQLModel, Field, Relationship, select, Session, and_
+from sqlmodel import SQLModel, Field, Relationship, select, Session
 
 from authentication import KeycloakUser
 from database.model.concept.aiod_entry import AIoDEntryORM, EntryStatus
-from database.model.concept.concept import AIoDConcept
 
 
 class User(SQLModel, table=True):  # type: ignore [call-arg]

--- a/src/database/model/resource_bundle/resource_bundle.py
+++ b/src/database/model/resource_bundle/resource_bundle.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 from sqlmodel import Relationship
 
 from database.model.ai_resource.resource import AIResource, AIResourceBase

--- a/src/routers/resource_ai_asset_router.py
+++ b/src/routers/resource_ai_asset_router.py
@@ -1,8 +1,9 @@
 from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, status, Path
+from fastapi import APIRouter, HTTPException, status, Path, Depends
 from fastapi.responses import RedirectResponse
 
+from authentication import get_user_or_none, KeycloakUser
 from database.model.ai_asset.ai_asset import AIAsset
 from .resource_router import ResourceRouter
 
@@ -56,9 +57,13 @@ class ResourceAIAssetRouter(ResourceRouter):
                 int,
                 Path(description=f"The index of the distribution within the {self.resource_name}"),
             ],
+            user: KeycloakUser | None = Depends(get_user_or_none),
         ):
             metadata: AIAsset = self.get_resource(
-                identifier=identifier, schema="aiod", platform=None
+                identifier=identifier,
+                schema="aiod",
+                platform=None,
+                user=user,
             )  # type: ignore
 
             distributions = metadata.distribution
@@ -88,8 +93,9 @@ class ResourceAIAssetRouter(ResourceRouter):
             identifier: Annotated[
                 str, Path(description=f"The identifier of the {self.resource_name}")
             ],
+            user: KeycloakUser | None = Depends(get_user_or_none),
         ):
-            return get_resource_content(identifier=identifier, distribution_idx=0)
+            return get_resource_content(identifier=identifier, distribution_idx=0, user=user)
 
         if default:
             return get_resource_content_default

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -288,7 +288,7 @@ class ResourceRouter(abc.ABC):
 
     def get_resource_count_func(self):
         """
-        Gets the total number of resources from the database.
+        Gets the total number of published resources from the database.
         This function returns a function (instead of being that function directly) because the
         docstring and the variables are dynamic, and used in Swagger.
         """
@@ -303,7 +303,11 @@ class ResourceRouter(abc.ABC):
                     if not detailed:
                         return (
                             session.query(self.resource_class)
-                            .where(is_(self.resource_class.date_deleted, None))
+                            .join(self.resource_class.aiod_entry, isouter=True)
+                            .where(
+                                is_(self.resource_class.date_deleted, None),
+                                AIoDEntryORM.status == EntryStatus.PUBLISHED,
+                            )
                             .count()
                         )
                     else:
@@ -312,7 +316,11 @@ class ResourceRouter(abc.ABC):
                                 self.resource_class.platform,
                                 func.count(self.resource_class.identifier),
                             )
-                            .where(is_(self.resource_class.date_deleted, None))
+                            .join(self.resource_class.aiod_entry, isouter=True)
+                            .where(
+                                is_(self.resource_class.date_deleted, None),
+                                AIoDEntryORM.status == EntryStatus.PUBLISHED,
+                            )
                             .group_by(self.resource_class.platform)
                             .all()
                         )

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -2,6 +2,7 @@ import abc
 import datetime
 import traceback
 from functools import partial
+from http import HTTPStatus
 from typing import Annotated, Any, Literal, Sequence, Type, TypeVar, Union
 from wsgiref.handlers import format_date_time
 
@@ -13,7 +14,6 @@ from sqlmodel import SQLModel, Session, select
 from starlette.responses import JSONResponse
 
 from authentication import KeycloakUser, get_user_or_none, get_user_or_raise
-from config import KEYCLOAK_CONFIG
 from converters.schema_converters.schema_converter import SchemaConverter
 from database.authorization import (
     user_can_administer,
@@ -21,6 +21,7 @@ from database.authorization import (
     register_user,
     PermissionType,
     user_can_write,
+    user_can_read,
 )
 from database.model.ai_resource.resource import AIResource
 from database.model.concept.aiod_entry import AIoDEntryORM, EntryStatus
@@ -32,7 +33,7 @@ from database.model.resource_read_and_create import (
     resource_read,
 )
 from database.model.serializers import deserialize_resource_relationships
-from database.review import Decision, Review, Submission, ReviewCreate, SubmissionCreate
+from database.review import Submission, SubmissionCreate
 from database.session import DbSession
 from dependencies.filtering import ResourceFilters, ResourceFiltersParams
 from dependencies.pagination import Pagination, PaginationParams
@@ -244,6 +245,17 @@ class ResourceRouter(abc.ABC):
                 resource: Any = self._retrieve_resource_and_post_process(
                     session, identifier, user, platform=platform
                 )
+                if resource.aiod_entry.status != EntryStatus.PUBLISHED:
+                    if user is None:
+                        raise HTTPException(
+                            status_code=HTTPStatus.UNAUTHORIZED,
+                            detail="This asset is not published. It requires authentication to access.",
+                        )
+                    if not user_can_read(user, resource.aiod_entry):
+                        raise HTTPException(
+                            status_code=HTTPStatus.FORBIDDEN,
+                            detail="You are not allowed to view this resource.",
+                        )
                 if schema != "aiod":
                     return self.schema_converters[schema].convert(session, resource)
                 return self._wrap_with_headers(self.resource_class_read.from_orm(resource))

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -212,7 +212,7 @@ class ResourceRouter(abc.ABC):
         user: KeycloakUser | None = None,
         platform: str | None = None,
     ):
-        """Fetch all resources of this platform in given schema, using pagination"""
+        """Fetch all published resources of this platform in given schema, using pagination"""
         _raise_error_on_invalid_schema(self._possible_schemas, schema)
         with DbSession(autoflush=False) as session:
             try:
@@ -624,8 +624,8 @@ class ResourceRouter(abc.ABC):
         platform: str | None = None,
     ) -> Sequence[type[RESOURCE_MODEL]]:
         """
-        Retrieve a sequence of resources from the database based on the provided identifier,
-        platform and resource filters (if applicable).
+        Retrieve a sequence of published resources from the database based on the
+        provided identifier, platform and resource filters (if applicable).
         """
         where_clause = and_(
             is_(self.resource_class.date_deleted, None),
@@ -636,6 +636,7 @@ class ResourceRouter(abc.ABC):
             AIoDEntryORM.date_modified < resource_filters.date_modified_before
             if resource_filters.date_modified_before is not None
             else True,
+            AIoDEntryORM.status == EntryStatus.PUBLISHED,
         )
         query = (
             select(self.resource_class)

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -36,7 +36,10 @@ def test_new_asset_is_draft(client, publication, mocked_privileged_token: Mock):
         )
         assert response.status_code == HTTPStatus.OK, response.json()
 
-        server_data = client.get(f"/publications/v1/{response.json()['identifier']}").json()
+        server_data = client.get(
+            f"/publications/v1/{response.json()['identifier']}",
+            headers={"Authorization": "Fake token"},
+        ).json()
         assert server_data["aiod_entry"]["status"] == EntryStatus.DRAFT
 
 
@@ -291,7 +294,10 @@ def test_user_can_edit_asset_in_draft(publication, client):
             headers={"Authorization": "Fake token"},
         )
         assert response.status_code == HTTPStatus.OK, response.json()
-        updated_publication = client.get(f"/publications/v1/{identifier}").json()
+        updated_publication = client.get(
+            f"/publications/v1/{identifier}",
+            headers={"Authorization": "Fake token"},
+        ).json()
         assert updated_publication["name"] == new_name
 
 
@@ -351,7 +357,12 @@ def test_reviewer_can_reject_submission(publication, client):
         )
         assert response.status_code == HTTPStatus.OK, response.json()
 
-    response = client.get(f"/publications/v1/{identifier}")
+    # Because the rejected asset is back in draft status, it requires authentication to access.
+    with logged_in_user(ALICE):
+        response = client.get(
+            f"/publications/v1/{identifier}",
+            headers={"Authorization": "Fake token"},
+        )
     assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json()["aiod_entry"]["status"] == EntryStatus.DRAFT
 

--- a/src/tests/authorization/test_status_update.py
+++ b/src/tests/authorization/test_status_update.py
@@ -6,6 +6,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from database.model.concept.aiod_entry import EntryStatus
+from tests.testutils.users import logged_in_user, ALICE
 
 
 @pytest.fixture()
@@ -19,31 +20,34 @@ def publication_body(body_asset: dict) -> dict:
     return body
 
 
-def test_entry_status_can_update_on_put(
+def test_entry_status_does_not_update_on_put(
     client: TestClient,
-    mocked_privileged_token: Mock,
     publication_body: dict,
 ):
-    response = client.post(
-        "/publications/v1", json=publication_body, headers={"Authorization": "Fake token"}
-    )
+    with logged_in_user(ALICE):
+        response = client.post(
+            "/publications/v1", json=publication_body, headers={"Authorization": "Fake token"}
+        )
     assert response.status_code == 200, response.json()
 
     # Default is DRAFT
-    response = client.get("/publications/v1/1")
+    with logged_in_user(ALICE):
+        response = client.get("/publications/v1/1", headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
     assert response.json()["aiod_entry"]["status"] == EntryStatus.DRAFT
     identifier = response.json()["identifier"]
 
     publication_body["aiod_entry"]["status"] = EntryStatus.PUBLISHED
-    response = client.put(
-        f"/publications/v1/{identifier}",
-        json=publication_body,
-        headers={"Authorization": "Fake token"},
-    )
+    with logged_in_user(ALICE):
+        response = client.put(
+            f"/publications/v1/{identifier}",
+            json=publication_body,
+            headers={"Authorization": "Fake token"},
+        )
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
 
     # Status is not updated to published
-    response = client.get(f"/publications/v1/{identifier}")
+    with logged_in_user(ALICE):
+        response = client.get("/publications/v1/1", headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
     assert response.json()["aiod_entry"]["status"] == EntryStatus.DRAFT

--- a/src/tests/authorization/test_status_update.py
+++ b/src/tests/authorization/test_status_update.py
@@ -1,6 +1,5 @@
 import copy
 from http import HTTPStatus
-from unittest.mock import Mock
 
 import pytest
 from starlette.testclient import TestClient

--- a/src/tests/database/deletion/test_hard_delete.py
+++ b/src/tests/database/deletion/test_hard_delete.py
@@ -5,7 +5,7 @@ from sqlmodel import select
 from database.deletion import hard_delete
 from database.model.concept.aiod_entry import AIoDEntryORM, EntryStatus
 from database.session import DbSession
-from tests.testutils.test_resource import factory, TestResource
+from tests.testutils.test_resource import factory_test_resource, TestResource
 
 
 def test_hard_delete():
@@ -14,34 +14,18 @@ def test_hard_delete():
     with DbSession() as session:
         session.add_all(
             [
-                factory(
-                    title="test_resource_to_keep",
-                    platform="example",
-                    platform_resource_identifier=1,
-                    status=EntryStatus.DRAFT,
-                    date_deleted=None,
-                ),
-                factory(
-                    title="test_resource_to_keep_2",
-                    platform="example",
-                    platform_resource_identifier=2,
-                    status=EntryStatus.DRAFT,
-                    date_deleted=now,
-                ),
-                factory(
-                    title="my_test_resource",
-                    platform="example",
-                    platform_resource_identifier=3,
-                    status=EntryStatus.DRAFT,
-                    date_deleted=deletion_time,
-                ),
-                factory(
-                    title="second_test_resource",
-                    platform="example",
-                    platform_resource_identifier=4,
-                    status=EntryStatus.DRAFT,
-                    date_deleted=deletion_time,
-                ),
+                factory_test_resource(title="test_resource_to_keep", status=EntryStatus.DRAFT,
+                                      platform="example", platform_resource_identifier=1,
+                                      date_deleted=None),
+                factory_test_resource(title="test_resource_to_keep_2", status=EntryStatus.DRAFT,
+                                      platform="example", platform_resource_identifier=2,
+                                      date_deleted=now),
+                factory_test_resource(title="my_test_resource", status=EntryStatus.DRAFT,
+                                      platform="example", platform_resource_identifier=3,
+                                      date_deleted=deletion_time),
+                factory_test_resource(title="second_test_resource", status=EntryStatus.DRAFT,
+                                      platform="example", platform_resource_identifier=4,
+                                      date_deleted=deletion_time),
             ]
         )
         session.commit()

--- a/src/tests/routers/ai_asset_routers/test_router_aiassets_retrieve_content.py
+++ b/src/tests/routers/ai_asset_routers/test_router_aiassets_retrieve_content.py
@@ -8,7 +8,7 @@ from starlette.testclient import TestClient
 
 from database.model.agent.person import Person
 from database.session import DbSession
-from tests.testutils.users import logged_in_user, ALICE, bypass_reviewer_publish_everything
+from tests.testutils.users import logged_in_user, ALICE
 
 TEST_URL1 = "https://www.example.com/example1.csv/content"
 TEST_URL2 = "https://www.example.com/example2.tsv/content"

--- a/src/tests/routers/ai_asset_routers/test_router_aiassets_retrieve_content.py
+++ b/src/tests/routers/ai_asset_routers/test_router_aiassets_retrieve_content.py
@@ -8,6 +8,7 @@ from starlette.testclient import TestClient
 
 from database.model.agent.person import Person
 from database.session import DbSession
+from tests.testutils.users import logged_in_user, ALICE, bypass_reviewer_publish_everything
 
 TEST_URL1 = "https://www.example.com/example1.csv/content"
 TEST_URL2 = "https://www.example.com/example2.tsv/content"
@@ -31,8 +32,8 @@ def resource_name(request: FixtureRequest) -> str:
 def test_ai_asset_has_endpoints(
     client: TestClient,
     body_asset_with_single_distribution: dict,
-    db_with_person: None,
     resource_name: str,
+    auto_publish: None,
 ):
     """
     Test the existence and functionality of endpoints for an AIAsset resource.
@@ -43,23 +44,25 @@ def test_ai_asset_has_endpoints(
     return a response with status code 200.
     """
     body = copy.deepcopy(body_asset_with_single_distribution)
-    response = client.post(
-        f"/{resource_name}/v1", json=body, headers={"Authorization": "Fake token"}
-    )
+    with logged_in_user():
+        response = client.post(
+            f"/{resource_name}/v1", json=body, headers={"Authorization": "Fake token"}
+        )
     assert response.status_code == status.HTTP_200_OK, response.json()
 
     default_endpoint = f"{resource_name}/v1/1/content"
 
-    response = client.get(default_endpoint, allow_redirects=False)
+    response = client.get(default_endpoint, follow_redirects=False)
     assert response.status_code == status.HTTP_303_SEE_OTHER, response.status_code
-    response0 = client.get(default_endpoint + "/0", allow_redirects=False)
+
+    response0 = client.get(default_endpoint + "/0", follow_redirects=False)
     assert response0.status_code == status.HTTP_303_SEE_OTHER, response0.status_code
 
 
 def test_endpoints_when_empty_distribution(
     client: TestClient,
     body_asset: dict,
-    db_with_person: None,
+    auto_publish: None,
 ):
     """
     Test retrieving content from an AIAsset with an empty distribution list.
@@ -71,9 +74,10 @@ def test_endpoints_when_empty_distribution(
     body = copy.deepcopy(body_asset)
     body["distribution"] = []
 
-    response = client.post(
-        f"/{SAMPLE_RESOURCE_NAME}/v1", json=body, headers={"Authorization": "Fake token"}
-    )
+    with logged_in_user(ALICE):
+        response = client.post(
+            f"/{SAMPLE_RESOURCE_NAME}/v1", json=body, headers={"Authorization": "Fake token"}
+        )
     assert response.status_code == status.HTTP_200_OK, response.json()
 
     response = client.get(SAMPLE_ENDPOINT, allow_redirects=False)
@@ -98,6 +102,7 @@ def test_endpoints_when_single_distribution(
     client: TestClient,
     body_asset_with_single_distribution: dict,
     db_with_person: None,
+    auto_publish: None,
 ):
     """
     Test retrieving content from an AIAsset with a single distribution.
@@ -107,9 +112,10 @@ def test_endpoints_when_single_distribution(
     content, and headers are returned.
     """
     body = copy.deepcopy(body_asset_with_single_distribution)
-    response = client.post(
-        f"/{SAMPLE_RESOURCE_NAME}/v1", json=body, headers={"Authorization": "Fake token"}
-    )
+    with logged_in_user(ALICE):
+        response = client.post(
+            f"/{SAMPLE_RESOURCE_NAME}/v1", json=body, headers={"Authorization": "Fake token"}
+        )
     assert response.status_code == status.HTTP_200_OK, response.json()
 
     response = client.get(SAMPLE_ENDPOINT, allow_redirects=False)
@@ -143,7 +149,7 @@ def body_asset_with_two_distributions(body_asset_with_single_distribution: dict)
 def test_endpoints_when_two_distributions(
     client: TestClient,
     body_asset_with_two_distributions: dict,
-    db_with_person: None,
+    auto_publish: None,
 ):
     """
     Test getting content from an AIAsset with multiple distributions.
@@ -153,9 +159,10 @@ def test_endpoints_when_two_distributions(
     content, and headers are returned.
     """
     body = copy.deepcopy(body_asset_with_two_distributions)
-    response = client.post(
-        f"/{SAMPLE_RESOURCE_NAME}/v1", json=body, headers={"Authorization": "Fake token"}
-    )
+    with logged_in_user(ALICE):
+        response = client.post(
+            f"/{SAMPLE_RESOURCE_NAME}/v1", json=body, headers={"Authorization": "Fake token"}
+        )
     assert response.status_code == status.HTTP_200_OK, response.json()
 
     response = client.get(SAMPLE_ENDPOINT, allow_redirects=False)

--- a/src/tests/routers/generic/test_authentication.py
+++ b/src/tests/routers/generic/test_authentication.py
@@ -4,7 +4,6 @@ import pytest
 from sqlalchemy.future import Engine
 from starlette.testclient import TestClient
 
-from tests.testutils.users import bypass_reviewer_publish_everything
 
 
 def test_get_all_unauthenticated(

--- a/src/tests/routers/generic/test_authentication.py
+++ b/src/tests/routers/generic/test_authentication.py
@@ -4,6 +4,8 @@ import pytest
 from sqlalchemy.future import Engine
 from starlette.testclient import TestClient
 
+from tests.testutils.users import bypass_reviewer_publish_everything
+
 
 def test_get_all_unauthenticated(
     client_test_resource: TestClient, engine_test_resource_filled: Engine
@@ -14,7 +16,7 @@ def test_get_all_unauthenticated(
     assert len(response.json()) == 1
 
 
-def test_get_unauthenticated(client_test_resource: TestClient, engine_test_resource_filled: Engine):
+def test_get_unauthenticated(client_test_resource: TestClient, auto_publish: None, engine_test_resource_filled: Engine):
     """You don't need authentication for GET"""
     response = client_test_resource.get("/test_resources/v0/1")
     assert response.status_code == 200, response.json()

--- a/src/tests/routers/generic/test_router_delete.py
+++ b/src/tests/routers/generic/test_router_delete.py
@@ -32,7 +32,7 @@ def test_happy_path(
             ),
     ]
     for resource in resources:
-        register_asset(resource, owner=ALICE, status=EntryStatus.DRAFT)
+        register_asset(resource, owner=ALICE, status=EntryStatus.PUBLISHED)
 
     with logged_in_user(ALICE):
         response = client_test_resource.delete(

--- a/src/tests/routers/generic/test_router_delete.py
+++ b/src/tests/routers/generic/test_router_delete.py
@@ -61,8 +61,7 @@ def test_delete_requires_admin(
             f"/test_resources/v0/{identifier}",
         headers={"Authorization": "Fake token"}
     )
-    with logged_in_user(user=None):
-        assert try_delete().status_code == HTTPStatus.UNAUTHORIZED
+    assert try_delete().status_code == HTTPStatus.UNAUTHORIZED
     with logged_in_user(other):
         assert try_delete().status_code == HTTPStatus.FORBIDDEN
     with logged_in_user(owner):

--- a/src/tests/routers/generic/test_router_delete.py
+++ b/src/tests/routers/generic/test_router_delete.py
@@ -8,7 +8,7 @@ from starlette.testclient import TestClient
 from authentication import KeycloakUser
 from database.session import DbSession
 from database.model.concept.aiod_entry import EntryStatus
-from tests.testutils.test_resource import factory
+from tests.testutils.test_resource import factory_test_resource
 from tests.testutils.users import register_asset, ALICE, logged_in_user, BOB
 
 
@@ -18,18 +18,10 @@ def test_happy_path(
     identifier: int,
 ):
     resources = [
-            factory(
-                title="my_test_resource",
-                platform="example",
-                platform_resource_identifier=1,
-                status=EntryStatus.DRAFT,
-            ),
-            factory(
-                title="second_test_resource",
-                platform="example",
-                platform_resource_identifier=2,
-                status=EntryStatus.DRAFT,
-            ),
+        factory_test_resource(title="my_test_resource", status=EntryStatus.DRAFT,
+                              platform="example", platform_resource_identifier=1),
+        factory_test_resource(title="second_test_resource", status=EntryStatus.DRAFT,
+                              platform="example", platform_resource_identifier=2),
     ]
     for resource in resources:
         register_asset(resource, owner=ALICE, status=EntryStatus.PUBLISHED)
@@ -55,7 +47,7 @@ def test_delete_requires_admin(
         other: KeycloakUser,
         client_test_resource: TestClient,
 ):
-    identifier = register_asset(factory(), owner=owner, status=EntryStatus.DRAFT)
+    identifier = register_asset(factory_test_resource(), owner=owner, status=EntryStatus.DRAFT)
     try_delete = partial(
         client_test_resource.delete,
             f"/test_resources/v0/{identifier}",
@@ -77,18 +69,10 @@ def test_non_existent(
     with DbSession() as session:
         session.add_all(
             [
-                factory(
-                    title="my_test_resource",
-                    platform="example",
-                    platform_resource_identifier=1,
-                    status=EntryStatus.DRAFT,
-                ),
-                factory(
-                    title="second_test_resource",
-                    platform="example",
-                    platform_resource_identifier=2,
-                    status=EntryStatus.DRAFT,
-                ),
+                factory_test_resource(title="my_test_resource", status=EntryStatus.DRAFT,
+                                      platform="example", platform_resource_identifier=1),
+                factory_test_resource(title="second_test_resource", status=EntryStatus.DRAFT,
+                                      platform="example", platform_resource_identifier=2),
             ]
         )
         session.commit()

--- a/src/tests/routers/generic/test_router_deprecation.py
+++ b/src/tests/routers/generic/test_router_deprecation.py
@@ -1,5 +1,4 @@
 import datetime
-from unittest.mock import Mock
 
 import pytest
 from fastapi import FastAPI

--- a/src/tests/routers/generic/test_router_get.py
+++ b/src/tests/routers/generic/test_router_get.py
@@ -1,12 +1,16 @@
+from http import HTTPStatus
+
 from sqlalchemy.future import Engine
 from starlette.testclient import TestClient
 
-from tests.testutils.users import register_asset
+from database.model.concept.aiod_entry import EntryStatus
+from tests.testutils.users import register_asset, ALICE, logged_in_user
+from tests.testutils.test_resource import factory_test_resource
 
 
 def test_get_happy_path(client_test_resource: TestClient, engine_test_resource_filled: Engine):
     response = client_test_resource.get("/test_resources/v0/1")
-    assert response.status_code == 200, response.json()
+    assert response.status_code == HTTPStatus.OK, response.json()
     response_json = response.json()
 
     assert response_json["title"] == "A title"
@@ -16,9 +20,25 @@ def test_get_happy_path(client_test_resource: TestClient, engine_test_resource_f
 
 def test_not_found(client_test_resource: TestClient, engine_test_resource_filled: Engine):
     response = client_test_resource.get("/test_resources/v0/99")
-    assert response.status_code == 404, response.json()
+    assert response.status_code == HTTPStatus.NOT_FOUND, response.json()
     assert response.json()["detail"] == "Test_resource '99' not found in the database."
 
 
-# def test_get_draft_unauthenticated_not_allow(client_test_resource: TestClient):
-#     register_asset()
+def test_get_draft_unauthenticated_not_allowed(client_test_resource: TestClient):
+    identifier = register_asset(factory_test_resource(), owner=ALICE, status=EntryStatus.DRAFT)
+    response = client_test_resource.get(f"/test_resources/v0/{identifier}")
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_get_draft_no_permission_not_allowed(client_test_resource: TestClient):
+    identifier = register_asset(factory_test_resource(), owner=ALICE, status=EntryStatus.DRAFT)
+    with logged_in_user():
+        response = client_test_resource.get(f"/test_resources/v0/{identifier}", headers={"Authorization": "fake-token"})
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_get_draft_with_permission_is_allowed(client_test_resource: TestClient):
+    identifier = register_asset(factory_test_resource(), owner=ALICE, status=EntryStatus.DRAFT)
+    with logged_in_user(ALICE):
+        response = client_test_resource.get(f"/test_resources/v0/{identifier}", headers={"Authorization": "fake-token"})
+    assert response.status_code == HTTPStatus.OK

--- a/src/tests/routers/generic/test_router_get.py
+++ b/src/tests/routers/generic/test_router_get.py
@@ -1,6 +1,8 @@
 from sqlalchemy.future import Engine
 from starlette.testclient import TestClient
 
+from tests.testutils.users import register_asset
+
 
 def test_get_happy_path(client_test_resource: TestClient, engine_test_resource_filled: Engine):
     response = client_test_resource.get("/test_resources/v0/1")
@@ -16,3 +18,7 @@ def test_not_found(client_test_resource: TestClient, engine_test_resource_filled
     response = client_test_resource.get("/test_resources/v0/99")
     assert response.status_code == 404, response.json()
     assert response.json()["detail"] == "Test_resource '99' not found in the database."
+
+
+# def test_get_draft_unauthenticated_not_allow(client_test_resource: TestClient):
+#     register_asset()

--- a/src/tests/routers/generic/test_router_get_all.py
+++ b/src/tests/routers/generic/test_router_get_all.py
@@ -2,28 +2,19 @@ from starlette.testclient import TestClient
 
 from database.session import DbSession
 from database.model.concept.aiod_entry import EntryStatus
-from tests.testutils.test_resource import factory
+from tests.testutils.test_resource import factory_test_resource
 
 
 def test_get_all_happy_path(client_test_resource: TestClient):
     with DbSession() as session:
         session.add_all(
             [
-                factory(
-                    title="my_test_resource_1",
-                    status=EntryStatus.PUBLISHED,
-                    platform_resource_identifier="2",
-                ),
-                factory(
-                    title="My second test resource",
-                    status=EntryStatus.PUBLISHED,
-                    platform_resource_identifier="3",
-                ),
-                factory(
-                    title="My third test resource",
-                    status=EntryStatus.DRAFT,
-                    platform_resource_identifier="4",
-                ),
+                factory_test_resource(title="my_test_resource_1", status=EntryStatus.PUBLISHED,
+                                      platform_resource_identifier="2"),
+                factory_test_resource(title="My second test resource", status=EntryStatus.PUBLISHED,
+                                      platform_resource_identifier="3"),
+                factory_test_resource(title="My third test resource", status=EntryStatus.DRAFT,
+                                      platform_resource_identifier="4"),
             ]
         )
         session.commit()

--- a/src/tests/routers/generic/test_router_get_all.py
+++ b/src/tests/routers/generic/test_router_get_all.py
@@ -11,13 +11,18 @@ def test_get_all_happy_path(client_test_resource: TestClient):
             [
                 factory(
                     title="my_test_resource_1",
-                    status=EntryStatus.DRAFT,
+                    status=EntryStatus.PUBLISHED,
                     platform_resource_identifier="2",
                 ),
                 factory(
                     title="My second test resource",
-                    status=EntryStatus.DRAFT,
+                    status=EntryStatus.PUBLISHED,
                     platform_resource_identifier="3",
+                ),
+                factory(
+                    title="My third test resource",
+                    status=EntryStatus.DRAFT,
+                    platform_resource_identifier="4",
                 ),
             ]
         )
@@ -26,7 +31,7 @@ def test_get_all_happy_path(client_test_resource: TestClient):
     assert response.status_code == 200, response.json()
     response_json = response.json()
 
-    assert len(response_json) == 2
+    assert len(response_json) == 2, "Expecting only two published assets"
     response_1, response_2 = response_json
     assert response_1["identifier"] == 1
     assert response_1["title"] == "my_test_resource_1"

--- a/src/tests/routers/generic/test_router_get_count.py
+++ b/src/tests/routers/generic/test_router_get_count.py
@@ -4,10 +4,11 @@ from starlette.testclient import TestClient
 
 from database.model.agent.contact import Contact
 from database.model.agent.person import Person
-from database.model.concept.aiod_entry import AIoDEntryORM, EntryStatus
+from database.model.concept.aiod_entry import  EntryStatus
 from database.model.knowledge_asset.publication import Publication
 from database.session import DbSession
 from tests.testutils.test_resource import factory
+from tests.testutils.users import register_asset
 
 
 def test_get_count_happy_path(client_test_resource: TestClient):
@@ -16,19 +17,24 @@ def test_get_count_happy_path(client_test_resource: TestClient):
             [
                 factory(
                     title="my_test_resource_1",
-                    status=EntryStatus.DRAFT,
+                    status=EntryStatus.PUBLISHED,
                     platform_resource_identifier="1",
                 ),
                 factory(
                     title="My second test resource",
-                    status=EntryStatus.DRAFT,
+                    status=EntryStatus.PUBLISHED,
                     platform_resource_identifier="2",
                 ),
                 factory(
                     title="My third test resource",
-                    status=EntryStatus.DRAFT,
+                    status=EntryStatus.PUBLISHED,
                     platform_resource_identifier="3",
                     date_deleted=datetime.datetime.now(),
+                ),
+                factory(
+                    title="My fourth test resource",
+                    status=EntryStatus.DRAFT,
+                    platform_resource_identifier="4",
                 ),
             ]
         )
@@ -47,30 +53,30 @@ def test_get_count_detailed_happy_path(client_test_resource: TestClient):
             [
                 factory(
                     title="my_test_resource_1",
-                    status=EntryStatus.DRAFT,
+                    status=EntryStatus.PUBLISHED,
                     platform_resource_identifier="1",
                 ),
                 factory(
                     title="My second test resource",
-                    status=EntryStatus.DRAFT,
+                    status=EntryStatus.PUBLISHED,
                     platform_resource_identifier="2",
                 ),
                 factory(
                     title="My third test resource",
-                    status=EntryStatus.DRAFT,
+                    status=EntryStatus.PUBLISHED,
                     platform_resource_identifier="3",
                     date_deleted=datetime.datetime.now(),
                     platform="openml",
                 ),
                 factory(
                     title="My third test resource",
-                    status=EntryStatus.DRAFT,
+                    status=EntryStatus.PUBLISHED,
                     platform_resource_identifier="4",
                     platform="openml",
                 ),
                 factory(
                     title="My fourth test resource",
-                    status=EntryStatus.DRAFT,
+                    status=EntryStatus.PUBLISHED,
                     platform=None,
                     platform_resource_identifier=None,
                 ),
@@ -91,14 +97,11 @@ def test_get_count_total(
     publication: Publication,
     contact: Contact,
 ):
-
-    with DbSession() as session:
-        session.add(person)
-        session.merge(publication)
-        session.add(Publication(name="2", aiod_enty=AIoDEntryORM(type="publication")))
-        session.add(Publication(name="3", aiod_enty=AIoDEntryORM(type="publication")))
-        session.add(contact)
-        session.commit()
+    register_asset(person)
+    register_asset(publication)
+    register_asset(Publication(name="2"))
+    register_asset(Publication(name="3"))
+    register_asset(contact)
 
     response = client.get("/counts/v1")
     assert response.status_code == 200, response.json()

--- a/src/tests/routers/generic/test_router_get_count.py
+++ b/src/tests/routers/generic/test_router_get_count.py
@@ -7,7 +7,7 @@ from database.model.agent.person import Person
 from database.model.concept.aiod_entry import  EntryStatus
 from database.model.knowledge_asset.publication import Publication
 from database.session import DbSession
-from tests.testutils.test_resource import factory
+from tests.testutils.test_resource import factory_test_resource
 from tests.testutils.users import register_asset
 
 
@@ -15,27 +15,15 @@ def test_get_count_happy_path(client_test_resource: TestClient):
     with DbSession() as session:
         session.add_all(
             [
-                factory(
-                    title="my_test_resource_1",
-                    status=EntryStatus.PUBLISHED,
-                    platform_resource_identifier="1",
-                ),
-                factory(
-                    title="My second test resource",
-                    status=EntryStatus.PUBLISHED,
-                    platform_resource_identifier="2",
-                ),
-                factory(
-                    title="My third test resource",
-                    status=EntryStatus.PUBLISHED,
-                    platform_resource_identifier="3",
-                    date_deleted=datetime.datetime.now(),
-                ),
-                factory(
-                    title="My fourth test resource",
-                    status=EntryStatus.DRAFT,
-                    platform_resource_identifier="4",
-                ),
+                factory_test_resource(title="my_test_resource_1", status=EntryStatus.PUBLISHED,
+                                      platform_resource_identifier="1"),
+                factory_test_resource(title="My second test resource", status=EntryStatus.PUBLISHED,
+                                      platform_resource_identifier="2"),
+                factory_test_resource(title="My third test resource", status=EntryStatus.PUBLISHED,
+                                      platform_resource_identifier="3",
+                                      date_deleted=datetime.datetime.now()),
+                factory_test_resource(title="My fourth test resource", status=EntryStatus.DRAFT,
+                                      platform_resource_identifier="4"),
             ]
         )
         session.commit()
@@ -51,35 +39,17 @@ def test_get_count_detailed_happy_path(client_test_resource: TestClient):
     with DbSession() as session:
         session.add_all(
             [
-                factory(
-                    title="my_test_resource_1",
-                    status=EntryStatus.PUBLISHED,
-                    platform_resource_identifier="1",
-                ),
-                factory(
-                    title="My second test resource",
-                    status=EntryStatus.PUBLISHED,
-                    platform_resource_identifier="2",
-                ),
-                factory(
-                    title="My third test resource",
-                    status=EntryStatus.PUBLISHED,
-                    platform_resource_identifier="3",
-                    date_deleted=datetime.datetime.now(),
-                    platform="openml",
-                ),
-                factory(
-                    title="My third test resource",
-                    status=EntryStatus.PUBLISHED,
-                    platform_resource_identifier="4",
-                    platform="openml",
-                ),
-                factory(
-                    title="My fourth test resource",
-                    status=EntryStatus.PUBLISHED,
-                    platform=None,
-                    platform_resource_identifier=None,
-                ),
+                factory_test_resource(title="my_test_resource_1", status=EntryStatus.PUBLISHED,
+                                      platform_resource_identifier="1"),
+                factory_test_resource(title="My second test resource", status=EntryStatus.PUBLISHED,
+                                      platform_resource_identifier="2"),
+                factory_test_resource(title="My third test resource", status=EntryStatus.PUBLISHED,
+                                      platform="openml", platform_resource_identifier="3",
+                                      date_deleted=datetime.datetime.now()),
+                factory_test_resource(title="My third test resource", status=EntryStatus.PUBLISHED,
+                                      platform="openml", platform_resource_identifier="4"),
+                factory_test_resource(title="My fourth test resource", status=EntryStatus.PUBLISHED,
+                                      platform=None, platform_resource_identifier=None),
             ]
         )
         session.commit()

--- a/src/tests/routers/generic/test_router_platform_get_all.py
+++ b/src/tests/routers/generic/test_router_platform_get_all.py
@@ -1,20 +1,23 @@
 from starlette.testclient import TestClient
 
 from database.session import DbSession
+from database.model.concept.aiod_entry import AIoDEntryORM
 from tests.testutils.test_resource import TestResource
 
 
-def test_get_all_happy_path(client_test_resource: TestClient):
+def test_get_all_happy_path(client_test_resource: TestClient, auto_publish):
     with DbSession() as session:
         session.add_all(
             [
                 TestResource(
-                    title="my_test_resource_1", platform="example", platform_resource_identifier="1"
+                    title="my_test_resource_1", platform="example", platform_resource_identifier="1",
+                    aiod_entry=AIoDEntryORM(),
                 ),
                 TestResource(
                     title="My second test resource",
                     platform="example",
                     platform_resource_identifier="2",
+                    aiod_entry=AIoDEntryORM(),
                 ),
             ]
         )

--- a/src/tests/routers/generic/test_router_post.py
+++ b/src/tests/routers/generic/test_router_post.py
@@ -1,10 +1,8 @@
-from unittest.mock import Mock
 
 import pytest
 from starlette.testclient import TestClient
 
-from tests.testutils.users import kc_user_with_roles, logged_in_user, \
-    bypass_reviewer_publish_everything
+from tests.testutils.users import logged_in_user
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routers/generic/test_router_post.py
+++ b/src/tests/routers/generic/test_router_post.py
@@ -12,7 +12,7 @@ from tests.testutils.users import kc_user_with_roles, logged_in_user, \
     ["\"'é:?", "!@#$%^&*()`~", "Ω≈ç√∫˜µ≤≥÷", "田中さんにあげて下さい", " أي بعد, ", "𝑻𝒉𝒆 𝐪𝐮𝐢𝐜𝐤", "گچپژ"],
 )
 def test_unicode(client_test_resource: TestClient, title: str, auto_publish: None):
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post(
             "/test_resources/v0",
             json={"title": title, "platform": "example", "platform_resource_identifier": "1"},
@@ -29,7 +29,7 @@ def test_unicode(client_test_resource: TestClient, title: str, auto_publish: Non
 
 def test_missing_value(client_test_resource: TestClient):
     body = {"platform": "example", "platform_resource_identifier": "1"}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post(
             "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
         )
@@ -41,7 +41,7 @@ def test_missing_value(client_test_resource: TestClient):
 
 def test_null_value(client_test_resource: TestClient):
     body = {"title": None, "platform": "example", "platform_resource_identifier": "1"}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post(
             "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
         )
@@ -58,11 +58,11 @@ def test_null_value(client_test_resource: TestClient):
 def test_posting_same_item_twice(client_test_resource: TestClient):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "example", "platform_resource_identifier": "1"}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 200, response.json()
     body = {"title": "title2", "platform": "example", "platform_resource_identifier": "1"}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 409, response.json()
     assert (
@@ -76,16 +76,16 @@ def test_posting_same_item_twice_but_deleted(
 ):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "example", "platform_resource_identifier": "1"}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 200, response.json()
 
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.delete("/test_resources/v0/1", headers=headers)
     assert response.status_code == 200, response.json()
 
     body = {"title": "title2", "platform": "example", "platform_resource_identifier": "1"}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 200, response.json()
 
@@ -95,11 +95,11 @@ def test_no_platform_no_platform_resource_identifier(
 ):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": None, "platform_resource_identifier": None}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 200, response.json()
     body = {"title": "title2", "platform": None, "platform_resource_identifier": None}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 200, response.json()
 
@@ -109,7 +109,7 @@ def test_no_platform_with_platform_resource_identifier(
 ):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": None, "platform_resource_identifier": "1"}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 400, response.json()
     assert (
@@ -124,7 +124,7 @@ def test_platform_with_no_platform_resource_identifier(
 ):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "example", "platform_resource_identifier": None}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 400, response.json()
     assert (
@@ -137,7 +137,7 @@ def test_platform_with_no_platform_resource_identifier(
 def test_non_existent_platform(client_test_resource: TestClient):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "this_does_not_exist", "platform_resource_identifier": 1}
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 412
     assert (

--- a/src/tests/routers/generic/test_router_post.py
+++ b/src/tests/routers/generic/test_router_post.py
@@ -3,41 +3,48 @@ from unittest.mock import Mock
 import pytest
 from starlette.testclient import TestClient
 
+from tests.testutils.users import kc_user_with_roles, logged_in_user, \
+    bypass_reviewer_publish_everything
+
 
 @pytest.mark.parametrize(
     "title",
     ["\"'é:?", "!@#$%^&*()`~", "Ω≈ç√∫˜µ≤≥÷", "田中さんにあげて下さい", " أي بعد, ", "𝑻𝒉𝒆 𝐪𝐮𝐢𝐜𝐤", "گچپژ"],
 )
-def test_unicode(client_test_resource: TestClient, title: str, mocked_privileged_token: Mock):
-    response = client_test_resource.post(
-        "/test_resources/v0",
-        json={"title": title, "platform": "example", "platform_resource_identifier": "1"},
-        headers={"Authorization": "Fake token"},
-    )
+def test_unicode(client_test_resource: TestClient, title: str, auto_publish: None):
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post(
+            "/test_resources/v0",
+            json={"title": title, "platform": "example", "platform_resource_identifier": "1"},
+            headers={"Authorization": "Fake token"},
+        )
     assert response.status_code == 200, response.json()
     assert response.json() == {"identifier": 1}
+
     response = client_test_resource.get("/test_resources/v0/1")
     assert response.status_code == 200, response.json()
     response_json = response.json()
     assert response_json["title"] == title
 
 
-def test_missing_value(client_test_resource: TestClient, mocked_privileged_token: Mock):
+def test_missing_value(client_test_resource: TestClient):
     body = {"platform": "example", "platform_resource_identifier": "1"}
-    response = client_test_resource.post(
-        "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
-    )
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post(
+            "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
+        )
     assert response.status_code == 422, response.json()
     assert response.json()["detail"] == [
         {"loc": ["body", "title"], "msg": "field required", "type": "value_error.missing"}
     ]
 
 
-def test_null_value(client_test_resource: TestClient, mocked_privileged_token: Mock):
+def test_null_value(client_test_resource: TestClient):
     body = {"title": None, "platform": "example", "platform_resource_identifier": "1"}
-    response = client_test_resource.post(
-        "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
-    )
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post(
+            "/test_resources/v0", json=body, headers={"Authorization": "Fake token"}
+        )
     assert response.status_code == 422, response.json()
     assert response.json()["detail"] == [
         {
@@ -48,13 +55,15 @@ def test_null_value(client_test_resource: TestClient, mocked_privileged_token: M
     ]
 
 
-def test_posting_same_item_twice(client_test_resource: TestClient, mocked_privileged_token: Mock):
+def test_posting_same_item_twice(client_test_resource: TestClient):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "example", "platform_resource_identifier": "1"}
-    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 200, response.json()
     body = {"title": "title2", "platform": "example", "platform_resource_identifier": "1"}
-    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 409, response.json()
     assert (
         response.json()["detail"] == "There already exists a test_resource with the same "
@@ -63,39 +72,45 @@ def test_posting_same_item_twice(client_test_resource: TestClient, mocked_privil
 
 
 def test_posting_same_item_twice_but_deleted(
-    client_test_resource: TestClient, mocked_privileged_token: Mock
+    client_test_resource: TestClient
 ):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "example", "platform_resource_identifier": "1"}
-    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 200, response.json()
 
-    response = client_test_resource.delete("/test_resources/v0/1", headers=headers)
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.delete("/test_resources/v0/1", headers=headers)
     assert response.status_code == 200, response.json()
 
     body = {"title": "title2", "platform": "example", "platform_resource_identifier": "1"}
-    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 200, response.json()
 
 
 def test_no_platform_no_platform_resource_identifier(
-    client_test_resource: TestClient, mocked_privileged_token: Mock
+    client_test_resource: TestClient
 ):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": None, "platform_resource_identifier": None}
-    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 200, response.json()
     body = {"title": "title2", "platform": None, "platform_resource_identifier": None}
-    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 200, response.json()
 
 
 def test_no_platform_with_platform_resource_identifier(
-    client_test_resource: TestClient, mocked_privileged_token: Mock
+    client_test_resource: TestClient
 ):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": None, "platform_resource_identifier": "1"}
-    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 400, response.json()
     assert (
         response.json()["detail"]
@@ -105,11 +120,12 @@ def test_no_platform_with_platform_resource_identifier(
 
 
 def test_platform_with_no_platform_resource_identifier(
-    client_test_resource: TestClient, mocked_privileged_token: Mock
+    client_test_resource: TestClient
 ):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "example", "platform_resource_identifier": None}
-    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 400, response.json()
     assert (
         response.json()["detail"]
@@ -118,10 +134,11 @@ def test_platform_with_no_platform_resource_identifier(
     )
 
 
-def test_non_existent_platform(client_test_resource: TestClient, mocked_privileged_token: Mock):
+def test_non_existent_platform(client_test_resource: TestClient):
     headers = {"Authorization": "Fake token"}
     body = {"title": "title1", "platform": "this_does_not_exist", "platform_resource_identifier": 1}
-    response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
+    with logged_in_user(kc_user_with_roles()):
+        response = client_test_resource.post("/test_resources/v0", json=body, headers=headers)
     assert response.status_code == 412
     assert (
         response.json()["detail"] == "Platform this_does_not_exist does not exist. You can "

--- a/src/tests/routers/generic/test_router_relations.py
+++ b/src/tests/routers/generic/test_router_relations.py
@@ -197,7 +197,7 @@ def test_get_all_happy_path(client_with_testobject: TestClient):
 
 
 def test_post_happy_path(client_with_testobject: TestClient, auto_publish: None):
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client_with_testobject.post(
             "/test_resources/v0",
             json={

--- a/src/tests/routers/generic/test_router_relations.py
+++ b/src/tests/routers/generic/test_router_relations.py
@@ -18,7 +18,8 @@ from database.model.serializers import (
 )
 from database.session import DbSession
 from routers import ResourceRouter
-from tests.testutils.users import logged_in_user, kc_user_with_roles
+from tests.testutils.users import logged_in_user, kc_user_with_roles, \
+    bypass_reviewer_publish_everything
 
 
 class TestEnum(NamedRelation, table=True):  # type: ignore [call-arg]
@@ -135,30 +136,29 @@ def client_with_testobject() -> TestClient:
     with DbSession() as session:
         named1, named2 = TestEnum(name="named_string1"), TestEnum(name="named_string2")
         enum1, enum2, enum3 = TestEnum2(name="1"), TestEnum2(name="2"), TestEnum2(name="3")
-        draft = EntryStatus.DRAFT
         session.add_all(
             [
                 TestObject(
-                    aiod_entry=AIoDEntryORM(status=draft),
+                    aiod_entry=AIoDEntryORM(status=EntryStatus.PUBLISHED),
                     identifier=1,
                     title="object 1",
                     named_string=named1,
                     named_string_list=[enum1, enum2],
                 ),
                 TestObject(
-                    aiod_entry=AIoDEntryORM(status=draft),
+                    aiod_entry=AIoDEntryORM(status=EntryStatus.PUBLISHED),
                     identifier=2,
                     title="object 2",
                     named_string=named1,
                 ),
                 TestObject(
-                    aiod_entry=AIoDEntryORM(status=draft),
+                    aiod_entry=AIoDEntryORM(status=EntryStatus.PUBLISHED),
                     identifier=3,
                     title="object 3",
                     named_string=named2,
                     named_string_list=[enum2, enum3],
                 ),
-                TestObject(aiod_entry=AIoDEntryORM(status=draft), identifier=4, title="object 4"),
+                TestObject(aiod_entry=AIoDEntryORM(status=EntryStatus.PUBLISHED), identifier=4, title="object 4"),
             ]
         )
         session.commit()
@@ -196,20 +196,21 @@ def test_get_all_happy_path(client_with_testobject: TestClient):
     assert "named_string" not in r4
 
 
-def test_post_happy_path(client_with_testobject: TestClient, mocked_privileged_token: Mock):
-    response = client_with_testobject.post(
-        "/test_resources/v0",
-        json={
-            "title": "title",
-            "named_string": "named_string1",
-            "named_string_list": ["1", "4"],
-            "related_objects": [
-                {"field1": "val1.1", "field2": "val1.2"},
-                {"field1": "val2.1", "field2": "val2.2"},
-            ],
-        },
-        headers={"Authorization": "Fake token"},
-    )
+def test_post_happy_path(client_with_testobject: TestClient, auto_publish: None):
+    with logged_in_user(kc_user_with_roles()):
+        response = client_with_testobject.post(
+            "/test_resources/v0",
+            json={
+                "title": "title",
+                "named_string": "named_string1",
+                "named_string_list": ["1", "4"],
+                "related_objects": [
+                    {"field1": "val1.1", "field2": "val1.2"},
+                    {"field1": "val2.1", "field2": "val2.2"},
+                ],
+            },
+            headers={"Authorization": "Fake token"},
+        )
     assert response.status_code == 200, response.json()
     objects = client_with_testobject.get("/test_resources/v0").json()
     obj = objects[-1]
@@ -226,7 +227,7 @@ def test_post_happy_path(client_with_testobject: TestClient, mocked_privileged_t
     assert related_objects[1]["field2"] == "val2.2"
 
 
-def test_put_happy_path(client_with_testobject: TestClient):
+def test_put_happy_path(client_with_testobject: TestClient, auto_publish: None):
     with logged_in_user(kc_user_with_roles("update_test_resources")):
         response = client_with_testobject.put(
             "/test_resources/v0/4",

--- a/src/tests/routers/generic/test_router_relations.py
+++ b/src/tests/routers/generic/test_router_relations.py
@@ -1,5 +1,4 @@
 from typing import Optional, List, Type
-from unittest.mock import Mock
 
 import pytest
 from fastapi import FastAPI
@@ -18,8 +17,7 @@ from database.model.serializers import (
 )
 from database.session import DbSession
 from routers import ResourceRouter
-from tests.testutils.users import logged_in_user, kc_user_with_roles, \
-    bypass_reviewer_publish_everything
+from tests.testutils.users import logged_in_user, kc_user_with_roles
 
 
 class TestEnum(NamedRelation, table=True):  # type: ignore [call-arg]

--- a/src/tests/routers/resource_routers/test_resource_router.py
+++ b/src/tests/routers/resource_routers/test_resource_router.py
@@ -63,7 +63,6 @@ def test_happy_path_with_filters(
         f"/{resource_type}/v1", json=body_asset, headers={"Authorization": "Fake token"}
     )
     assert response.status_code == 200, response.json()
-    # bypass_reviewer_publish_everything()
 
     response = client.get(f"/{resource_type}/v1", params=resource_filters)
     assert response.status_code == 200, response.json()

--- a/src/tests/routers/resource_routers/test_resource_router.py
+++ b/src/tests/routers/resource_routers/test_resource_router.py
@@ -4,6 +4,8 @@ from unittest.mock import Mock
 import pytest
 from starlette.testclient import TestClient
 
+from tests.testutils.users import bypass_reviewer_publish_everything
+
 
 @pytest.mark.parametrize(
     "resource_type",
@@ -55,11 +57,13 @@ def test_happy_path_with_filters(
     resource_type,
     resource_filters: dict,
     expected_count: int,
+    auto_publish: None,
 ):
     response = client.post(
         f"/{resource_type}/v1", json=body_asset, headers={"Authorization": "Fake token"}
     )
     assert response.status_code == 200, response.json()
+    # bypass_reviewer_publish_everything()
 
     response = client.get(f"/{resource_type}/v1", params=resource_filters)
     assert response.status_code == 200, response.json()

--- a/src/tests/routers/resource_routers/test_resource_router.py
+++ b/src/tests/routers/resource_routers/test_resource_router.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock
 import pytest
 from starlette.testclient import TestClient
 
-from tests.testutils.users import bypass_reviewer_publish_everything
 
 
 @pytest.mark.parametrize(

--- a/src/tests/routers/resource_routers/test_router_case_study.py
+++ b/src/tests/routers/resource_routers/test_router_case_study.py
@@ -2,7 +2,7 @@ import copy
 
 from starlette.testclient import TestClient
 
-from tests.testutils.users import logged_in_user, bypass_reviewer_publish_everything
+from tests.testutils.users import logged_in_user
 
 
 def test_happy_path(

--- a/src/tests/routers/resource_routers/test_router_case_study.py
+++ b/src/tests/routers/resource_routers/test_router_case_study.py
@@ -1,20 +1,21 @@
 import copy
-from unittest.mock import Mock
 
 from starlette.testclient import TestClient
+
+from tests.testutils.users import logged_in_user, bypass_reviewer_publish_everything
 
 
 def test_happy_path(
     client: TestClient,
-    mocked_privileged_token: Mock,
     body_asset: dict,
+    auto_publish: None,
 ):
     body = copy.copy(body_asset)
     body["name"] = "Case Study"
 
-    response = client.post("/case_studies/v1", json=body, headers={"Authorization": "Fake token"})
+    with logged_in_user():
+        response = client.post("/case_studies/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
-
     response = client.get("/case_studies/v1/1")
     assert response.status_code == 200, response.json()
 

--- a/src/tests/routers/resource_routers/test_router_computational_asset.py
+++ b/src/tests/routers/resource_routers/test_router_computational_asset.py
@@ -2,7 +2,7 @@ import copy
 
 from starlette.testclient import TestClient
 
-from tests.testutils.users import logged_in_user, bypass_reviewer_publish_everything
+from tests.testutils.users import logged_in_user
 
 
 def test_happy_path(client: TestClient, body_asset: dict, auto_publish: None):

--- a/src/tests/routers/resource_routers/test_router_computational_asset.py
+++ b/src/tests/routers/resource_routers/test_router_computational_asset.py
@@ -1,17 +1,19 @@
 import copy
-from unittest.mock import Mock
 
 from starlette.testclient import TestClient
 
+from tests.testutils.users import logged_in_user, bypass_reviewer_publish_everything
 
-def test_happy_path(client: TestClient, mocked_privileged_token: Mock, body_asset: dict):
+
+def test_happy_path(client: TestClient, body_asset: dict, auto_publish: None):
     body = copy.deepcopy(body_asset)
     body["status_info"] = "https://www.example.com/cluster-status"
     body["type"] = "storage"
 
-    response = client.post(
-        "/computational_assets/v1", json=body, headers={"Authorization": "Fake token"}
-    )
+    with logged_in_user():
+        response = client.post(
+            "/computational_assets/v1", json=body, headers={"Authorization": "Fake token"}
+        )
     assert response.status_code == 200, response.json()
 
     response = client.get("/computational_assets/v1/1")

--- a/src/tests/routers/resource_routers/test_router_contact.py
+++ b/src/tests/routers/resource_routers/test_router_contact.py
@@ -11,7 +11,7 @@ from database.model.platform.platform import Platform
 from database.session import DbSession
 from tests.testutils.default_instances import _create_class_with_body
 from tests.testutils.default_sqlalchemy import AI4EUROPE_CMS_TOKEN
-from tests.testutils.users import logged_in_user, bypass_reviewer_publish_everything
+from tests.testutils.users import logged_in_user
 
 
 def test_happy_path(client: TestClient, body_asset: dict, auto_publish: None):

--- a/src/tests/routers/resource_routers/test_router_contact.py
+++ b/src/tests/routers/resource_routers/test_router_contact.py
@@ -11,12 +11,14 @@ from database.model.platform.platform import Platform
 from database.session import DbSession
 from tests.testutils.default_instances import _create_class_with_body
 from tests.testutils.default_sqlalchemy import AI4EUROPE_CMS_TOKEN
+from tests.testutils.users import logged_in_user, bypass_reviewer_publish_everything
 
 
-def test_happy_path(client: TestClient, mocked_privileged_token: Mock, body_asset: dict):
-    client.post(
-        "/persons/v1", json={"name": "test person"}, headers={"Authorization": "Fake token"}
-    )
+def test_happy_path(client: TestClient, body_asset: dict, auto_publish: None):
+    with logged_in_user():
+        client.post(
+            "/persons/v1", json={"name": "test person"}, headers={"Authorization": "Fake token"}
+        )
 
     body = copy.deepcopy(body_asset)
     body["name"] = "Contact name"
@@ -30,10 +32,12 @@ def test_happy_path(client: TestClient, mocked_privileged_token: Mock, body_asse
     ]
     body["person"] = 1
 
-    response = client.post("/contacts/v1", json=body, headers={"Authorization": "Fake token"})
+    with logged_in_user():
+        response = client.post("/contacts/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
 
-    response = client.get("/contacts/v1/1", headers={"Authorization": "Fake token"})
+    with logged_in_user():  # Authenticated users should not get masked e-mail addresses
+        response = client.get("/contacts/v1/1", headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
 
     response_json = response.json()
@@ -51,34 +55,38 @@ def test_happy_path(client: TestClient, mocked_privileged_token: Mock, body_asse
 
 def test_post_duplicate_email(
     client: TestClient,
-    mocked_privileged_token: Mock,
+    auto_publish: None,
 ):
     """
     It should be possible to add same email in different contacts, to enable
     """
     body1 = {"email": ["a@example.com", "b@example.com"]}
     body2 = {"email": ["c@example.com", "b@example.com"]}
-    response = client.post("/contacts/v1", json=body1, headers={"Authorization": "Fake token"})
-    assert response.status_code == 200, response.json()
-    response = client.post("/contacts/v1", json=body2, headers={"Authorization": "Fake token"})
-    assert response.status_code == 200, response.json()
+    # Authenticated users should not get masked e-mail addresses
+    with logged_in_user():
+        response = client.post("/contacts/v1", json=body1, headers={"Authorization": "Fake token"})
+        assert response.status_code == 200, response.json()
 
-    contact = client.get("/contacts/v1/2", headers={"Authorization": "Fake token"}).json()
-    assert set(contact["email"]) == {"b@example.com", "c@example.com"}
-    body3 = {"email": ["d@example.com", "b@example.com"]}
-    client.put("/contacts/v1/1", json=body3, headers={"Authorization": "Fake token"})
-    contact = client.get("/contacts/v1/2", headers={"Authorization": "Fake token"}).json()
-    msg = "changing emails of contact 1 should not change emails of contact 2."
-    assert set(contact["email"]) == {"b@example.com", "c@example.com"}, msg
+        response = client.post("/contacts/v1", json=body2, headers={"Authorization": "Fake token"})
+        assert response.status_code == 200, response.json()
+
+        contact = client.get("/contacts/v1/2", headers={"Authorization": "Fake token"}).json()
+        assert set(contact["email"]) == {"b@example.com", "c@example.com"}
+
+        body3 = {"email": ["d@example.com", "b@example.com"]}
+        client.put("/contacts/v1/1", json=body3, headers={"Authorization": "Fake token"})
+        contact = client.get("/contacts/v1/2", headers={"Authorization": "Fake token"}).json()
+        msg = "changing emails of contact 1 should not change emails of contact 2."
+        assert set(contact["email"]) == {"b@example.com", "c@example.com"}, msg
 
 
-def test_person_and_organisation_both_specified(client: TestClient, mocked_privileged_token):
+def test_person_and_organisation_both_specified(client: TestClient):
     headers = {"Authorization": "Fake token"}
-    client.post("/persons/v1", json={"name": "test person"}, headers=headers)
-    client.post("/organisations/v1", json={"name": "test organisation"}, headers=headers)
-
     body = {"person": 1, "organisation": 1}
-    response = client.post("/contacts/v1", json=body, headers=headers)
+    with logged_in_user():
+        client.post("/persons/v1", json={"name": "test person"}, headers=headers)
+        client.post("/organisations/v1", json={"name": "test organisation"}, headers=headers)
+        response = client.post("/contacts/v1", json=body, headers=headers)
     assert response.status_code == 400, response.json()
     assert response.json()["detail"] == "Person and organisation cannot be both filled."
 
@@ -109,6 +117,7 @@ def test_email_mask_for_not_authenticated_user(
     contact: Contact,
     contact2: Contact,
     endpoint_from_fixture1: str,
+    auto_publish: None,
 ):
     with DbSession() as session:
         session.add(contact)
@@ -131,6 +140,7 @@ def test_email_mask_for_authenticated_user(
     overwrites_keycloak_token: None,  # Technically already used by privileged token, but we also overwrite explicitly  # noqa: E501
     contact: Contact,
     contact2: Contact,
+    auto_publish: None,
 ):
     headers = {"Authorization": "Fake token"}
 
@@ -182,6 +192,7 @@ def test_email_privacy_for_ai4europe_cms(
     contact: Contact,
     platform: Platform,
     endpoint_from_fixture2: str,
+    auto_publish: None,
 ):
 
     with DbSession() as session:

--- a/src/tests/routers/resource_routers/test_router_dataset.py
+++ b/src/tests/routers/resource_routers/test_router_dataset.py
@@ -6,7 +6,7 @@ from starlette.testclient import TestClient
 
 from database.model.agent.person import Person
 from database.session import DbSession
-from tests.testutils.users import logged_in_user, bypass_reviewer_publish_everything
+from tests.testutils.users import logged_in_user
 
 
 def test_happy_path(

--- a/src/tests/routers/resource_routers/test_router_dataset.py
+++ b/src/tests/routers/resource_routers/test_router_dataset.py
@@ -6,13 +6,14 @@ from starlette.testclient import TestClient
 
 from database.model.agent.person import Person
 from database.session import DbSession
+from tests.testutils.users import logged_in_user, bypass_reviewer_publish_everything
 
 
 def test_happy_path(
     client: TestClient,
-    mocked_privileged_token: Mock,
     body_asset: dict,
     person: Person,
+    auto_publish: None,
 ):
     with DbSession() as session:
         session.add(person)
@@ -30,7 +31,8 @@ def test_happy_path(
         "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},
     }
 
-    response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
+    with logged_in_user():
+        response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
 
     response = client.get("/datasets/v1/1")

--- a/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
+++ b/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
@@ -21,7 +21,7 @@ from database.model.dataset.dataset import Dataset
 from database.model.knowledge_asset.publication import Publication
 from database.model.news.news import News
 from database.session import DbSession
-from tests.testutils.users import logged_in_user, bypass_reviewer_publish_everything
+from tests.testutils.users import logged_in_user
 
 
 def test_happy_path(

--- a/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
+++ b/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
@@ -1,6 +1,8 @@
 import copy
 import time
 from datetime import datetime
+from functools import partial
+from http import HTTPStatus
 from unittest.mock import Mock
 
 import dateutil.parser
@@ -19,15 +21,16 @@ from database.model.dataset.dataset import Dataset
 from database.model.knowledge_asset.publication import Publication
 from database.model.news.news import News
 from database.session import DbSession
+from tests.testutils.users import logged_in_user, bypass_reviewer_publish_everything
 
 
 def test_happy_path(
     client: TestClient,
-    mocked_privileged_token: Mock,
     body_asset: dict,
     person: Person,
     publication: Publication,
     contact: Contact,
+    auto_publish: None,
 ):
     with DbSession() as session:
         session.add(person)
@@ -45,7 +48,8 @@ def test_happy_path(
     body["description"] = {"plain": description_plain, "html": description_html}
 
     datetime_create_request = datetime.utcnow().replace(tzinfo=pytz.utc)
-    response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
+    with logged_in_user():
+        response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
 
     response = client.get("/datasets/v1/1")
@@ -59,7 +63,7 @@ def test_happy_path(
     assert response_json["platform"] == "example"
     assert response_json["platform_resource_identifier"] == "1"
     assert response_json["aiod_entry"]["editor"] == [1]
-    assert response_json["aiod_entry"]["status"] == EntryStatus.DRAFT
+    assert response_json["aiod_entry"]["status"] == EntryStatus.PUBLISHED
     date_created = dateutil.parser.parse(response_json["aiod_entry"]["date_created"] + "Z")
     date_modified = dateutil.parser.parse(response_json["aiod_entry"]["date_modified"] + "Z")
     assert 0 < (date_created - datetime_create_request).total_seconds() < 0.2
@@ -120,7 +124,8 @@ def test_happy_path(
 
     time.sleep(0.15)
     datetime_update_request = datetime.utcnow().replace(tzinfo=pytz.utc)
-    response = client.put("/datasets/v1/1", json=body, headers={"Authorization": "Fake token"})
+    with logged_in_user():
+        response = client.put("/datasets/v1/1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
 
     response = client.get("/datasets/v1/1")
@@ -148,7 +153,7 @@ def test_happy_path(
 
 def test_post_duplicate_named_relations(
     client: TestClient,
-    mocked_privileged_token: Mock,
+    auto_publish: None,
 ):
     """
     Unittest mirroring situation reported during the data migration of AI4EU news.
@@ -182,10 +187,15 @@ def test_post_duplicate_named_relations(
         "ArtificialIntelligence",
     )
 
-    client.post("/news/v1", json=body1, headers={"Authorization": "Fake token"})
-    response = client.post("/news/v1", json=body2, headers={"Authorization": "Fake token"})
-    assert response.status_code == 200, response.json()
+    post_news = partial(client.post, "/news/v1", headers={"Authorization": "Fake token"})
+    with logged_in_user():
+        assert post_news(json=body1).status_code == HTTPStatus.OK
+        assert post_news(json=body2).status_code == HTTPStatus.OK
+        assert post_news(json=body3).status_code == HTTPStatus.OK
+        assert post_news(json=body4).status_code == HTTPStatus.OK
+
     response = client.get("/news/v1/2")
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert set(response.json()["keyword"]) == {
         "ai",
         "artificialintelligence",
@@ -196,10 +206,8 @@ def test_post_duplicate_named_relations(
         "energy",
     }
 
-    client.post("/news/v1", json=body3, headers={"Authorization": "Fake token"})
     response = client.get("/news/v1/3")
     assert len(response.json()["keyword"]) == 0
-    client.post("/news/v1", json=body4, headers={"Authorization": "Fake token"})
     response = client.get("/news/v1/4")
     assert set(response.json()["keyword"]) == {
         "ai4eu experiments",
@@ -230,15 +238,16 @@ def test_post_duplicate_named_relations_with_different_capitals(
 
 def test_post_editors(
     client: TestClient,
-    mocked_privileged_token: Mock,
+    auto_publish: None,
 ):
     """
     Unittest mirroring situation reported during the data migration of AI4EU events.
     """
     headers = {"Authorization": "Fake token"}
-    client.post("/persons/v1", json={"name": "1"}, headers=headers)
-    client.post("/persons/v1", json={"name": "2"}, headers=headers)
-    client.post("/persons/v1", json={"name": "3"}, headers=headers)
+    with logged_in_user():
+        client.post("/persons/v1", json={"name": "1"}, headers=headers)
+        client.post("/persons/v1", json={"name": "2"}, headers=headers)
+        client.post("/persons/v1", json={"name": "3"}, headers=headers)
 
     def assert_editors_are_stored(id_: str, *editors: int):
         body = {
@@ -247,7 +256,8 @@ def test_post_editors(
             "name": "How user evaluation changed in times of COVID-19",
             "aiod_entry": {"editor": editors},
         }
-        response = client.post("/events/v1", json=body, headers=headers)
+        with logged_in_user():
+            response = client.post("/events/v1", json=body, headers=headers)
         assert response.status_code == 200, response.json()
         response = client.get(f"/events/v1/{response.json()['identifier']}")
         assert response.status_code == 200, response.json()
@@ -259,10 +269,11 @@ def test_post_editors(
     assert_editors_are_stored("36", 1, 2)
 
 
-def test_create_aiod_entry(client: TestClient, mocked_privileged_token: Mock):
+def test_create_aiod_entry(client: TestClient, auto_publish):
     body = {"name": "news"}
     start = datetime.now(pytz.utc)
-    response = client.post("/news/v1", json=body, headers={"Authorization": "Fake token"})
+    with logged_in_user():
+        response = client.post("/news/v1", json=body, headers={"Authorization": "Fake token"})
     end = datetime.now(pytz.utc)
     assert response.status_code == 200, response.json()
     response = client.get("/news/v1/1")
@@ -281,6 +292,7 @@ def test_update_aiod_entry(
     client: TestClient,
     mocked_privileged_token: Mock,
     person: Person,
+    auto_publish: None,
 ):
     with DbSession() as session:
         session.add(person)
@@ -323,7 +335,7 @@ def assert_distributions(client: TestClient, *content_urls: str):
         assert {distribution.content_url for distribution in distributions} == set(content_urls)
 
 
-def test_update_distribution(client: TestClient, mocked_privileged_token: Mock):
+def test_update_distribution(client: TestClient, mocked_privileged_token: Mock, auto_publish: None):
     body = {"name": "dataset", "distribution": [{"content_url": "url"}]}
     response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
@@ -364,6 +376,7 @@ def test_relations_between_resources(
     dataset: Dataset,
     publication: Publication,
     organisation: Organisation,
+    auto_publish: None,
 ):
     with DbSession() as session:
         session.add(dataset)

--- a/src/tests/routers/resource_routers/test_router_educational_resource.py
+++ b/src/tests/routers/resource_routers/test_router_educational_resource.py
@@ -8,6 +8,7 @@ def test_happy_path(
     client: TestClient,
     mocked_privileged_token: Mock,
     body_asset: dict,
+    auto_publish: None,
 ):
     body = copy.deepcopy(body_asset)
     body["time_required"] = "3 weeks"

--- a/src/tests/routers/resource_routers/test_router_event.py
+++ b/src/tests/routers/resource_routers/test_router_event.py
@@ -12,6 +12,7 @@ def test_happy_path(
     mocked_privileged_token: Mock,
     body_resource: dict,
     person: Person,
+    auto_publish: None,
 ):
 
     with DbSession() as session:

--- a/src/tests/routers/resource_routers/test_router_experiment.py
+++ b/src/tests/routers/resource_routers/test_router_experiment.py
@@ -8,6 +8,7 @@ def test_happy_path(
     client: TestClient,
     mocked_privileged_token: Mock,
     body_asset: dict,
+    auto_publish: None,
 ):
     body = copy.copy(body_asset)
     body["pid"] = "https://doi.org/10.1000/182"

--- a/src/tests/routers/resource_routers/test_router_ml_model.py
+++ b/src/tests/routers/resource_routers/test_router_ml_model.py
@@ -12,6 +12,7 @@ def test_happy_path(
     mocked_privileged_token: Mock,
     experiment: Experiment,
     body_asset: dict,
+    auto_publish: None,
 ):
     with DbSession() as session:
         session.add(experiment)

--- a/src/tests/routers/resource_routers/test_router_news.py
+++ b/src/tests/routers/resource_routers/test_router_news.py
@@ -8,6 +8,7 @@ def test_happy_path(
     client: TestClient,
     mocked_privileged_token: Mock,
     body_resource: dict,
+    auto_publish: None,
 ):
     body = copy.deepcopy(body_resource)
     body["headline"] = "A headline to show on top of the page."

--- a/src/tests/routers/resource_routers/test_router_organisation.py
+++ b/src/tests/routers/resource_routers/test_router_organisation.py
@@ -14,6 +14,7 @@ def test_happy_path(
     organisation: Organisation,
     contact: Contact,
     body_agent: dict,
+    auto_publish: None,
 ):
     with DbSession() as session:
         session.add(organisation)  # The new organisation will be a member of this organisation

--- a/src/tests/routers/resource_routers/test_router_person.py
+++ b/src/tests/routers/resource_routers/test_router_person.py
@@ -20,7 +20,7 @@ def test_happy_path(
     person: Person,
     contact: Contact,
     organisation: Organisation,
-
+    auto_publish: None,
 ):
     with DbSession() as session:
         person.platform_resource_identifier = "2"
@@ -77,6 +77,7 @@ def test_privacy_for_ai4europe_cms(
     person: Person,
     contact: Contact,
     endpoint: str,
+    auto_publish: None,
 ):
     """Test to ensure that only authenticated users with "full_view_ai4europe_cms_resources" role
     can visualise fields such as name, given_name and surname of a person migrated from

--- a/src/tests/routers/resource_routers/test_router_platform.py
+++ b/src/tests/routers/resource_routers/test_router_platform.py
@@ -9,7 +9,7 @@ from database.model.platform.platform_names import PlatformName
 @pytest.mark.parametrize(
     "mocked_token", [["create_platforms"]], indirect=True
 )
-def test_happy_path(mocked_token: Mock, client: TestClient):
+def test_happy_path(mocked_token: Mock, client: TestClient, auto_publish: None):
     body = {"name": "my_favourite_platform"}
     response = client.post("/platforms/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()

--- a/src/tests/routers/resource_routers/test_router_project.py
+++ b/src/tests/routers/resource_routers/test_router_project.py
@@ -18,6 +18,7 @@ def test_happy_path(
     organisation: Organisation,
     publication: Publication,
     dataset: Dataset,
+    auto_publish: None,
 ):
     with DbSession() as session:
         session.add(person)

--- a/src/tests/routers/resource_routers/test_router_publication.py
+++ b/src/tests/routers/resource_routers/test_router_publication.py
@@ -11,6 +11,7 @@ def test_happy_path(
     mocked_privileged_token: Mock,
     body_asset: dict,
     dataset: Dataset,
+    auto_publish: None,
 ):
     body = copy.copy(body_asset)
     body["permanent_identifier"] = "http://dx.doi.org/10.1093/ajae/aaq063"

--- a/src/tests/routers/resource_routers/test_router_resource_bundle.py
+++ b/src/tests/routers/resource_routers/test_router_resource_bundle.py
@@ -2,7 +2,6 @@ import copy
 from unittest.mock import Mock
 
 from starlette.testclient import TestClient
-from database.model.resource_bundle.resource_bundle import ResourceBundle
 from database.model.ai_resource.resource_table import AIResourceORM
 from database.session import DbSession
 

--- a/src/tests/routers/resource_routers/test_router_resource_bundle.py
+++ b/src/tests/routers/resource_routers/test_router_resource_bundle.py
@@ -11,6 +11,7 @@ def test_resource_bundle_api(
     client: TestClient,
     mocked_privileged_token: Mock,
     body_asset: dict,
+    auto_publish: None,
 ):
     """
     Test creating and retrieving a ResourceBundle through the API.

--- a/src/tests/routers/resource_routers/test_router_service.py
+++ b/src/tests/routers/resource_routers/test_router_service.py
@@ -8,6 +8,7 @@ def test_happy_path(
     client: TestClient,
     mocked_privileged_token: Mock,
     body_resource: dict,
+    auto_publish: None,
 ):
     body = copy.copy(body_resource)
     body["slogan"] = "Smart Blockchains for everyone!"

--- a/src/tests/routers/resource_routers/test_router_team.py
+++ b/src/tests/routers/resource_routers/test_router_team.py
@@ -14,6 +14,7 @@ def test_happy_path(
     body_resource: dict,
     person: Person,
     organisation: Organisation,
+    auto_publish: None,
 ):
     with DbSession() as session:
         session.add(person)

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -1,24 +1,27 @@
 import sqlite3
 import tempfile
+from functools import partial
 from typing import Iterator, Any
 from unittest.mock import Mock
 
 import pytest
 from fastapi import FastAPI
 from pytest import FixtureRequest
-from sqlalchemy import event
+from sqlalchemy import event, text
 from sqlalchemy.engine import Engine
 from sqlmodel import create_engine, SQLModel, Session, select
 from starlette.testclient import TestClient
 
 from authentication import keycloak_openid
 from database.deletion.triggers import create_delete_triggers
+from database.model.concept.aiod_entry import EntryStatus, AIoDEntryORM
 from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
 from database.session import EngineSingleton
 from main import build_app
 from tests.testutils.test_resource import RouterTestResource, factory
+from tests.testutils.users import bypass_reviewer_publish_everything
 
 
 @pytest.fixture(scope="session")
@@ -66,6 +69,7 @@ def clear_db(request, engine: Engine):
                 )
             )
         session.commit()
+        bypass_reviewer_publish_everything()
 
     yield
 
@@ -94,6 +98,46 @@ def client(engine: Engine) -> TestClient:
     """
     app = build_app(version="unittest")
     yield TestClient(app, base_url="http://localhost")
+
+
+@pytest.fixture(scope="session")
+def client_with_headers(engine: Engine) -> TestClient:
+    """Yield a client which can mock requests and always sets a header.
+    To be used in conjunction with functions such as `logged_in_user`.
+    """
+    app = build_app(version="unittest")
+    client = TestClient(app, base_url="http://localhost")
+    for operation in ["get", "put", "post", "delete"]:
+        operation_with_header = partial(getattr(client, operation), headers={"Authorization": "Fake token"})
+        setattr(client, operation, operation_with_header)
+    yield client
+
+
+# *NEVER* broaden the scope of this fixture, bypassing reviews should be on a test-by-test basis
+@pytest.fixture(scope="function")
+def auto_publish(engine: Engine):
+    """Automatically sets *all* new insertions to the aiod_entry table as published.
+
+    This can be useful to bypass the reviewing workflow, as otherwise assets that were
+    just uploaded also require authenticated requests as they would be in a private
+    DRAFT status.
+    """
+    trigger_name = "publish_on_insert"
+    with Session(engine) as session:
+        session.execute(
+            text(f"""
+            CREATE TRIGGER {trigger_name}
+            AFTER INSERT ON {AIoDEntryORM.__tablename__}
+            BEGIN
+              UPDATE {AIoDEntryORM.__tablename__}
+              SET status='{EntryStatus.PUBLISHED.upper()}'
+              WHERE identifier=NEW.identifier;
+            END;
+            """)
+        )
+    yield
+    with Session(engine):
+        session.execute(text(f"DROP TRIGGER {trigger_name}"))
 
 
 @pytest.fixture(scope="session")

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -136,7 +136,7 @@ def auto_publish(engine: Engine):
             """)
         )
     yield
-    with Session(engine):
+    with Session(engine) as session:
         session.execute(text(f"DROP TRIGGER {trigger_name}"))
 
 

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -20,7 +20,7 @@ from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
 from database.session import EngineSingleton
 from main import build_app
-from tests.testutils.test_resource import RouterTestResource, factory
+from tests.testutils.test_resource import RouterTestResource, factory_test_resource
 from tests.testutils.users import bypass_reviewer_publish_everything
 
 
@@ -62,11 +62,8 @@ def clear_db(request, engine: Engine):
         session.add_all([Platform(name=name) for name in PlatformName])
         if any("engine" in fixture and "filled" in fixture for fixture in request.fixturenames):
             session.add(
-                factory(
-                    title="A title",
-                    platform="example",
-                    platform_resource_identifier="1",
-                )
+                factory_test_resource(title="A title", platform="example",
+                                      platform_resource_identifier="1")
             )
         session.commit()
         bypass_reviewer_publish_everything()

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -1,6 +1,5 @@
 import sqlite3
 import tempfile
-from functools import partial
 from typing import Iterator, Any
 from unittest.mock import Mock
 

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -97,19 +97,6 @@ def client(engine: Engine) -> TestClient:
     yield TestClient(app, base_url="http://localhost")
 
 
-@pytest.fixture(scope="session")
-def client_with_headers(engine: Engine) -> TestClient:
-    """Yield a client which can mock requests and always sets a header.
-    To be used in conjunction with functions such as `logged_in_user`.
-    """
-    app = build_app(version="unittest")
-    client = TestClient(app, base_url="http://localhost")
-    for operation in ["get", "put", "post", "delete"]:
-        operation_with_header = partial(getattr(client, operation), headers={"Authorization": "Fake token"})
-        setattr(client, operation, operation_with_header)
-    yield client
-
-
 # *NEVER* broaden the scope of this fixture, bypassing reviews should be on a test-by-test basis
 @pytest.fixture(scope="function")
 def auto_publish(engine: Engine):

--- a/src/tests/testutils/test_resource.py
+++ b/src/tests/testutils/test_resource.py
@@ -19,7 +19,8 @@ class TestResource(TestResourceBase, AIoDConcept, table=True):  # type: ignore [
     identifier: int = Field(default=None, primary_key=True)
 
 
-def factory(
+# Note that the alternative name `test_resource_factory` would make pytest pick this up as a unit test
+def factory_test_resource(
     title="default_title", status=EntryStatus.DRAFT, platform="example", platform_resource_identifier="1", date_deleted=None
 ):
     return TestResource(

--- a/src/tests/testutils/users.py
+++ b/src/tests/testutils/users.py
@@ -1,13 +1,16 @@
 import contextlib
+from select import select
 from typing import cast
 from unittest.mock import Mock
 
+from sqlalchemy import update
+
 from authentication import KeycloakUser, keycloak_openid, REVIEWER_ROLE
 from database.authorization import register_user, set_permission, PermissionType
-from database.model.concept.aiod_entry import EntryStatus
+from database.model.concept.aiod_entry import EntryStatus, AIoDEntryORM
 from database.model.concept.concept import AIoDConcept
 from database.review import Submission, Review, Decision
-from database.session import DbSession
+from database.session import DbSession, EngineSingleton
 
 ALICE = KeycloakUser("Alice", set(), "alice-sub")
 BOB = KeycloakUser("Bob", set(), "bob-sub")
@@ -30,8 +33,10 @@ def kc_user_with_roles(*roles: str) -> KeycloakUser:
     )
 
 @contextlib.contextmanager
-def logged_in_user(user: KeycloakUser | None):
+def logged_in_user(user: KeycloakUser | None = None):
+    """Act as if the specified user is logged in. If no user is specified, a new user will be generated. """
     original = keycloak_openid.introspect
+    user = user or kc_user_with_roles()
     keycloak_openid.introspect = Mock(
         return_value={
             "realm_access": {"roles": user.roles},
@@ -44,7 +49,7 @@ def logged_in_user(user: KeycloakUser | None):
             "active": True,
             "sub": user._subject_identifier,
         }
-    ) if user else None
+    )
     yield
     keycloak_openid.introspect = original
 
@@ -76,3 +81,12 @@ def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser, status: EntryS
                 session.add(review)
         session.commit()
         return asset.identifier
+
+def bypass_reviewer_publish_everything() -> None:
+    """Function to set the AIoD entry to published without a review.
+    This function is a *test utility* to simplify test setups, and avoid
+    e.g., authentication for get requests.
+    """
+    with DbSession() as session:
+        session.exec(update(AIoDEntryORM).values(status=EntryStatus.PUBLISHED))
+        session.commit()

--- a/src/tests/testutils/users.py
+++ b/src/tests/testutils/users.py
@@ -1,16 +1,16 @@
 import contextlib
-from select import select
 from typing import cast
 from unittest.mock import Mock
 
 from sqlalchemy import update
+from sqlalchemy.orm.exc import DetachedInstanceError
 
 from authentication import KeycloakUser, keycloak_openid, REVIEWER_ROLE
 from database.authorization import register_user, set_permission, PermissionType
 from database.model.concept.aiod_entry import EntryStatus, AIoDEntryORM
 from database.model.concept.concept import AIoDConcept
 from database.review import Submission, Review, Decision
-from database.session import DbSession, EngineSingleton
+from database.session import DbSession
 
 ALICE = KeycloakUser("Alice", set(), "alice-sub")
 BOB = KeycloakUser("Bob", set(), "bob-sub")
@@ -54,7 +54,15 @@ def logged_in_user(user: KeycloakUser | None = None):
     keycloak_openid.introspect = original
 
 
-def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser, status: EntryStatus):
+def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser | None = None, status: EntryStatus = EntryStatus.PUBLISHED):
+    owner = owner or kc_user_with_roles()
+
+    try:
+        if not asset.aiod_entry:
+            asset.aiod_entry = AIoDEntryORM()
+    except DetachedInstanceError:
+        pass  # if the asset came from a database connection, it already has an entry
+
     with DbSession() as session:
         session.add(asset)
         session.commit()

--- a/src/tests/uploader/zenodo/test_dataset_uploader.py
+++ b/src/tests/uploader/zenodo/test_dataset_uploader.py
@@ -306,7 +306,7 @@ def test_attempt_to_upload_published_resource(
         session.add(contact)
         session.commit()
 
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == status.HTTP_200_OK, response.json()
 
@@ -398,7 +398,7 @@ def test_fail_due_to_missing_contact_name(
     with DbSession() as session:
         session.add(person)
         session.commit()
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == status.HTTP_200_OK, response.json()
 

--- a/src/tests/uploader/zenodo/test_dataset_uploader.py
+++ b/src/tests/uploader/zenodo/test_dataset_uploader.py
@@ -21,7 +21,8 @@ from database.model.dataset.dataset import Dataset
 from tests.testutils.paths import path_test_resources
 
 import tests.uploader.zenodo.mock_zenodo as zenodo
-from tests.testutils.users import logged_in_user, kc_user_with_roles
+from tests.testutils.users import logged_in_user, kc_user_with_roles, \
+    bypass_reviewer_publish_everything
 from uploaders.zenodo_uploader import ZenodoUploader
 
 ENDPOINT = "/upload/datasets/1/zenodo"
@@ -92,13 +93,13 @@ def body_with_dist(body_no_dist: dict) -> dict:
 
 
 def test_happy_path_creating_repo(
-    client: TestClient, body_empty: dict, db_with_person_and_contact: None
+    client: TestClient, body_empty: dict, db_with_person_and_contact: None, auto_publish: None,
 ):
     """
     Test the successful path for creating a new repository on Zenodo before uploading a file.
     The creation of a new repo must be triggered when platform_resource_identifier is None.
     """
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client.post("/datasets/v1", json=body_empty, headers={"Authorization": "Fake token"})
     assert response.status_code == status.HTTP_200_OK, response.json()
 
@@ -134,7 +135,7 @@ def test_happy_path_existing_repo(
     When the platform_resource_identifier is not None (zenodo.org:int) the code should
     get metadata and url of the existing repo, then upload a file.
     """
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client.post(
             "/datasets/v1", json=body_with_dist, headers={"Authorization": "Fake token"}
         )
@@ -154,6 +155,7 @@ def test_happy_path_existing_repo(
                 response = client.post(ENDPOINT, params=PARAMS_DRAFT, headers=HEADERS, files=test_file)
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json() == 1, response.json()
+    bypass_reviewer_publish_everything()
 
     response_json = client.get("datasets/v1/1").json()
     assert response_json["platform"] == "zenodo", response_json
@@ -169,7 +171,7 @@ def test_happy_path_existing_file(
     """
     Test uploading a second file to zenodo.
     """
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client.post(
             "/datasets/v1", json=body_with_dist, headers={"Authorization": "Fake token"}
         )
@@ -188,6 +190,7 @@ def test_happy_path_existing_file(
                 response = client.post(ENDPOINT, params=PARAMS_DRAFT, headers=HEADERS, files=test_file)
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json() == 1, response.json()
+    bypass_reviewer_publish_everything()
 
     response_json = client.get("datasets/v1/1").json()
     assert response_json["platform"] == "zenodo", response_json
@@ -208,7 +211,7 @@ def test_happy_path_updating_an_existing_file(
     """
     updated_file_new_id = "newid000-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client.post(
             "/datasets/v1", json=body_with_dist, headers={"Authorization": "Fake token"}
         )
@@ -234,6 +237,7 @@ def test_happy_path_updating_an_existing_file(
                 response = client.post(ENDPOINT, params=PARAMS_DRAFT, headers=HEADERS, files=test_file)
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json() == 1, response.json()
+    bypass_reviewer_publish_everything()
 
     response_json = client.get("datasets/v1/1").json()
     assert response_json["platform"] == "zenodo", response_json
@@ -252,7 +256,7 @@ def test_happy_path_publishing(
     Test publishing the resource on Zenodo after uploading a file.
     The URL of the content should not be empty
     """
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client.post("/datasets/v1", json=body_empty, headers={"Authorization": "Fake token"})
     assert response.status_code == status.HTTP_200_OK, response.json()
 
@@ -272,6 +276,7 @@ def test_happy_path_publishing(
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json() == 1, response.json()
 
+    bypass_reviewer_publish_everything()
     response_json = client.get("datasets/v1/1").json()
     assert response_json["aiod_entry"]["status"] == "published", response_json
     assert (
@@ -355,7 +360,7 @@ def test_platform_name_conflict(
         session.add(contact)
         session.commit()
 
-    with logged_in_user(kc_user_with_roles()):
+    with logged_in_user():
         response = client.post("/datasets/v1", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == status.HTTP_200_OK, response.json()
 
@@ -371,6 +376,7 @@ def test_platform_name_conflict(
             "The dataset with identifier 1 should have platform=" f"{PlatformName.zenodo}."
         ), response.json()
 
+    bypass_reviewer_publish_everything()
     response_json = client.get("datasets/v1/1").json()
     assert response_json["platform"] == "huggingface", response_json
     assert response_json["platform_resource_identifier"] == "fake-id", response_json

--- a/src/uploaders/uploader.py
+++ b/src/uploaders/uploader.py
@@ -5,7 +5,6 @@ from typing import Any
 from fastapi import HTTPException, status, UploadFile
 
 from authentication import KeycloakUser
-from config import KEYCLOAK_CONFIG
 from database.model.dataset.dataset import Dataset
 from sqlmodel import Session, select
 


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
Make draft assets private, only visible with explicit permission.
That means:
 - Assets in draft are never considered count or list assets, not even if you have read-permissions
 - Assets in draft can only be retrieved by `ASSET/{identifier}` if the user as read permissions for that asset
 - Reviewers currently can see the asset through the `get_submission` endpoint, but not directly.

## How to Test
<!-- Describe a way to test the change of this PR -->
Primarily try to think if there are permutations which do not work with these changes.
In particular ones that inadvertently may expose the draft asset.
More generally, tests are updated and it can be manually tested.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Related to #449

