### PR TITLE
Source from override file as well

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -14,6 +14,8 @@ if [ "$ENV_MODE" != "testing" ]; then
 
     cd $SCRIPT_DIR/..
     source .env
+    [ ! -f override.env ] && touch override.env
+    source override.env
 fi
 
 DATA_PATH=$(realpath "$DATA_PATH")

--- a/scripts/mysql_dump.sh
+++ b/scripts/mysql_dump.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 
 cd $SCRIPT_DIR/..
 source .env
+[ ! -f override.env ] && touch override.env
+source override.env
 
 DATA_PATH=$(realpath "$DATA_PATH")
 LOCAL_BACKUP_PATH="$DATA_PATH"/mysql_dump

--- a/scripts/mysql_restore.sh
+++ b/scripts/mysql_restore.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 
 cd $SCRIPT_DIR/..
 source .env
+[ ! -f override.env ] && touch override.env
+source override.env
 
 DATA_PATH=$(realpath "$DATA_PATH")
 

--- a/scripts/realm_export.sh
+++ b/scripts/realm_export.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 cd $SCRIPT_DIR/..
 
 source .env
+[ ! -f override.env ] && touch override.env
+source override.env
 DATA_PATH=$(realpath "$DATA_PATH")
 LOCAL_BACKUP_PATH="$DATA_PATH"/keycloak_realm
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -14,6 +14,8 @@ if [ "$ENV_MODE" != "testing" ]; then
 
     cd $SCRIPT_DIR/..
     source .env
+    [ ! -f override.env ] && touch override.env
+    source override.env
 fi
 
 DESTINATION_PATH=$(realpath "$DATA_PATH")

--- a/scripts/set_alembic.sh
+++ b/scripts/set_alembic.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-docker exec -it sqlserver mysql -uroot -pok --database=aiod -e "UPDATE alembic_version SET version_num = '$1'"


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
Also source the `override.env` file for updated variables.

## How to Test
<!-- Describe a way to test the change of this PR -->
Configure some element required for the scripts in the `override.env`instead of `.env`. The scripts use those variables instead now (e.g., if `override.env` overrides the database password with something that's wrong, the `mysql_dump` script should fail).

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained: not under tests.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained: should be the expected behavior, so no documentation changes are required.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


