### PR TITLE
Fix an issue where routing behind a proxy with a prefix wouldn't work as expected

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -176,6 +176,7 @@ services:
         condition: service_healthy
 
   elasticsearch:
+    user: "1005"
     image: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
     container_name: elasticsearch
     environment:
@@ -199,6 +200,7 @@ services:
       retries: 30
 
   es_logstash_setup:
+    user: root
     image: aiod_metadata_catalogue
     container_name:  es_logstash_setup
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -176,7 +176,6 @@ services:
         condition: service_healthy
 
   elasticsearch:
-    user: "1005"
     image: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
     container_name: elasticsearch
     environment:
@@ -200,7 +199,6 @@ services:
       retries: 30
 
   es_logstash_setup:
-    user: root
     image: aiod_metadata_catalogue
     container_name:  es_logstash_setup
     environment:

--- a/docs/hosting/proxy.md
+++ b/docs/hosting/proxy.md
@@ -1,0 +1,30 @@
+# Behind a Proxy
+
+The app should work without issue when deployed behind a proxy.
+If you configured the proxy to remove a path prefix, then you will need to configure your proxy to add a `x-forwarded-prefix` header.
+Otherwise, some endpoints may not function as expected.
+This is currently predominantly relevant for the generated documentation pages and their authentication mechanisms.
+Here are examples on how to configure a proxy with the `/aiod` prefix and add the correct header:
+
+=== "Apache"
+
+    ``` { .conf }
+    <Location /aiod>
+       ProxyPass http://localhost:8009
+       ProxypassReverse http://localhost:8009
+       RequestHeader set X-Forwarded-Prefix "/aiod"
+       RequestHeader set X-Forwarded-Proto "https"
+    </Location>
+    ```
+
+=== "nginx"
+
+    ```
+    server {
+        location /aiod/ {
+            proxy_pass http://app:8000/;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Prefix "/aiod";
+        }
+    }
+    ```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -47,6 +47,7 @@ nav:
       - 'Connectors': hosting/connectors.md
       - 'Synchronization': hosting/synchronization.md
       - 'Monitoring': hosting/metrics.md
+      - 'Proxies': hosting/proxy.md
   - 'Developer Resources':
       - developer/index.md
       - 'Authentication': developer/authentication.md

--- a/src/main.py
+++ b/src/main.py
@@ -61,7 +61,7 @@ def add_routes(app: FastAPI, version: Version, url_prefix=""):
     @app.get("/", include_in_schema=False, response_class=HTMLResponse)
     def home(request: Request) -> str:
         """Provides a redirect page to the docs."""
-        prefix = request.headers.get("x-forwarded-prefix")
+        prefix = request.headers.get("x-forwarded-prefix", "")
         return f"""
         <!DOCTYPE html>
         <html>

--- a/src/main.py
+++ b/src/main.py
@@ -61,7 +61,9 @@ def add_routes(app: FastAPI, version: Version, url_prefix=""):
     @app.get("/", include_in_schema=False, response_class=HTMLResponse)
     def home(request: Request) -> str:
         """Provides a redirect page to the docs."""
-        prefix = request.headers.get("x-forwarded-prefix", "")
+        proxy_prefix = request.headers.get("x-forwarded-prefix", "")
+        version_prefix = "" if version == Version.LATEST else f"/{version}"
+        prefix = proxy_prefix + version_prefix
         return f"""
         <!DOCTYPE html>
         <html>

