### PR TITLE
Fix/identifiers

### DIFF
--- a/alembic/alembic/versions/42f747800456_knowledge_asset_identifiers.py
+++ b/alembic/alembic/versions/42f747800456_knowledge_asset_identifiers.py
@@ -1,0 +1,89 @@
+"""knowledge_asset_identifiers
+
+Revision ID: 42f747800456
+Revises: 459323683348
+Create Date: 2025-06-24 13:05:59.728619
+
+"""
+
+import logging
+
+# no user input
+# ruff: noqa: S608
+from typing import Sequence, Union, NamedTuple
+
+from alembic import op
+from sqlalchemy import text
+
+from database.session import DbSession
+
+
+# revision identifiers, used by Alembic.
+revision: str = "42f747800456"
+down_revision: Union[str, None] = "459323683348"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+logger = logging.getLogger("alembic")
+
+
+class ParentTable(NamedTuple):
+    name: str
+    fk_identifier: str
+    children: list[str]
+
+
+def upgrade() -> None:
+    # Simply forgot to update knowledge asset identifiers last time.
+    # This script follows the same setup as the last, but only applies to knowledge asset,
+    # which at this point only has `publication` as a child referencing it.
+
+    # Fetch foreign key constraints so we can drop them and add them back later.
+    with DbSession() as session:
+        logger.info("Fetching existing foreign key constraints.")
+        constraints = session.execute(
+            text(
+                "SELECT refs.CONSTRAINT_NAME, refs.DELETE_RULE, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME "
+                "FROM information_schema.REFERENTIAL_CONSTRAINTS as refs "
+                "JOIN information_schema.KEY_COLUMN_USAGE as kcu "
+                "ON refs.CONSTRAINT_NAME=kcu.CONSTRAINT_NAME "
+                f"WHERE refs.REFERENCED_TABLE_NAME='knowledge_asset';"
+            )
+        )
+    constraints = list(constraints)
+    logger.info(f"Dropping {len(constraints)} foreign key constraints.")
+    for constraint, delete_rule, from_table, from_column, to_table, to_column in constraints:
+        op.execute(f"ALTER TABLE {from_table} DROP FOREIGN KEY {constraint}")
+
+    # Without the foreign key constraints in place, we can update the columns.
+    updated_columns = set()
+    for constraint, delete_rule, from_table, from_column, to_table, to_column in constraints:
+        for table, column in [(to_table, to_column), (from_table, from_column)]:
+            if (table, column) not in updated_columns:
+                logger.info(f"Altering {table}.{column} to VARCHAR(30) COLLATE utf8_bin.")
+                op.execute(
+                    f"ALTER TABLE {table} CHANGE COLUMN {column} {column} VARCHAR(30) COLLATE utf8_bin;"
+                )
+                updated_columns.add((table, column))
+
+    for constraint, delete_rule, from_table, from_column, to_table, to_column in constraints:
+        logger.info(f"Adding back constraint {constraint}.")
+        op.execute(
+            f"ALTER TABLE {from_table} "
+            f"ADD CONSTRAINT {constraint} "
+            f"FOREIGN KEY ({from_column}) REFERENCES {to_table}({to_column}) "
+            f"ON DELETE {delete_rule} "
+            f"ON UPDATE CASCADE;"
+        )
+
+    logger.info(f"Assigning new identifiers to knowledge_asset so they match the publication.")
+    op.execute(
+        f"UPDATE knowledge_asset "
+        f"JOIN (select identifier, knowledge_asset_id from publication) as pubs "
+        f"ON knowledge_asset.identifier=pubs.knowledge_asset_id "
+        f"SET knowledge_asset.identifier=pubs.identifier;"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/alembic/versions/42f747800456_knowledge_asset_identifiers.py
+++ b/alembic/alembic/versions/42f747800456_knowledge_asset_identifiers.py
@@ -76,13 +76,11 @@ def upgrade() -> None:
             f"ON UPDATE CASCADE;"
         )
 
-    logger.info(f"Assigning new identifiers to knowledge_asset so they match the publication.")
-    op.execute(
-        f"UPDATE knowledge_asset "
-        f"JOIN (select identifier, knowledge_asset_id from publication) as pubs "
-        f"ON knowledge_asset.identifier=pubs.knowledge_asset_id "
-        f"SET knowledge_asset.identifier=pubs.identifier;"
-    )
+    # There was a bug which resulted in knowledge asset identifiers not being generated
+    logger.info("Creating Identifiers of Knowledge Assets")
+    op.execute("INSERT INTO knowledge_asset SELECT identifier, 'publication' FROM publication; ")
+    logger.info("Link publications to their parents")
+    op.execute("UPDATE publication SET knowledge_asset_id=identifier; ")
 
 
 def downgrade() -> None:

