### PR TITLE
Add pagination to `/bookmarks`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: pytest-check
         name: pytest-check
-        entry: pytest src/tests --versions ''
+        entry: pytest src/tests --versions 'latest'
         language: system
         pass_filenames: false
         exclude: ".*.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,4 @@ env_files = [
     ".env",  # Only used if running from docker container
     "tests/.env"  # Only used if running from docker container
 ]
+markers=["versions"]

--- a/src/routers/bookmark_router.py
+++ b/src/routers/bookmark_router.py
@@ -8,6 +8,8 @@ from database.session import get_session
 from database.model.bookmark.bookmark import Bookmark
 from http import HTTPStatus
 from datetime import datetime
+
+from dependencies.pagination import PaginationParams
 from routers.helper_functions import get_asset_type_by_abbreviation
 from versioning import Version
 
@@ -33,11 +35,17 @@ def create(url_prefix: str = "", version: Version = Version.LATEST) -> APIRouter
         response_model=List[BookmarkRead],
     )
     def list_bookmarks(
-        user: KeycloakUser = Depends(get_user_or_raise), session: Session = Depends(get_session)
+        pagination: PaginationParams,
+        user: KeycloakUser = Depends(get_user_or_raise),
+        session: Session = Depends(get_session),
     ) -> List[BookmarkRead]:
-        return session.exec(
-            select(Bookmark).where(Bookmark.user_identifier == user._subject_identifier)
-        ).all()
+        stmt = (
+            select(Bookmark)
+            .where(Bookmark.user_identifier == user._subject_identifier)
+            .offset(pagination.offset)
+            .limit(pagination.limit)
+        )
+        return session.exec(stmt).all()
 
     @router.post(
         path,

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -15,12 +15,10 @@ def pytest_generate_tests(metafunc):
         selected_versions = version_marker.args if version_marker else default_versions
 
         # If version is set through the command line, only use that for testing.
-        all_versions = list(Version)
-        versions_to_include = metafunc.config.getoption("versions") or all_versions
+        versions_to_include = list(Version)
+        if cmd_line_versions := metafunc.config.getoption("versions"):
+            versions_to_include = [Version(v) for v in cmd_line_versions]
         versions = set(selected_versions).intersection(set(versions_to_include))
-        if not versions:
-            pytest.skip(f"Test not defined for selection: {versions_to_include}")
-
         metafunc.parametrize(
             "client", versions, indirect=True
         )

--- a/src/tests/test_bookmark_endpoints.py
+++ b/src/tests/test_bookmark_endpoints.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 
+import pytest
 from starlette.testclient import TestClient
 from database.session import DbSession
 
@@ -10,6 +11,7 @@ from tests.testutils.users import register_asset, register_user
 from datetime import datetime
 from database.model.agent.person import Person
 from database.model.agent.contact import Contact
+from versioning import Version
 
 
 def test_create_bookmark(
@@ -140,3 +142,45 @@ def test_delete_bookmark(
         )
     assert response.status_code == HTTPStatus.OK
     assert all(b["resource_identifier"] != identifier for b in response.json())
+
+
+@pytest.mark.versions(Version.V2, Version.LATEST)
+def test_get_bookmark_pagination(client: TestClient, publication_factory) -> None:
+    PAGINATION_DEFAULT_LIMIT = 10
+    publications = [publication_factory() for _ in range(PAGINATION_DEFAULT_LIMIT + 1)]
+    with logged_in_user(ALICE):
+        for pub in publications:
+            register_asset(pub, owner=ALICE)
+            response = client.post(
+                f"/bookmarks?resource_identifier={pub.identifier}",
+                headers={"Authorization": "fake token"},
+            )
+            assert response.status_code == HTTPStatus.OK
+
+        response = client.get(
+            "/bookmarks",
+            headers={"Authorization": "fake token"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert len(response.json()) == PAGINATION_DEFAULT_LIMIT
+
+        response = client.get(
+            "/bookmarks?limit=100",
+            headers={"Authorization": "fake token"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert len(response.json()) == PAGINATION_DEFAULT_LIMIT + 1
+
+        response = client.get(
+            "/bookmarks?offset=10",
+            headers={"Authorization": "fake token"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert len(response.json()) == 1
+
+        response = client.get(
+            "/bookmarks?offset=8&limit=2",
+            headers={"Authorization": "fake token"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert len(response.json()) == 2

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -152,7 +152,7 @@ def client(request, engine: Engine) -> TestClient:
     app = build_app(version="unittest")
     client = TestClient(
         app,
-        base_url=f"http://localhost/{request.param.prefix}",  # param is Version
+        base_url=f"http://localhost{request.param.prefix}/",  # param is Version
     )
     client.version = request.param
     yield client


### PR DESCRIPTION
<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Added <!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Interface <!-- Documentation/Interface/Internal/Other -->

Changelog Entry: <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->
Add pagination to `/bookmarks`

Pagination limits and offsets can now be specified when browsing a user's bookmarks.
Note that the defaults have different behavior, and requesting all bookmarks in `v2` now also limits to 10 by default.
Unlike the change to `user/resources`, we add this to `v2` since the endpoint was not in use yet.
<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Covered by tests.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Closes #599 