### PR TITLE
Also prevent collaborator with write-right to review the asset

### DIFF
--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -7,7 +7,7 @@ from sqlmodel import select, Session
 from starlette import status
 
 from authentication import KeycloakUser, get_user_or_raise
-from database.authorization import register_user, user_can_administer
+from database.authorization import register_user, user_can_administer, user_can_write
 from database.session import DbSession, get_session
 from database.review import (
     Submission,
@@ -153,7 +153,7 @@ def _review_resource(
     register_user(user, session)
 
     aiod_entry = cast(AIoDEntryORM, session.get(AIoDEntryORM, submission.aiod_entry_identifier))
-    if user_can_administer(user, aiod_entry):
+    if user_can_write(user, aiod_entry):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have permission to review your own assets.",

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -1,5 +1,6 @@
 import json
 from http import HTTPStatus
+from typing import Callable
 from unittest.mock import Mock
 
 import pytest
@@ -7,9 +8,9 @@ from starlette.testclient import TestClient
 
 from authentication import KeycloakUser
 from database.authorization import (
-    PermissionType, user_can_read, user_can_write, user_can_administer,
+    PermissionType, user_can_read, user_can_write, user_can_administer, set_permission,
 )
-from database.model.concept.aiod_entry import EntryStatus
+from database.model.concept.aiod_entry import EntryStatus, AIoDEntryORM
 from database.review import Decision, ReviewCreate
 from database.session import DbSession
 from database.model.knowledge_asset.publication import Publication
@@ -367,10 +368,26 @@ def test_reviewer_can_reject_submission(publication, client):
     assert response.json()["aiod_entry"]["status"] == EntryStatus.DRAFT
 
 
-def test_reviewer_cannot_approve_own_submission(publication, client):
-    register_asset(publication, owner=REVIEWER, status=EntryStatus.SUBMITTED)
+@pytest.mark.parametrize(
+    "permission", [PermissionType.WRITE, PermissionType.ADMIN]
+)
+def test_reviewer_cannot_approve_own_submission(
+        permission: PermissionType,
+        publication_factory: Callable[[], Publication],
+        client: TestClient
+):
+    # Create an asset and add REVIEWER as a collaborator (write/admin)
     _register_user_in_db(REVIEWER)
 
+    publication = publication_factory()
+    register_asset(publication, owner=ALICE, status=EntryStatus.SUBMITTED)
+
+    with DbSession() as session:
+        session.add(publication)
+        set_permission(REVIEWER, publication.aiod_entry, session, type_=permission)
+        session.commit()
+
+    # See if the review endpoint correctly rejects collaborators from reviewing the asset
     with logged_in_user(REVIEWER):
         response = client.post(
             "/reviews/v1",


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
Reviewers now also cannot review assets for which they have _write_ permissions.

note: I do not think it's necessary to explicitly check for read permissions.
In general this guard is likely not going to be that relevant (it's low stakes, and there are so many ways to cheat it anyway, if desired), it's more of a sanity check that users don't get in the habit of immediately approving their assets, especially when we delegate reviewing to community members.


## How to Test
<!-- Describe a way to test the change of this PR -->
Covered by the unit test. If you're not convinced, use the REST API :)

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Came up in #509 

