### PR TITLE
Fix issue when syncing with new child definitions

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -53,3 +53,8 @@ services:
   es_logstash_setup:
     volumes:
       - ./src:/app:ro
+
+  taxonomy:
+    stdin_open: true
+    volumes:
+       - ./src:/app:ro

--- a/src/database/model/named_relation.py
+++ b/src/database/model/named_relation.py
@@ -69,13 +69,17 @@ def create_taxonomy(class_name: str, table_name: str) -> type[Taxonomy]:
             int | None,
             Field(foreign_key=f"{table_name}.identifier", default=None, nullable=True),
         ),
+        parent=(
+            ForwardRef(class_name) | None,
+            Relationship(
+                back_populates="children",
+                sa_relationship_kwargs=dict(remote_side=f"{class_name}.identifier"),
+            ),
+        ),
         children=(
             List[ForwardRef(class_name)],  # type: ignore
             Relationship(
-                sa_relationship_kwargs=dict(
-                    cascade="all",
-                    backref=backref("parent", remote_side=f"{class_name}.identifier"),
-                )
+                back_populates="parent",
             ),
         ),
     )

--- a/src/taxonomies/synchronize_taxonomy.py
+++ b/src/taxonomies/synchronize_taxonomy.py
@@ -104,11 +104,17 @@ def synchronize(
             term_object.official = True
             term_object.children = synchronized_children
             return term_object
+
         if term.name not in added_terms:
             logging.info(f"Adding new term {term.name!r}")
+            if term.parent is not None and (
+                parent := db_definitions.get(term.parent.name.casefold())
+            ):
+                term.parent = parent
             added_terms[term.name] = term
             session.add(term)
             return term
+
         logging.warning(f"Term {term.name!r} defined more than once!")
         return added_terms[term.name]
 


### PR DESCRIPTION
## Change
<!-- Briefly describe the change of this PR -->
 - Fix an issue where introducing a new child to an existing term would cause the synchronization script to fail.


## How to Test
<!-- Describe a way to test the change of this PR -->
Synchronize the taxonomies, then add some child terms to an existing taxonomy. Fails on dev, succeeds on this branch.

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


