### PR TITLE
Project 'total_cost_euro' renamed to 'project_cost_euros'

### DIFF
--- a/alembic/alembic/versions/1fd9b6a162c4_rename_project_total_cost_euro.py
+++ b/alembic/alembic/versions/1fd9b6a162c4_rename_project_total_cost_euro.py
@@ -1,0 +1,41 @@
+"""rename project total_cost_euro
+
+Revision ID: 1fd9b6a162c4
+Revises: fabaaad1cf1f
+Create Date: 2025-08-19 08:43:51.774262
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.mysql import DECIMAL
+
+# revision identifiers, used by Alembic.
+revision: str = "1fd9b6a162c4"
+down_revision: Union[str, None] = "fabaaad1cf1f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "project",
+        "total_cost_euro",
+        new_column_name="total_cost_euros",
+        existing_type=DECIMAL(12, 2),
+        existing_nullable=True,
+        existing_server_default=None,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "project",
+        "total_cost_euros",
+        new_column_name="total_cost_euro",
+        existing_type=DECIMAL(12, 2),
+        existing_nullable=True,
+        existing_server_default=None,
+    )

--- a/src/database/model/project/project.py
+++ b/src/database/model/project/project.py
@@ -119,11 +119,7 @@ class Project(ProjectBase, AIResource, table=True):  # type: ignore [call-arg]
 
 
 def project_v3_to_v2() -> VersionedResource:
-    """
-    Name changes:
-        * total_cost_euro -> total_cost_euros
-        * funder -> project_funder
-    """
+    """Name change: total_cost_euro -> total_cost_euros"""
     old_parameter = dict(
         total_cost_euro=(
             condecimal(max_digits=12, decimal_places=2) | None,

--- a/src/database/model/project/project.py
+++ b/src/database/model/project/project.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional, cast
 
-from pydantic import condecimal, BaseModel
+from pydantic import condecimal
 from sqlmodel import Field, Relationship, SQLModel
 
 from database.model.agent.organisation import Organisation
@@ -125,14 +125,14 @@ def project_v3_to_v2() -> VersionedResource:
         * funder -> project_funder
     """
     old_parameter = dict(
-        total_cost_euros=(
+        total_cost_euro=(
             condecimal(max_digits=12, decimal_places=2) | None,
             Field(  # type: ignore
                 description="The total budget of the project in euros.",
                 schema_extra={"example": 1000000},
                 default=None,
             ),
-        )
+        ),
     )
     ProjectV2Read = schema_transform(
         resource_read(Project),

--- a/src/database/model/project/project.py
+++ b/src/database/model/project/project.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, cast
 
-from pydantic import condecimal
-from sqlmodel import Field, Relationship
+from pydantic import condecimal, BaseModel
+from sqlmodel import Field, Relationship, SQLModel
 
 from database.model.agent.organisation import Organisation
 from database.model.ai_asset.ai_asset_table import AIAssetTable
@@ -14,7 +14,8 @@ from database.model.serializers import (
     FindByIdentifierDeserializerList,
 )
 from database.model.field_length import IDENTIFIER_LENGTH
-from versioning import Version, VersionedResource, VersionedResourceCollection
+from database.model.resource_read_and_create import resource_read, resource_create
+from versioning import Version, VersionedResource, VersionedResourceCollection, schema_transform
 
 
 class ProjectBase(AIResourceBase):
@@ -28,7 +29,7 @@ class ProjectBase(AIResourceBase):
         default=None,
         schema_extra={"example": "2022-01-01T15:15:00"},
     )