--- a/src/database/deletion/triggers.py
+++ b/src/database/deletion/triggers.py
@@ -25,12 +25,15 @@ def create_identifier_synchronization_triggers(dialect: str = "mysql"):
     from database.model.ai_asset.ai_asset_table import AIAssetTable
     from database.model.ai_resource.resource import AIResource
     from database.model.ai_resource.resource_table import AIResourceORM
+    from database.model.knowledge_asset.knowledge_asset import KnowledgeAsset
+    from database.model.knowledge_asset.knowledge_asset_table import KnowledgeAssetTable
 
     triggers = []
     for parent_class, reference_table in [
         (AIResource, AIResourceORM),
         (AIAsset, AIAssetTable),
         (Agent, AgentTable),
+        (KnowledgeAsset, KnowledgeAssetTable),
     ]:
         parent_table_name = reference_table.__tablename__  # type: ignore[attr-defined]
         for cls in non_abstract_subclasses(parent_class):

--- a/src/database/model/ai_asset/distribution.py
+++ b/src/database/model/ai_asset/distribution.py
@@ -2,11 +2,12 @@ from datetime import datetime
 from typing import Type
 
 from pydantic import create_model
-from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy import Column, Integer, ForeignKey, String
 from sqlmodel import Field
 
 from database.model.concept.concept import AIoDConceptBase
 from database.model.field_length import LONG, NORMAL, SHORT
+from database.model.field_length import IDENTIFIER_LENGTH
 
 
 class DistributionBase(AIoDConceptBase):
@@ -60,10 +61,11 @@ def distribution_factory(table_from: str, distribution_name="distribution") -> T
         __cls_kwargs__=dict(table=True),
         identifier=(int | None, Field(primary_key=True)),
         asset_identifier=(
-            int | None,
+            str | None,
             Field(
                 sa_column=Column(
-                    Integer, ForeignKey(table_from + ".identifier", ondelete="CASCADE")
+                    String(IDENTIFIER_LENGTH),
+                    ForeignKey(table_from + ".identifier", ondelete="CASCADE"),
                 )
             ),
         ),

--- a/src/database/model/ai_resource/note.py
+++ b/src/database/model/ai_resource/note.py
@@ -1,10 +1,11 @@
 from typing import Type
 
 from pydantic import create_model
-from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy import Column, Integer, ForeignKey, String
 from sqlmodel import Field, SQLModel
 
 from database.model.field_length import VERY_LONG
+from database.model.field_length import IDENTIFIER_LENGTH
 
 
 class NoteBase(SQLModel):
@@ -24,10 +25,11 @@ def note_factory(table_from: str) -> Type:
         __cls_kwargs__=dict(table=True),
         identifier=(int | None, Field(primary_key=True)),
         linked_identifier=(
-            int | None,
+            str | None,
             Field(
                 sa_column=Column(
-                    Integer, ForeignKey(table_from + ".identifier", ondelete="CASCADE")
+                    String(IDENTIFIER_LENGTH),
+                    ForeignKey(table_from + ".identifier", ondelete="CASCADE"),
                 )
             ),
         ),

--- a/src/database/model/event/event.py
+++ b/src/database/model/event/event.py
@@ -76,13 +76,9 @@ class Event(EventBase, AIResource, table=True):  # type: ignore [call-arg]
         max_length=IDENTIFIER_LENGTH, foreign_key=AgentTable.__tablename__ + ".identifier"
     )
     organiser: Optional[AgentTable] = Relationship()
-    status_identifier: str | None = Field(
-        max_length=IDENTIFIER_LENGTH, foreign_key=EventStatus.__tablename__ + ".identifier"
-    )
+    status_identifier: int | None = Field(foreign_key=EventStatus.__tablename__ + ".identifier")
     status: Optional[EventStatus] = Relationship()
-    mode_identifier: str | None = Field(
-        max_length=IDENTIFIER_LENGTH, foreign_key=EventMode.__tablename__ + ".identifier"
-    )
+    mode_identifier: int | None = Field(foreign_key=EventMode.__tablename__ + ".identifier")
     mode: Optional[EventMode] = Relationship()
 
     class RelationshipConfig(AIResource.RelationshipConfig):

--- a/src/database/model/knowledge_asset/knowledge_asset.py
+++ b/src/database/model/knowledge_asset/knowledge_asset.py
@@ -1,5 +1,6 @@
 import copy
 
+from sqlalchemy import ForeignKey
 from sqlmodel import Field, Relationship
 
 from database.model.ai_asset.ai_asset import AIAssetBase, AIAsset
@@ -8,6 +9,7 @@ from database.model.helper_functions import many_to_many_link_factory
 from database.model.knowledge_asset.knowledge_asset_table import KnowledgeAssetTable
 from database.model.relationships import ManyToMany
 from database.model.serializers import AttributeSerializer, FindByIdentifierDeserializerList
+from database.model.field_length import IDENTIFIER_LENGTH
 
 
 class KnowledgeAssetBase(AIAssetBase):
