### PR TITLE
Add pagination to `user/resources`

### DIFF
--- a/src/routers/user_router.py
+++ b/src/routers/user_router.py
@@ -33,10 +33,17 @@ def create(url_prefix: str, version: Version) -> APIRouter:
         },
     )
 
+    resources_for_user_description = "Return all assets for which you have administrator rights."
+    if version == Version.V2:
+        resources_for_user_description += (
+            " For backwards compatibility reasons, if `limit=10` no limit is applied."
+            " In V3 and later, the default limit of 10 is respected."
+        )
+
     @router.get(
         f"/user/resources",
+        description=resources_for_user_description,
         tags=["User"],
-        description="Return all assets for which you have administrator rights",
         response_model=Catalogue,
     )
     def get_versioned_resources_for_user(
@@ -44,11 +51,15 @@ def create(url_prefix: str, version: Version) -> APIRouter:
         user: KeycloakUser = Depends(get_user_or_raise),
         session: Session = Depends(get_session),
     ) -> dict[str, list[AIoDConcept]]:
+        limit: int | None = pagination.limit
+        if limit == 10 and version == Version.V2:
+            limit = None
+
         resources = _get_resources_for_user(
             user,
             session,
             offset=pagination.offset,
-            limit=pagination.limit,
+            limit=limit,
         )
         orm_to_read = {
             r.resource_class.__tablename__: r.orm_to_read

--- a/src/routers/user_router.py
+++ b/src/routers/user_router.py
@@ -5,6 +5,7 @@ from pydantic import create_model, Field
 from sqlalchemy import select
 from sqlmodel import Session
 
+from dependencies.pagination import PaginationParams
 from routers.resource_routers import versioned_routers
 from authentication import KeycloakUser, get_user_or_raise
 from database.authorization import Permission, PermissionType
@@ -39,10 +40,16 @@ def create(url_prefix: str, version: Version) -> APIRouter:
         response_model=Catalogue,
     )
     def get_versioned_resources_for_user(
+        pagination: PaginationParams,
         user: KeycloakUser = Depends(get_user_or_raise),
         session: Session = Depends(get_session),
     ) -> dict[str, list[AIoDConcept]]:
-        resources = _get_resources_for_user(user, session)
+        resources = _get_resources_for_user(
+            user,
+            session,
+            offset=pagination.offset,
+            limit=pagination.limit,
+        )
         orm_to_read = {
             r.resource_class.__tablename__: r.orm_to_read
             for r in versioned_routers.get(version, [])
@@ -55,7 +62,13 @@ def create(url_prefix: str, version: Version) -> APIRouter:
     return router
 
 
-def _get_resources_for_user(user: KeycloakUser, session: Session) -> dict[str, list[AIoDConcept]]:
+def _get_resources_for_user(
+    user: KeycloakUser,
+    session: Session,
+    *,
+    offset: int = 0,
+    limit: int | None = None,
+) -> dict[str, list[AIoDConcept]]:
     # "Ownership" is currently equivalent to having ADMIN permissions
     stmt = (
         select(AIoDEntryORM)
@@ -64,7 +77,10 @@ def _get_resources_for_user(user: KeycloakUser, session: Session) -> dict[str, l
             Permission.user_identifier == user._subject_identifier,
             Permission.type_ == PermissionType.ADMIN,
         )
+        .offset(offset)
     )
+    if limit:
+        stmt = stmt.limit(limit)
     entries = session.scalars(stmt).all()
     assets_to_fetch = [entry.identifier for entry in entries]
     # We have AIoD entries, but want their respective asset information (e.g. publication).

--- a/src/tests/test_user_endpoints.py
+++ b/src/tests/test_user_endpoints.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from typing import Callable
 
+import pytest
 from starlette.testclient import TestClient
 
 from database.authorization import set_permission, PermissionType, register_user
@@ -10,6 +11,7 @@ from database.session import DbSession
 from database.model.agent.organisation import Organisation
 from tests.testutils.users import register_asset, logged_in_user, ALICE, BOB
 from tests.testutils.default_instances import publication_factory, publication
+from versioning import Version
 
 
 def test_my_resources_can_be_empty(client: TestClient) -> None:
@@ -121,3 +123,25 @@ def test_my_resources_paginates(client: TestClient, publication_factory: Publica
         response = client.get("/user/resources?offset=1&limit=1", headers={"Authorization": "fake token"})
         assert response.status_code == HTTPStatus.OK
         assert len(response.json()["publication"]) == 1, "Offset and limit should be able to be used together."
+
+
+@pytest.mark.versions(Version.V2)
+def test_my_resources_no_limit_default_in_v2(client: TestClient, publication_factory: Publication) -> None:
+    for _ in range(11):  # The default pagination limit is 10
+        register_asset(publication_factory(), owner=ALICE, status=EntryStatus.PUBLISHED)
+
+    with logged_in_user(ALICE):
+        response = client.get("/user/resources", headers={"Authorization": "fake token"})
+        assert response.status_code == HTTPStatus.OK
+        assert len(response.json()["publication"]) == 11
+
+
+@pytest.mark.versions(Version.LATEST)
+def test_my_resources_limit_default_in_latest(client: TestClient, publication_factory: Publication) -> None:
+    for _ in range(11):  # The default pagination limit is 10
+        register_asset(publication_factory(), owner=ALICE, status=EntryStatus.PUBLISHED)
+
+    with logged_in_user(ALICE):
+        response = client.get("/user/resources", headers={"Authorization": "fake token"})
+        assert response.status_code == HTTPStatus.OK
+        assert len(response.json()["publication"]) == 10, "Set limit should be respected"

--- a/src/tests/test_user_endpoints.py
+++ b/src/tests/test_user_endpoints.py
@@ -98,3 +98,26 @@ def test_my_resources_counts_only_if_admin(client: TestClient, publication_facto
 def test_my_resources_must_be_authorized(client: TestClient) -> None:
     response = client.get("/user/resources")
     assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_my_resources_paginates(client: TestClient, publication_factory: Publication) -> None:
+    register_asset(publication_factory(), owner=ALICE, status=EntryStatus.PUBLISHED)
+    register_asset(publication_factory(), owner=ALICE, status=EntryStatus.PUBLISHED)
+    register_asset(publication_factory(), owner=ALICE, status=EntryStatus.PUBLISHED)
+
+    with logged_in_user(ALICE):
+        response = client.get("/user/resources?limit=2", headers={"Authorization": "fake token"})
+        assert response.status_code == HTTPStatus.OK
+        assert len(response.json()["publication"]) == 2, "Set limit should be respected"
+
+        first_asset = response.json()["publication"][0]["identifier"]
+
+        response = client.get("/user/resources?offset=1", headers={"Authorization": "fake token"})
+        assert response.status_code == HTTPStatus.OK
+        assert len(response.json()["publication"]) == 2, "Using an offset can reduce the amount of returned results."
+        msg = "Increasing offset should lead to different assets."
+        assert first_asset not in [pub["identifier"] for pub in response.json()["publication"]], msg
+
+        response = client.get("/user/resources?offset=1&limit=1", headers={"Authorization": "fake token"})
+        assert response.status_code == HTTPStatus.OK
+        assert len(response.json()["publication"]) == 1, "Offset and limit should be able to be used together."


### PR DESCRIPTION
## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Added <!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Interface <!-- Documentation/Interface/Internal/Other -->

Changelog Entry: <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->

Add pagination to `user/resources`.

Set `limit` (default=10) and/or `offset` (default=0) to use pagination. Also available in V2, but for backwards compatibility reasons, `limit=10` will apply no limit at all.

<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Covered by tests.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Closes #598 