### PR TITLE
Add an option to disable the review process

### DIFF
--- a/docs/developer/users.md
+++ b/docs/developer/users.md
@@ -31,6 +31,7 @@ There is no special privilege for user A, and this also means that e.g., user B 
 
 !!! info
     The upload and review process is described from a user perspective in ["Uploading"](../using/upload.md).
+    The review process may be disabled by setting the `--disable-reviews` flag when starting the server.
 
 An asset uploaded by a user is by default in `draft` state.
 The user may request the asset to be `published` by submitting it for review through the REST API.

--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,7 @@ from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
 from database.session import EngineSingleton, DbSession
 from database.setup import create_database, database_exists
+from triggers import disable_review_process, enable_review_process
 from error_handling import http_exception_handler
 from routers import (
     resource_routers,
@@ -58,6 +59,12 @@ def _parse_args() -> argparse.Namespace:
         "--reload",
         action=argparse.BooleanOptionalAction,
         help="Use `--reload` for FastAPI.",
+    )
+    parser.add_argument(
+        "--disable-reviews",
+        action="store_true",
+        help="Use --disable-reviews to disable the review process for new assets."
+        "This does not affect the state of assets already created or under review.",
     )
     return parser.parse_args()
 
@@ -161,6 +168,12 @@ def build_database(args):
         triggers = create_delete_triggers(AIoDConcept)
         for trigger in triggers:
             session.execute(trigger)
+
+        if args.disable_reviews:
+            disable_review_process(session)
+        else:
+            enable_review_process(session)
+
         existing_platforms = session.scalars(select(Platform)).all()
         missing_platforms = set(PlatformName) - {p.name for p in existing_platforms}
         if any(missing_platforms):

--- a/src/triggers.py
+++ b/src/triggers.py
@@ -1,0 +1,23 @@
+from sqlalchemy import DDL
+from sqlmodel import Session
+
+BYPASS_REVIEW_TRIGGER_NAME: str = "PUBLISH_ON_CREATE"
+
+
+def disable_review_process(session: Session) -> None:
+    """Sets new entries to automatically be published, circumventing the review process."""
+    session.execute(
+        DDL(f"""
+        CREATE TRIGGER IF NOT EXISTS {BYPASS_REVIEW_TRIGGER_NAME}
+        BEFORE INSERT ON aiod_entry
+        FOR EACH ROW
+        BEGIN
+            SET NEW.status = 'PUBLISHED';
+        END;
+    """)
+    )
+
+
+def enable_review_process(session: Session) -> None:
+    """Drops the trigger created by `disable_review_process`"""
+    session.execute(DDL(f"DROP TRIGGER IF EXISTS {BYPASS_REVIEW_TRIGGER_NAME};"))


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
Add an option when starting the server that disables the review process (`--disable-reviews`).
This is needed for the production server for as long as we do not have reviewers, but may also be useful for developers and should probably be considered as a default for the `dev` compose file.


## How to Test
<!-- Describe a way to test the change of this PR -->
Manual test only: start with `--disable-reviews`, log in, upload something, see it gets published.
Restart the server without the flag, and check that reviews are now required (again).

I tried to make a test, but unfortunately the dialects between sqlite (in test) and mysql (in practice) are incompatible. It didn't make sense to me to include the test as you'd be testing different code at that point.
E.g., the sqlite trigger would have been: 
```sqlite
CREATE TRIGGER IF NOT EXISTS {BYPASS_REVIEW_TRIGGER_NAME}  
AFTER INSERT ON aiod_entry  
FOR EACH ROW BEGIN  
    UPDATE aiod_entry SET status = 'PUBLISHED' WHERE identifier=NEW.identifier;
END;  
```
Note that 1) it needs AFTER INSERT, which is disallowed for these type of updates in MySQL, and 2) it doesn't allow setting of `NEW`, which seems the most appropriate in `MySQL`.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