-    total_cost_euro: condecimal(max_digits=12, decimal_places=2) | None = Field(  # type: ignore
+    total_cost_euros: condecimal(max_digits=12, decimal_places=2) | None = Field(  # type: ignore
         description="The total budget of the project in euros.",
         schema_extra={"example": 1000000},
         default=None,
@@ -117,9 +118,58 @@ class Project(ProjectBase, AIResource, table=True):  # type: ignore [call-arg]
         )
 
 
+def project_v3_to_v2() -> VersionedResource:
+    """
+    Name changes:
+        * total_cost_euro -> total_cost_euros
+        * funder -> project_funder
+    """
+    old_parameter = dict(
+        total_cost_euros=(
+            condecimal(max_digits=12, decimal_places=2) | None,
+            Field(  # type: ignore
+                description="The total budget of the project in euros.",
+                schema_extra={"example": 1000000},
+                default=None,
+            ),
+        )
+    )
+    ProjectV2Read = schema_transform(
+        resource_read(Project),
+        "ProjectV2Read",
+        add_fields=old_parameter,
+    )
+    ProjectV2Create = schema_transform(
+        resource_create(Project),
+        "ProjectV2Create",
+        add_fields=old_parameter,
+    )
+
+    def orm_to_read(project: Project) -> ProjectV2Read:  # type: ignore[valid-type]
+        read = resource_read(Project).model_validate(project).model_dump()
+        read["total_cost_euro"] = project.total_cost_euros
+        return ProjectV2Read.model_validate(read)
+
+    def create_to_orm(project: ProjectV2Create) -> Project:  # type: ignore[valid-type]
+        fields = cast(SQLModel, project).model_dump()
+        old = fields.get("total_cost_euro")
+        new = fields.get("total_cost_euros")
+
+        if (old and new) and old != new:
+            raise ValueError(
+                "'total_cost_euro' and 'total_cost_euros' are both specified, but with different values. Please only use one or the other."
+            )
+
+        fields["total_cost_euros"] = new or old
+        return Project.model_validate(fields)
+
+    return VersionedResource(Project, ProjectV2Create, ProjectV2Read, create_to_orm, orm_to_read)
+
+
 project_versions = VersionedResourceCollection(
     {
-        Version.V2: VersionedResource(Project),
+        Version.V3: VersionedResource(Project),
+        Version.V2: project_v3_to_v2(),
         Version.LATEST: VersionedResource(Project),
     }
 )

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -10,7 +10,7 @@ def pytest_generate_tests(metafunc):
     # and allow version-specific tests to be written using a
     # @pytest.mark.versions("vX") marker
     if "client" in metafunc.fixturenames:
-        default_versions = (Version.LATEST, Version.V2)
+        default_versions = (Version.LATEST, Version.V3)
         version_marker = next((m for m in metafunc.definition.own_markers if m.name == "versions"), None)
         selected_versions = version_marker.args if version_marker else default_versions
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from versioning import Version
+
 pytest_plugins = ["tests.testutils.default_instances", "tests.testutils.default_sqlalchemy"]
 
 
@@ -8,12 +10,12 @@ def pytest_generate_tests(metafunc):
     # and allow version-specific tests to be written using a
     # @pytest.mark.versions("vX") marker
     if "client" in metafunc.fixturenames:
-        default_versions = ("", "v2")
+        default_versions = (Version.LATEST, Version.V2)
         version_marker = next((m for m in metafunc.definition.own_markers if m.name == "versions"), None)
         selected_versions = version_marker.args if version_marker else default_versions
 
-        # Allow to skip anything not defined in the command line:
-        all_versions = ("", "v2")
+        # If version is set through the command line, only use that for testing.
+        all_versions = list(Version)
         versions_to_include = metafunc.config.getoption("versions") or all_versions
         versions = set(selected_versions).intersection(set(versions_to_include))
         if not versions:

--- a/src/tests/routers/resource_routers/test_router_project.py
+++ b/src/tests/routers/resource_routers/test_router_project.py
@@ -1,6 +1,7 @@
 import copy
 from unittest.mock import Mock
 
+import pytest
 from starlette.testclient import TestClient
 
 from database.model.agent.organisation import Organisation
@@ -8,6 +9,8 @@ from database.model.agent.person import Person
 from database.model.dataset.dataset import Dataset
 from database.model.knowledge_asset.publication import Publication
 from database.session import DbSession
+from tests.testutils.users import logged_in_user
+from versioning import Version
 
 
 def test_happy_path(
@@ -63,3 +66,29 @@ def test_happy_path(
     body["used"] = []
     response = client.put(f"/projects/{identifier}", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
+
+
+@pytest.mark.versions(Version.V2)
+@pytest.mark.parametrize(
+    "field_alias", ["total_cost_euro", "total_cost_euros"]
+)
+def test_happy_path_v2_total_cost_euros(
+        client: TestClient,
+        field_alias: str,
+        body_resource: dict,
+        auto_publish: None,
+):
+    body = copy.deepcopy(body_resource)
+    body[field_alias] = 10000000.53
+
+    with logged_in_user():
+        response = client.post("/projects", json=body, headers={"Authorization": "Fake token"})
+    assert response.status_code == 200, response.json()
+    identifier = response.json()['identifier']
+
+    response = client.get(f"/projects/{identifier}")
+    assert response.status_code == 200, response.json()
+
+    response_json = response.json()
+    assert response_json["total_cost_euros"] == 10000000.53
+    assert response_json["total_cost_euro"] == 10000000.53

--- a/src/tests/routers/resource_routers/test_router_project.py
+++ b/src/tests/routers/resource_routers/test_router_project.py
@@ -31,7 +31,7 @@ def test_happy_path(
     body = copy.deepcopy(body_resource)
     body["start_date"] = "2021-02-02T15:15:00"
     body["end_date"] = "2021-02-03T15:15:00"
-    body["total_cost_euro"] = 10000000.53
+    body["total_cost_euros"] = 10000000.53
     body["funder"] = [organisation.identifier]
     body["participant"] = [organisation.identifier]
     body["coordinator"] = organisation.identifier
@@ -48,7 +48,7 @@ def test_happy_path(
     response_json = response.json()
     assert response_json["start_date"] == "2021-02-02T15:15:00"
     assert response_json["end_date"] == "2021-02-03T15:15:00"
-    assert response_json["total_cost_euro"] == 10000000.53
+    assert response_json["total_cost_euros"] == 10000000.53
     assert response_json["funder"] == [organisation.identifier]
     assert response_json["participant"] == [organisation.identifier]
     assert response_json["coordinator"] == organisation.identifier

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -29,6 +29,7 @@ from database.model.news.news_category import NewsCategory
 from tests.testutils.test_resource import RouterTestResource, factory_test_resource
 from tests.testutils.users import bypass_reviewer_publish_everything
 from taxonomies.synchronize_taxonomy import Term
+from versioning import Version
 
 DEFAULT_TEST_RESOURCE_IDENTIFIER = "test_KwfnsoJOAejyRdv2PaXUPAbW"
 DEFAULT_INDUSTRIAL_SECTORS = [
@@ -149,7 +150,8 @@ def client(request, engine: Engine) -> TestClient:
     Create a TestClient that can be used to mock sending requests to our application
     """
     app = build_app(version="unittest")
-    yield TestClient(app, base_url=f"http://localhost/{request.param}")
+    path_prefix = str(request.param) if request.param != Version.LATEST else ""
+    yield TestClient(app, base_url=f"http://localhost/{path_prefix}")
 
 
 # *NEVER* broaden the scope of this fixture, bypassing reviews should be on a test-by-test basis

--- a/src/versions.toml
+++ b/src/versions.toml
@@ -1,3 +1,6 @@
+[v3]
+retired = false
+
 [v2]
 retired = false
 


### PR DESCRIPTION


## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type:  Changed <!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Interface <!-- Documentation/Interface/Internal/Other -->

Changelog Entry: Project 'total_cost_euro' renamed to 'project_cost_euros' 

The use of 'total_cost_euro' is now deprecated and will be removed in version 3. You may already use 'total_cost_euros' in Version 2 for forward compatibility.

## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Covered by unit tests.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
The remaining discrepancy with the conceptual model is now the 'funder' attribute, but I maintain that the REST API name should stay and the conceptual model should be updated. See https://github.com/aiondemand/metadata-schema/issues/3.