@@ -15,8 +17,13 @@ class KnowledgeAssetBase(AIAssetBase):
 
 
 class KnowledgeAsset(KnowledgeAssetBase, AIAsset):
-    knowledge_asset_id: int | None = Field(
-        foreign_key=KnowledgeAssetTable.__tablename__ + ".identifier", unique=True, index=True
+    knowledge_asset_id: str | None = Field(
+        max_length=IDENTIFIER_LENGTH,
+        # Initializing `sa_column` instead doesn't work. Perhaps because it'd be used twice?
+        sa_column_args=[
+            ForeignKey(KnowledgeAssetTable.__tablename__ + ".identifier", onupdate="CASCADE")
+        ],
+        sa_column_kwargs=dict(nullable=True, index=True, unique=True),
     )
     knowledge_asset_identifier: KnowledgeAssetTable | None = Relationship()
 

--- a/src/database/model/knowledge_asset/knowledge_asset.py
+++ b/src/database/model/knowledge_asset/knowledge_asset.py
@@ -7,7 +7,7 @@ from database.model.ai_asset.ai_asset import AIAssetBase, AIAsset
 from database.model.ai_asset.ai_asset_table import AIAssetTable
 from database.model.helper_functions import many_to_many_link_factory
 from database.model.knowledge_asset.knowledge_asset_table import KnowledgeAssetTable
-from database.model.relationships import ManyToMany
+from database.model.relationships import ManyToMany, OneToOne
 from database.model.serializers import AttributeSerializer, FindByIdentifierDeserializerList
 from database.model.field_length import IDENTIFIER_LENGTH
 
@@ -56,4 +56,11 @@ class KnowledgeAsset(KnowledgeAssetBase, AIAsset):
             deserializer=FindByIdentifierDeserializerList(AIAssetTable),
             example=[],
             default_factory_pydantic=list,
+        )
+        knowledge_asset_identifier: str | None = OneToOne(
+            identifier_name="knowledge_asset_id",
+            _serializer=AttributeSerializer("identifier"),
+            include_in_create=False,
+            default_factory_orm=lambda type_: KnowledgeAssetTable(type=type_),
+            on_delete_trigger_deletion_by="knowledge_asset_id",
         )

--- a/src/database/model/knowledge_asset/knowledge_asset_table.py
+++ b/src/database/model/knowledge_asset/knowledge_asset_table.py
@@ -1,11 +1,16 @@
 from sqlmodel import Field, SQLModel
 
 from database.model.field_length import IDENTIFIER_LENGTH
+from database.identifiers import create_id_generator
 
 
 class KnowledgeAssetTable(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "knowledge_asset"
-    identifier: str = Field(max_length=IDENTIFIER_LENGTH, default=None, primary_key=True)
+    identifier: str = Field(
+        max_length=IDENTIFIER_LENGTH,
+        default_factory=create_id_generator(),
+        primary_key=True,
+    )
     type: str = Field(
         description="The name of the table of the knowledge asset. E.g. 'publication'"
     )

--- a/src/database/model/models_and_experiments/runnable_distribution.py
+++ b/src/database/model/models_and_experiments/runnable_distribution.py
@@ -1,11 +1,11 @@
 from typing import Type
 
 from pydantic import create_model
-from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy import Column, Integer, ForeignKey, String
 from sqlmodel import Field
 
 from database.model.ai_asset.distribution import DistributionBase
-from database.model.field_length import NORMAL, LONG
+from database.model.field_length import NORMAL, LONG, IDENTIFIER_LENGTH
 
 
 class RunnableDistributionBase(DistributionBase):
@@ -82,10 +82,11 @@ def runnable_distribution_factory(table_from: str, distribution_name="distributi
         __cls_kwargs__=dict(table=True),
         identifier=(int | None, Field(primary_key=True)),
         asset_identifier=(
-            int | None,
+            str | None,
             Field(
                 sa_column=Column(
-                    Integer, ForeignKey(table_from + ".identifier", ondelete="CASCADE")
+                    String(IDENTIFIER_LENGTH),
+                    ForeignKey(table_from + ".identifier", ondelete="CASCADE"),
                 )
             ),
         ),


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
I changed some NamedRelation identifiers by accident, while at the same time not converting the KnowledgeAsset identifiers in #519. Due to this I also found that the knowledge asset table wasn't ever populated so this PR fixes that too.


## How to Test
<!-- Describe a way to test the change of this PR -->
Check out some old version of develop (pre the migration merge, e.g. 79dca9ca1ca4ab60e43dae58e27ad1f64d110bea). Create the database (drop it first, or clean.sh). Upload some assets (publications of main interest), checkout this branch and execute the migration. Before the migration you should see that there is no entry in knowledge asset table. After migration you should see it populated and it also is part of the response when getting the publication (before it wasn't, because it was None). New publications created after the migration should also have it.

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained: maybe should still add a regression test but I'm not sure how useful that is.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained: This is a bugfix, expected behavior did not change.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


