### PR TITLE
Taxonomy on startup

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,6 +3,7 @@ services:
     stdin_open: true
     volumes:
       - ./src:/app:ro
+      - ${DATA_PATH}/taxonomies:/data/taxonomies
     command: python main.py
 
   fill-db-with-examples:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -237,9 +237,9 @@ services:
         condition: service_completed_successfully
 
   taxonomy:
+    profiles: ["taxonomy"]
     container_name: taxonomy
     image: aiod_metadata_catalogue
     volumes:
-      - ./data/taxonomies.json:/data/taxonomies.json
-      - ./src:/app
+      - ${DATA_PATH}/taxonomies/taxonomies.json:/data/taxonomies.json
     command: python taxonomies/synchronize_taxonomy.py

--- a/docs/developer/schema/taxonomies.md
+++ b/docs/developer/schema/taxonomies.md
@@ -1,0 +1,25 @@
+# Taxonomies
+
+AI-on-Demand uses [taxonomies](https://en.wikipedia.org/wiki/Taxonomy) to standardize terms across assets, for example, for [licenses](https://aiod-dev.i3a.es/docs#/Taxonomies/license_licenses_get), [business sectors](https://aiod-dev.i3a.es/docs#/Taxonomies/industrial_sector_industrial_sectors_get), or [news categories](https://aiod-dev.i3a.es/docs#/Taxonomies/news_category_news_categorys_get).
+These taxonomies are defined by the [conceptual model](https://github.com/aiondemand/metadata-schema).
+Each term in a taxonomy has a specific definition and may have subterms defined. e.g., the business sector `construction` has subsectors for `infrastructure` and `buildings`, which each may also have subterms.
+
+## Importing the Taxonomy
+The JSON file produced by the export script in the metadata repository can be used as input for the `taxonomy` service of this project's `docker compose`.
+Put the JSON file at `${DATA_PATH}/taxonomies/taxonomies.json`, where `DATA_PATH` is an environment variable (typically set from the `.env` file).
+Then invoke docker compose with the "taxonomy" profile. The script will then:
+
+ - invalidate all old known terms that are no longer part of the taxonomy: assets which already use them will keep them, but they may not be added to new items.
+ - update existing terms, e.g., with new definitions
+ - add new terms to the taxonomy
+
+## Development Taxonomy
+When using the development configuration, you put a file in the `${DATA_PATH}/taxonomies` directory and point to it from the API configuration file (`config.override.toml`), where `${DATA_PATH}/taxonomies` will be mounted as `/data/taxonomies`. For example, with `DATA_PATH=./data` and `./data/taxonomies/example_taxonomies.json` present:
+
+```toml
+[dev]
+taxonomy="/data/taxonomies/example_taxonomies.json"
+```
+
+It is not intended to use this in production, since it might result in accidentally overwriting the taxonomies.
+In production, use the `taxonomy` service discussed above.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -55,6 +55,7 @@ nav:
           - 'Relationships': developer/schema/relationships.md
           - 'Objects': developer/schema/objects.md
           - 'Schema Migration': developer/schema/migration.md
+          - 'Taxonomies': developer/schema/taxonomies.md
       - 'Elastic Search': developer/elastic_search.md
       - 'Scripts': developer/scripts.md
       - 'Release Workflow': developer/releases.md

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+profiles=""
+for arg in "$@"; do
+  profiles+="--profile $arg "
+done
+
+NC='\033[0m' # No Color
+CYAN='\033[1;36m'
+GREEN='\033[0;32m'
+
+source .env
+[ ! -f override.env ] && touch override.env
+source override.env
+
+if [[ "${USE_LOCAL_DEV}" == "true" ]]; then
+  compose_with_dev="-f docker-compose.dev.yaml"
+  profiles+="--profile nginx"
+  echo -e "Launching ${CYAN}with${NC} local changes."
+else
+  compose_with_dev=""
+  echo -e "Launching ${GREEN}without${NC} local changes."
+fi
+
+command="docker compose --env-file=.env --env-file=override.env -f docker-compose.yaml ${compose_with_dev} ${profiles} build"
+echo "${command}"
+eval "${command}"

--- a/src/config.default.toml
+++ b/src/config.default.toml
@@ -29,6 +29,7 @@ request_timeout = 10  # seconds
 log_level = "INFO"  # Python log levels: https://docs.python.org/3/library/logging.html#logging-levels
 disable_reviews = false  # set to true to automatically publish submissions
 url_prefix = ""
+taxonomy = ""  # Set to a JSON file containing a taxonomy to put into the database on startup
 
 # Authentication and authorization
 [keycloak]

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ Note: order matters for overloaded paths
 import argparse
 from datetime import datetime, timezone
 import logging
+from pathlib import Path
 
 import pkg_resources
 import uvicorn
@@ -28,6 +29,7 @@ from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
 from database.session import EngineSingleton, DbSession
 from database.setup import create_database, database_exists
+from taxonomies.synchronize_taxonomy import synchronize_taxonomy_from_file
 from triggers import disable_review_process, enable_review_process
 from error_handling import http_exception_handler
 from database.model.agent.agent import Agent
@@ -104,6 +106,11 @@ def create_app() -> FastAPI:
     else:
         drop_database = build_database_setting == "drop-then-build"
         build_database(drop_database=drop_database)
+
+    if taxonomy_path := DEV_CONFIG.get("taxonomy"):
+        if not (taxonomy_file := Path(taxonomy_path)).is_file():
+            raise ValueError(f"dev.taxonomy must be a path to a file, but is {taxonomy_path!r}.")
+        synchronize_taxonomy_from_file(taxonomy_file)
 
     pyproject_toml = pkg_resources.get_distribution("aiod_metadata_catalogue")
     app = build_app(url_prefix=DEV_CONFIG.get("url_prefix", ""), version=pyproject_toml.version)

--- a/src/taxonomies/synchronize_taxonomy.py
+++ b/src/taxonomies/synchronize_taxonomy.py
@@ -30,7 +30,7 @@ def parse_args():
 class Term(NamedTuple):
     name: str
     definition: str
-    children: list[Self]  #  type: ignore[valid-type]
+    children: list[Self]  # type: ignore[valid-type]
 
 
 type_by_name: dict[str, type] = {
@@ -116,16 +116,20 @@ def synchronize(
         synchronize_term(term)
 
 
-def main():
-    logging.basicConfig(level=logging.INFO)
-    logging.info("Starting synchronization script.")
-    args = parse_args()
-    taxonomies = load_taxonomies_from_json(args.definitions_file)
+def synchronize_taxonomy_from_file(file: Path) -> None:
+    taxonomies = load_taxonomies_from_json(file)
     with DbSession(autoflush=False) as session:
         for type_, definitions in taxonomies:
             synchronize(type_, definitions, session)
         logging.info("Committing changes to database.")
         session.commit()
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Starting synchronization script.")
+    args = parse_args()
+    synchronize_taxonomy_from_file(args.definitions_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
 - Add a service for importing the taxonomy while the REST API is running
 - Add an option for the REST API to import a taxonomy on startup, intended for development scenarios
 - Add documentation on taxonomies

## How to Test
<!-- Describe a way to test the change of this PR -->
Try spinning up the API with the development configuration set according to the new documentation, with an example taxonomy (e.g., the current one from the metadata repository).

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained: there's not much to test beyond doing a full integration test, which doesn't make sense to me.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Contributes towards #554: we should pick a taxonomy file to include in the repo by default. Developers could then import it automatically, to make sure their examples work. It's probably easiest to take the existing file, a subset of it, and/or wait for the next update (I reported some problems with the current file that Antonis would fix).
Related to #552 