--- a/src/main.py
+++ b/src/main.py
@@ -57,7 +57,7 @@ from versioning import (
 def add_routes(app: FastAPI, version: Version, url_prefix=""):
     """Add routes to the FastAPI application"""
 
-    @app.get(url_prefix + "/", include_in_schema=False, response_class=HTMLResponse)
+    @app.get("/", include_in_schema=False, response_class=HTMLResponse)
     def home() -> str:
         """Provides a redirect page to the docs."""
         return """
@@ -152,7 +152,6 @@ def build_app(*, url_prefix: str = "", version: str = "dev"):
         },
     )
     main_app = FastAPI(
-        root_path=url_prefix,
         title="AI-on-Demand Metadata Catalogue REST API",
         version="latest",
         **kwargs,
@@ -181,6 +180,12 @@ def build_app(*, url_prefix: str = "", version: str = "dev"):
     # Since all traffic goes through the main app, this middleware only
     # needs to be registered with the main app and not the mounted apps.
     main_app.add_middleware(AccessLogMiddleware)
+
+    from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+    main_app.add_middleware(
+        ProxyHeadersMiddleware, trusted_hosts="*"  # or set to your domain(s) for safety
+    )
 
     for app, _ in versioned_apps:
         main_app.mount(f"/{app.version}", app)

--- a/src/main.py
+++ b/src/main.py
@@ -62,8 +62,7 @@ def add_routes(app: FastAPI, version: Version, url_prefix=""):
     def home(request: Request) -> str:
         """Provides a redirect page to the docs."""
         proxy_prefix = request.headers.get("x-forwarded-prefix", "")
-        version_prefix = "" if version == Version.LATEST else f"/{version}"
-        prefix = proxy_prefix + version_prefix
+        prefix = proxy_prefix + version.prefix
         return f"""
         <!DOCTYPE html>
         <html>

--- a/src/main.py
+++ b/src/main.py
@@ -80,19 +80,6 @@ def add_routes(app: FastAPI, version: Version, url_prefix=""):
         """
         return user
 
-    @app.get("/blodocs/oauth2-redirect")
-    def forward(request: Request):
-        # Janky setup needed for a proxy with the custom doc pages.
-        # `root_path` doesn't work, since it messes with the regular endpoints.
-        # but without rootpath, redirect uri explicitly needs the /aiod prefix..
-        # but then FastAPI also mounts the file with the prefix, which is now duplicated
-        # due to the header...
-        from fastapi.responses import RedirectResponse
-        print(vars(request))
-        redirect_url = f"/aiod/aiod{request.scope['path']}?{request.scope['query_string'].decode()}"
-        print("Redirec to", redirect_url)
-        return RedirectResponse(url=redirect_url, status_code=303)
-
     @app.get("/counts")
     def counts() -> dict:
         return {
@@ -149,9 +136,8 @@ def create_app() -> FastAPI:
 
 def build_app(*, url_prefix: str = "", version: str = "dev"):
     kwargs = dict(
-        root_path='/aiod',
-        #docs_url=None,  # We override the default pages with custom html
-        #redoc_url=None,
+        docs_url=None,  # We override the default pages with custom html
+        redoc_url=None,
         description="This is the REST API documentation of the AIoD Metadata Catalogue. "
         "See also our general "
         '<a href="https://aiondemand.github.io/AIOD-rest-api/">metadata catalogue documentation</a>, '
@@ -187,7 +173,7 @@ def build_app(*, url_prefix: str = "", version: str = "dev"):
         add_routes(app, version=version)
         app.add_exception_handler(HTTPException, http_exception_handler)
         add_deprecation_and_sunset_middleware(app)
-        #add_version_to_openapi(app, root_path=url_prefix)
+        add_version_to_openapi(app, root_path=url_prefix)
 
     Instrumentator().instrument(main_app).expose(
         main_app, endpoint="/metrics", include_in_schema=False
@@ -198,9 +184,9 @@ def build_app(*, url_prefix: str = "", version: str = "dev"):
 
     from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
-    #main_app.add_middleware(
-        #ProxyHeadersMiddleware, trusted_hosts="*"  # or set to your domain(s) for safety
-    #)
+    main_app.add_middleware(
+        ProxyHeadersMiddleware, trusted_hosts="*"  # or set to your domain(s) for safety
+    )
 
     for app, _ in versioned_apps:
         main_app.mount(f"/{app.version}", app)

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ import uvicorn
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from sqlmodel import select, SQLModel
+from starlette.requests import Request
 
 from authentication import get_user_or_raise, KeycloakUser, assert_required_settings_configured
 from config import KEYCLOAK_CONFIG, DB_CONFIG, DEV_CONFIG
@@ -79,6 +80,19 @@ def add_routes(app: FastAPI, version: Version, url_prefix=""):
         """
         return user
 
+    @app.get("/blodocs/oauth2-redirect")
+    def forward(request: Request):
+        # Janky setup needed for a proxy with the custom doc pages.
+        # `root_path` doesn't work, since it messes with the regular endpoints.
+        # but without rootpath, redirect uri explicitly needs the /aiod prefix..
+        # but then FastAPI also mounts the file with the prefix, which is now duplicated
+        # due to the header...
+        from fastapi.responses import RedirectResponse
+        print(vars(request))
+        redirect_url = f"/aiod/aiod{request.scope['path']}?{request.scope['query_string'].decode()}"
+        print("Redirec to", redirect_url)
+        return RedirectResponse(url=redirect_url, status_code=303)
+
     @app.get("/counts")
     def counts() -> dict:
         return {
@@ -135,8 +149,9 @@ def create_app() -> FastAPI:
 
 def build_app(*, url_prefix: str = "", version: str = "dev"):
     kwargs = dict(
-        docs_url=None,  # We override the default pages with custom html
-        redoc_url=None,
+        root_path='/aiod',
+        #docs_url=None,  # We override the default pages with custom html
+        #redoc_url=None,
         description="This is the REST API documentation of the AIoD Metadata Catalogue. "
         "See also our general "
         '<a href="https://aiondemand.github.io/AIOD-rest-api/">metadata catalogue documentation</a>, '
@@ -172,7 +187,7 @@ def build_app(*, url_prefix: str = "", version: str = "dev"):
         add_routes(app, version=version)
         app.add_exception_handler(HTTPException, http_exception_handler)
         add_deprecation_and_sunset_middleware(app)
-        add_version_to_openapi(app, root_path=url_prefix)
+        #add_version_to_openapi(app, root_path=url_prefix)
 
     Instrumentator().instrument(main_app).expose(
         main_app, endpoint="/metrics", include_in_schema=False
@@ -183,9 +198,9 @@ def build_app(*, url_prefix: str = "", version: str = "dev"):
 
     from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
-    main_app.add_middleware(
-        ProxyHeadersMiddleware, trusted_hosts="*"  # or set to your domain(s) for safety
-    )
+    #main_app.add_middleware(
+        #ProxyHeadersMiddleware, trusted_hosts="*"  # or set to your domain(s) for safety
+    #)
 
     for app, _ in versioned_apps:
         main_app.mount(f"/{app.version}", app)

--- a/src/main.py
+++ b/src/main.py
@@ -59,16 +59,17 @@ def add_routes(app: FastAPI, version: Version, url_prefix=""):
     """Add routes to the FastAPI application"""
 
     @app.get("/", include_in_schema=False, response_class=HTMLResponse)
-    def home() -> str:
+    def home(request: Request) -> str:
         """Provides a redirect page to the docs."""
-        return """
+        prefix = request.headers.get("x-forwarded-prefix")
+        return f"""
         <!DOCTYPE html>
         <html>
           <head>
-            <meta http-equiv="refresh" content="0; url='docs'" />
+            <meta http-equiv="refresh" content="0; url='{prefix}/docs'" />
           </head>
           <body>
-            <p>The REST API documentation is <a href="docs">here</a>.</p>
+            <p>The REST API documentation is <a href="{prefix}/docs">here</a>.</p>
           </body>
         </html>
         """
@@ -181,12 +182,6 @@ def build_app(*, url_prefix: str = "", version: str = "dev"):
     # Since all traffic goes through the main app, this middleware only
     # needs to be registered with the main app and not the mounted apps.
     main_app.add_middleware(AccessLogMiddleware)
-
-    from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
-
-    main_app.add_middleware(
-        ProxyHeadersMiddleware, trusted_hosts="*"  # or set to your domain(s) for safety
-    )
 
     for app, _ in versioned_apps:
         main_app.mount(f"/{app.version}", app)

--- a/src/main.py
+++ b/src/main.py
@@ -174,7 +174,7 @@ def build_app(*, url_prefix: str = "", version: str = "dev"):
         add_routes(app, version=version)
         app.add_exception_handler(HTTPException, http_exception_handler)
         add_deprecation_and_sunset_middleware(app)
-        add_version_to_openapi(app, root_path=url_prefix)
+        add_version_to_openapi(app)
 
     Instrumentator().instrument(main_app).expose(
         main_app, endpoint="/metrics", include_in_schema=False

--- a/src/routers/user_router.py
+++ b/src/routers/user_router.py
@@ -23,7 +23,7 @@ def create(url_prefix: str, version: Version) -> APIRouter:
     # types are included, and the (schema) documentation is generated.
     # It also makes sure assets are deserialized the same way as
     # direct access would have.
-    suffix = "" if version == Version.LATEST else version.capitalize()
+    suffix = version.prefix.capitalize()
     Catalogue = create_model(
         f"Catalogue{suffix}",
         **{

--- a/src/tests/test_proxy.py
+++ b/src/tests/test_proxy.py
@@ -7,12 +7,10 @@ from versioning import Version
 @pytest.mark.parametrize("prefix", ["/aiod", "/test"])
 def test_home_redirect_respects_proxy_header(prefix: str, client: TestClient):
     result = client.get("/", headers={"x-forwarded-prefix": prefix})
-    version_prefix = "" if client.version == Version.LATEST else f"/{client.version}"  # type: ignore[attr-defined]
-    assert f"{prefix}{version_prefix}/docs" in result.text
+    assert f"{prefix}{client.version.prefix}/docs" in result.text  # type: ignore[attr-defined]
 
 
 @pytest.mark.parametrize("prefix", ["/aiod", "/test"])
 def test_oauth_redirect_respects_proxy_header(prefix: str, client: TestClient):
     result = client.get("/docs", headers={"x-forwarded-prefix": prefix})
-    version_prefix = "" if client.version == Version.LATEST else f"/{client.version}"  # type: ignore[attr-defined]
-    assert f"{prefix}{version_prefix}/docs/oauth2-redirect" in result.text
+    assert f"{prefix}{client.version.prefix}/docs/oauth2-redirect" in result.text  # type: ignore[attr-defined]

--- a/src/tests/test_proxy.py
+++ b/src/tests/test_proxy.py
@@ -1,0 +1,18 @@
+import pytest
+from starlette.testclient import TestClient
+
+from versioning import Version
+
+
+@pytest.mark.parametrize("prefix", ["/aiod", "/test"])
+def test_home_redirect_respects_proxy_header(prefix: str, client: TestClient):
+    result = client.get("/", headers={"x-forwarded-prefix": prefix})
+    version_prefix = "" if client.version == Version.LATEST else f"/{client.version}"  # type: ignore[attr-defined]
+    assert f"{prefix}{version_prefix}/docs" in result.text
+
+
+@pytest.mark.parametrize("prefix", ["/aiod", "/test"])
+def test_oauth_redirect_respects_proxy_header(prefix: str, client: TestClient):
+    result = client.get("/docs", headers={"x-forwarded-prefix": prefix})
+    version_prefix = "" if client.version == Version.LATEST else f"/{client.version}"  # type: ignore[attr-defined]
+    assert f"{prefix}{version_prefix}/docs/oauth2-redirect" in result.text

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -151,7 +151,10 @@ def client(request, engine: Engine) -> TestClient:
     """
     app = build_app(version="unittest")
     path_prefix = str(request.param) if request.param != Version.LATEST else ""
-    yield TestClient(app, base_url=f"http://localhost/{path_prefix}")
+    client = TestClient(app, base_url=f"http://localhost/{path_prefix}")
+    client.version = request.param
+    yield client
+
 
 
 # *NEVER* broaden the scope of this fixture, bypassing reviews should be on a test-by-test basis

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -150,11 +150,12 @@ def client(request, engine: Engine) -> TestClient:
     Create a TestClient that can be used to mock sending requests to our application
     """
     app = build_app(version="unittest")
-    path_prefix = str(request.param) if request.param != Version.LATEST else ""
-    client = TestClient(app, base_url=f"http://localhost/{path_prefix}")
+    client = TestClient(
+        app,
+        base_url=f"http://localhost/{request.param.prefix}",  # param is Version
+    )
     client.version = request.param
     yield client
-
 
 
 # *NEVER* broaden the scope of this fixture, bypassing reviews should be on a test-by-test basis

--- a/src/versioning.py
+++ b/src/versioning.py
@@ -32,6 +32,12 @@ class Version(StrEnum):
     V3 = auto()
     LATEST = auto()
 
+    @property
+    def prefix(self) -> str:
+        if self == Version.LATEST:
+            return ""
+        return f"/{self}"
+
 
 def add_deprecation_header_middleware(app: FastAPI, date: datetime, link: str | None = None):
     async def add_deprecation_header(request: Request, call_next):

--- a/src/versioning.py
+++ b/src/versioning.py
@@ -13,7 +13,7 @@ from typing import NamedTuple
 
 from fastapi import FastAPI
 from starlette.requests import Request
-from fastapi.openapi.docs import get_swagger_ui_html, get_redoc_html
+from fastapi.openapi.docs import get_swagger_ui_html, get_redoc_html, get_swagger_ui_oauth2_redirect_html
 from starlette.responses import HTMLResponse
 
 from config import CONFIG, default_config_path
@@ -124,12 +124,12 @@ def add_version_to_openapi(versioned_api: FastAPI, root_path: str = ""):
             if not info.retired
         }
         menu = generate_version_menu(all_versions=show_versions, selected=versioned_api.version)
-
+        redirect_url = f"{root_path}{version_prefix}{versioned_api.swagger_ui_oauth2_redirect_url}"
         html_response = get_swagger_ui_html(
             openapi_url=f"{root_path}{version_prefix}/openapi.json",
             title="AI-on-Demand REST API",
             swagger_favicon_url="https://aiod.eu/wp-content/themes/aiod-v2/assets/img/favicon-192x192.png",
-            oauth2_redirect_url=versioned_api.swagger_ui_oauth2_redirect_url,
+            oauth2_redirect_url=redirect_url,
             init_oauth=versioned_api.swagger_ui_init_oauth,
         )
         html_str = html_response.body.decode()
@@ -141,6 +141,10 @@ def add_version_to_openapi(versioned_api: FastAPI, root_path: str = ""):
         )
 
     versioned_api.get("/docs", include_in_schema=False)(overridden_swagger)
+
+    async def oauth_redirect(request: Request) -> HTMLResponse:
+        return get_swagger_ui_oauth2_redirect_html()
+    versioned_api.add_route(versioned_api.swagger_ui_oauth2_redirect_url, oauth_redirect, include_in_schema=False)
 
     def overridden_redoc():
         html = get_redoc_html(

--- a/src/versioning.py
+++ b/src/versioning.py
@@ -13,7 +13,11 @@ from typing import NamedTuple
 
 from fastapi import FastAPI
 from starlette.requests import Request
-from fastapi.openapi.docs import get_swagger_ui_html, get_redoc_html, get_swagger_ui_oauth2_redirect_html
+from fastapi.openapi.docs import (
+    get_swagger_ui_html,
+    get_redoc_html,
+    get_swagger_ui_oauth2_redirect_html,
+)
 from starlette.responses import HTMLResponse
 
 from config import CONFIG, default_config_path
@@ -79,7 +83,7 @@ def add_deprecation_and_sunset_middleware(app: FastAPI):
         add_sunset_header_middleware(app, date=info.sunset, link=info.link)
 
 
-def add_version_to_openapi(versioned_api: FastAPI, root_path: str = ""):
+def add_version_to_openapi(versioned_api: FastAPI):
     """Adds the version prefix to all paths in the schema."""
     if versioned_api.version == "latest":
         version_prefix = ""
@@ -117,7 +121,8 @@ def add_version_to_openapi(versioned_api: FastAPI, root_path: str = ""):
     versioned_api._openapi = versioned_api.openapi
     versioned_api.openapi = custom_openapi
 
-    def overridden_swagger():
+    def overridden_swagger(request: Request):
+        root_path = request.headers.get("x-forwarded-prefix", "")
         show_versions = {"latest": f"{root_path}/docs"} | {
             version: f"{root_path}/{version}/docs"
             for version, info in versions.items()
@@ -144,9 +149,13 @@ def add_version_to_openapi(versioned_api: FastAPI, root_path: str = ""):
 
     async def oauth_redirect(request: Request) -> HTMLResponse:
         return get_swagger_ui_oauth2_redirect_html()
-    versioned_api.add_route(versioned_api.swagger_ui_oauth2_redirect_url, oauth_redirect, include_in_schema=False)
 
-    def overridden_redoc():
+    versioned_api.add_route(
+        versioned_api.swagger_ui_oauth2_redirect_url, oauth_redirect, include_in_schema=False
+    )
+
+    def overridden_redoc(request: Request):
+        root_path = request.headers.get("x-forwarded-prefix", "")
         html = get_redoc_html(
             openapi_url=f"{root_path}{version_prefix}/openapi.json",
             title="AI-on-Demand REST API",


### PR DESCRIPTION
<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Fixed <!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Internal <!-- Documentation/Interface/Internal/Other -->

Changelog Entry: Fix an issue where routing behind a proxy with a prefix wouldn't work as expected. <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->

<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Spin up normally, then direct access should work fine.
Spin up with the nginx profile and an updated nginx configuration as per the documentation, and see that .
Pay particular attention to the documentation pages, they wouldn't properly redirect without this fix.
Authentication likely won't work unless you add additional valid redirect URLs to the keycloak instance, but the test server (test.openml.org/aiod) is currently also running this branch where you can test it with a correctly configured auth server.

I also added a `prefix` property for the `Version` enum to handle formatting more centrally.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
