### PR TITLE
Introduce `__plural__` attribute on model classes to denote the spelling of the plural form.

### DIFF
--- a/src/database/model/agent/contact.py
+++ b/src/database/model/agent/contact.py
@@ -38,6 +38,7 @@ class ContactBase(AIoDConceptBase):
 class Contact(ContactBase, AIoDConcept, table=True):  # type: ignore [call-arg]
     __tablename__ = "contact"
     __abbreviation__ = "con"
+    __plural__ = "contacts"
 
     email: list[Email] = Relationship(
         link_model=many_to_many_link_factory(

--- a/src/database/model/agent/email.py
+++ b/src/database/model/agent/email.py
@@ -3,3 +3,4 @@ from database.model.named_relation import NamedRelation
 
 class Email(NamedRelation, table=True):  # type: ignore [call-arg]
     __tablename__ = "email"
+    __plural__ = "emails"

--- a/src/database/model/agent/expertise.py
+++ b/src/database/model/agent/expertise.py
@@ -3,3 +3,4 @@ from database.model.named_relation import NamedRelation
 
 class Expertise(NamedRelation, table=True):  # type: ignore [call-arg]
     __tablename__ = "expertise"
+    __plural__ = "expertises"

--- a/src/database/model/agent/language.py
+++ b/src/database/model/agent/language.py
@@ -3,3 +3,4 @@ from database.model.named_relation import NamedRelation
 
 class Language(NamedRelation, table=True):  # type: ignore [call-arg]
     __tablename__ = "language"
+    __plural__ = "languages"

--- a/src/database/model/agent/location.py
+++ b/src/database/model/agent/location.py
@@ -104,6 +104,7 @@ class LocationBase(SQLModel):
 
 class LocationORM(LocationBase, table=True):  # type: ignore [call-arg]
     __tablename__ = "location"
+    __plural__ = "locations"
 
     identifier: int | None = Field(primary_key=True)
     address: Optional["AddressORM"] = Relationship(

--- a/src/database/model/agent/organisation.py
+++ b/src/database/model/agent/organisation.py
@@ -20,10 +20,16 @@ from database.model.serializers import (
 from versioning import Version, VersionedResource, VersionedResourceCollection
 
 
-Turnover: type[Taxonomy] = create_taxonomy(class_name="Turnover", table_name="turnover")
+Turnover: type[Taxonomy] = create_taxonomy(
+    class_name="Turnover",
+    table_name="turnover",
+    plural_name="turnovers",
+)
 
 NumberOfEmployees: type[Taxonomy] = create_taxonomy(
-    class_name="NumberOfEmployees", table_name="number_of_employees"
+    class_name="NumberOfEmployees",
+    table_name="number_of_employees",
+    plural_name="numbers of employees",
 )
 
 
@@ -48,6 +54,7 @@ class OrganisationBase(AgentBase):
 class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-arg]
     __tablename__ = "organisation"
     __abbreviation__ = "org"
+    __plural__ = "organisations"
 
     contact_details: Optional[Contact] = Relationship(sa_relationship_kwargs={"uselist": False})
 

--- a/src/database/model/agent/organisation_type.py
+++ b/src/database/model/agent/organisation_type.py
@@ -3,3 +3,4 @@ from database.model.named_relation import NamedRelation
 
 class OrganisationType(NamedRelation, table=True):  # type: ignore [call-arg]
     __tablename__ = "organisation_type"
+    __plural__ = "organisation_types"

--- a/src/database/model/agent/person.py
+++ b/src/database/model/agent/person.py
@@ -49,6 +49,7 @@ class PersonBase(AgentBase):
 class Person(PersonBase, Agent, table=True):  # type: ignore [call-arg]
     __tablename__ = "person"
     __abbreviation__ = "prsn"
+    __plural__ = "persons"
 
     expertise: list[Expertise] = Relationship(
         link_model=many_to_many_link_factory(

--- a/src/database/model/agent/team.py
+++ b/src/database/model/agent/team.py
@@ -29,6 +29,7 @@ class TeamBase(AIResourceBase):
 class Team(TeamBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "team"
     __abbreviation__ = "team"
+    __plural__ = "teams"
 
     organisation_identifier: str | None = Field(
         max_length=IDENTIFIER_LENGTH, foreign_key=Organisation.__tablename__ + ".identifier"

--- a/src/database/model/ai_asset/license.py
+++ b/src/database/model/ai_asset/license.py
@@ -2,4 +2,8 @@ from typing import Type
 
 from database.model.named_relation import create_taxonomy, Taxonomy
 
-License: Type[Taxonomy] = create_taxonomy(class_name="License", table_name="license")
+License: Type[Taxonomy] = create_taxonomy(
+    class_name="License",
+    table_name="license",
+    plural_name="licenses",
+)

--- a/src/database/model/ai_resource/industrial_sector.py
+++ b/src/database/model/ai_resource/industrial_sector.py
@@ -3,5 +3,7 @@ from typing import Type
 from database.model.named_relation import create_taxonomy, Taxonomy
 
 IndustrialSector: Type[Taxonomy] = create_taxonomy(
-    class_name="IndustrialSector", table_name="industrial_sector"
+    class_name="IndustrialSector",
+    table_name="industrial_sector",
+    plural_name="industrial sectors",
 )

--- a/src/database/model/ai_resource/research_area.py
+++ b/src/database/model/ai_resource/research_area.py
@@ -3,5 +3,7 @@ from typing import Type
 from database.model.named_relation import create_taxonomy, Taxonomy
 
 ResearchArea: Type[Taxonomy] = create_taxonomy(
-    class_name="ResearchArea", table_name="research_area"
+    class_name="ResearchArea",
+    table_name="research_area",
+    plural_name="research areas",
 )

--- a/src/database/model/ai_resource/scientific_domain.py
+++ b/src/database/model/ai_resource/scientific_domain.py
@@ -3,5 +3,7 @@ from typing import Type
 from database.model.named_relation import create_taxonomy, Taxonomy
 
 ScientificDomain: Type[Taxonomy] = create_taxonomy(
-    class_name="ScientificDomain", table_name="scientific_domain"
+    class_name="ScientificDomain",
+    table_name="scientific_domain",
+    plural_name="scientific domains",
 )

--- a/src/database/model/bookmark/bookmark.py
+++ b/src/database/model/bookmark/bookmark.py
@@ -6,6 +6,7 @@ from sqlalchemy import Column, String
 
 class Bookmark(SQLModel, table=True):  # type: ignore [call-arg]
     __tablename__ = "bookmark"
+    __plural__ = "bookmarks"
     user_identifier: str = Field(
         foreign_key="user.subject_identifier",
         nullable=False,

--- a/src/database/model/case_study/case_study.py
+++ b/src/database/model/case_study/case_study.py
@@ -9,6 +9,7 @@ class CaseStudyBase(AIAssetBase):
 class CaseStudy(CaseStudyBase, AIAsset, table=True):  # type: ignore [call-arg]
     __tablename__ = "case_study"
     __abbreviation__ = "case"
+    __plural__ = "case studies"
 
 
 case_study_versions = VersionedResourceCollection(

--- a/src/database/model/computational_asset/computational_asset.py
+++ b/src/database/model/computational_asset/computational_asset.py
@@ -30,6 +30,7 @@ class ComputationalAsset(ComputationalAssetBase, AIAsset, table=True):  # type: 
 
     __tablename__ = "computational_asset"
     __abbreviation__ = "comp"
+    __plural__ = "computational assets"
 
     type_identifier: int | None = Field(
         foreign_key=ComputationalAssetType.__tablename__ + ".identifier"

--- a/src/database/model/dataset/dataset.py
+++ b/src/database/model/dataset/dataset.py
@@ -49,6 +49,7 @@ class DatasetBase(AIAssetBase):
 class Dataset(DatasetBase, AIAsset, table=True):  # type: ignore [call-arg]
     __tablename__ = "dataset"
     __abbreviation__ = "data"
+    __plural__ = "datasets"
 
     funder: list["AgentTable"] = Relationship(
         link_model=many_to_many_link_factory(

--- a/src/database/model/educational_resource/educational_resource.py
+++ b/src/database/model/educational_resource/educational_resource.py
@@ -36,6 +36,7 @@ class EducationalResourceBase(AIResourceBase):
 class EducationalResource(EducationalResourceBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "educational_resource"
     __abbreviation__ = "edu"
+    __plural__ = "educational resources"
 
     type_identifier: int | None = Field(
         foreign_key=EducationalResourceType.__tablename__ + ".identifier"

--- a/src/database/model/event/event.py
+++ b/src/database/model/event/event.py
@@ -53,6 +53,7 @@ class EventBase(AIResourceBase):
 class Event(EventBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "event"
     __abbreviation__ = "evnt"
+    __plural__ = "events"
 
     content_identifier: int | None = Field(
         index=True,

--- a/src/database/model/knowledge_asset/PublicationType.py
+++ b/src/database/model/knowledge_asset/PublicationType.py
@@ -3,5 +3,7 @@ from typing import Type
 from database.model.named_relation import create_taxonomy, Taxonomy
 
 PublicationType: Type[Taxonomy] = create_taxonomy(
-    class_name="PublicationType", table_name="publication_type"
+    class_name="PublicationType",
+    table_name="publication_type",
+    plural_name="publication types",
 )

--- a/src/database/model/knowledge_asset/publication.py
+++ b/src/database/model/knowledge_asset/publication.py
@@ -45,6 +45,7 @@ class PublicationBase(KnowledgeAssetBase):
 class Publication(PublicationBase, KnowledgeAsset, table=True):  # type: ignore [call-arg]
     __tablename__ = "publication"
     __abbreviation__ = "pub"
+    __plural__ = "publications"
 
     content_identifier: int | None = Field(
         index=True,

--- a/src/database/model/models_and_experiments/experiment.py
+++ b/src/database/model/models_and_experiments/experiment.py
@@ -44,6 +44,7 @@ class ExperimentBase(AIAssetBase):
 class Experiment(ExperimentBase, AIAsset, table=True):  # type: ignore [call-arg]
     __tablename__ = "experiment"
     __abbreviation__ = "exp"
+    __plural__ = "experiments"
 
     badge: list[Badge] = Relationship(
         link_model=many_to_many_link_factory(

--- a/src/database/model/models_and_experiments/ml_model.py
+++ b/src/database/model/models_and_experiments/ml_model.py
@@ -30,6 +30,7 @@ class MLModelBase(AIAssetBase):
 class MLModel(MLModelBase, AIAsset, table=True):  # type: ignore [call-arg]
     __tablename__ = "ml_model"
     __abbreviation__ = "mdl"
+    __plural__ = "ml models"
 
     related_experiment: list["Experiment"] = Relationship(
         link_model=many_to_many_link_factory(

--- a/src/database/model/named_relation.py
+++ b/src/database/model/named_relation.py
@@ -57,12 +57,17 @@ class Taxonomy(NamedRelation):
         return tuple()
 
 
-def create_taxonomy(class_name: str, table_name: str) -> type[Taxonomy]:
+def create_taxonomy(
+    class_name: str,
+    table_name: str,
+    plural_name: str,
+) -> type[Taxonomy]:
     clazz = create_model(
         __model_name=class_name,
         __base__=Taxonomy,
         __cls_kwargs__=dict(table=True),
         __tablename__=(str, table_name),
+        __plural__=(str, plural_name),
         # Taxonomies are hierarchical, e.g., a Cow is also a Mammal.
         # These fields are updated dynamically in `__init__subclass__`.
         parent_id=(

--- a/src/database/model/news/news.py
+++ b/src/database/model/news/news.py
@@ -39,6 +39,7 @@ class NewsBase(AIResourceBase):
 class News(NewsBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "news"
     __abbreviation__ = "news"
+    __plural__ = "news"
 
     category: list[NewsCategory] = Relationship(  # type: ignore[valid-type]
         link_model=many_to_many_link_factory(

--- a/src/database/model/news/news_category.py
+++ b/src/database/model/news/news_category.py
@@ -3,5 +3,7 @@ from typing import Type
 from database.model.named_relation import create_taxonomy, Taxonomy
 
 NewsCategory: Type[Taxonomy] = create_taxonomy(
-    class_name="NewsCategory", table_name="news_category"
+    class_name="NewsCategory",
+    table_name="news_category",
+    plural_name="news categories",
 )

--- a/src/database/model/platform/platform.py
+++ b/src/database/model/platform/platform.py
@@ -22,6 +22,7 @@ class Platform(PlatformBase, table=True):  # type: ignore [call-arg]
     AIoD. This table is partly filled with the enum PlatformName"""
 
     __tablename__ = "platform"
+    __plural__ = "platforms"
     __deletion_config__ = {"soft_delete": False}  # hard_deletion, otherwise name cannot be unique,
     # which is difficult for foreign key constraints
 

--- a/src/database/model/project/project.py
+++ b/src/database/model/project/project.py
@@ -39,6 +39,7 @@ class ProjectBase(AIResourceBase):
 class Project(ProjectBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "project"
     __abbreviation__ = "proj"
+    __plural__ = "projects"
 
     funder: list[Organisation] = Relationship(
         link_model=many_to_many_link_factory(

--- a/src/database/model/resource_bundle/resource_bundle.py
+++ b/src/database/model/resource_bundle/resource_bundle.py
@@ -26,6 +26,7 @@ class ResourceBundleBase(AIResourceBase):
 class ResourceBundle(ResourceBundleBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "resource_bundle"
     __abbreviation__ = "res"
+    __plural__ = "resource bundles"
 
     # Many-to-Many relationship linking ResourceBundle to external resources (URLs)
     includes_external_reference: List[ExternalResource] = Relationship(

--- a/src/database/model/service/service.py
+++ b/src/database/model/service/service.py
@@ -25,6 +25,7 @@ class ServiceBase(AIResourceBase):
 class Service(ServiceBase, AIResource, table=True):  # type: ignore [call-arg]
     __tablename__ = "service"
     __abbreviation__ = "srvc"
+    __plural__ = "services"
 
     class RelationshipConfig(AIResource.RelationshipConfig):
         pass

--- a/src/routers/enum_routers/taxonomy_router.py
+++ b/src/routers/enum_routers/taxonomy_router.py
@@ -30,15 +30,29 @@ class TaxonomyRouter(EnumRouter):
         default_kwargs = {
             "response_model_exclude_none": True,
             "tags": ["Taxonomies"],
+            "endpoint": self.get_official_terms_func(),
+            "response_model": list[TaxonomyHierarchy],
+            "name": self.resource_name,
         }
 
+        new_path = f"/{self.resource_class.__plural__.replace(' ', '_')}"
         router.add_api_route(
-            path=f"/{self.resource_name_plural}",
-            endpoint=self.get_official_terms_func(),
-            response_model=list[TaxonomyHierarchy],
-            name=self.resource_name,
+            path=new_path,
+            description=f"List definitions and descriptions of all valid {self.resource_class.__plural__}.",
             **default_kwargs,
         )
+        old_path = f"/{self.resource_name_plural}"
+        if version == Version.V2 and old_path != new_path:
+            router.add_api_route(
+                path=old_path,
+                deprecated=True,
+                description=(
+                    "List definitions and descriptions of all valid "
+                    f"{self.resource_class.__plural__}. "
+                    f"Deprecated: use `{new_path}` instead."
+                ),
+                **default_kwargs,
+            )
         return router
 
     def get_official_terms_func(self):

--- a/src/tests/routers/enum_routers/test_license_router.py
+++ b/src/tests/routers/enum_routers/test_license_router.py
@@ -1,7 +1,9 @@
+import pytest
 from starlette.testclient import TestClient
 from database.session import DbSession
 from database.model.agent.organisation import Organisation
 from database.model.agent.organisation_type import OrganisationType
+from versioning import Version
 
 
 def test_enum_router(client: TestClient, organisation: Organisation):
@@ -17,7 +19,15 @@ def test_enum_router(client: TestClient, organisation: Organisation):
 
 
 def test_taxonomy_router(client: TestClient):
-    response = client.get("/licenses")
+    response = client.get("/news_categories")
     assert response.status_code == 200, response.json()
     terms = {item["term"] for item in response.json()}
-    assert terms.issuperset({"CC-BY-4.0"})
+    assert terms.issuperset({"Education"})
+
+
+@pytest.mark.versions(Version.V2)
+def test_taxonomy_router_v2(client: TestClient):
+    response = client.get("/news_categorys")
+    assert response.status_code == 200, response.json()
+    terms = {item["term"] for item in response.json()}
+    assert terms.issuperset({"Education"})


### PR DESCRIPTION
A first step to avoid putting this knowledge on the router level, but rather on the model level. Fetching the `router` to have the information on the plural of the asset type is very roundabout way of doing it. Follow up work will gradually move usages from the router's `self.plural_name` to directly use the model class' `__plural__`.

## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Changed<!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Internal<!-- Documentation/Interface/Internal/Other -->

Changelog Entry: <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->
Introduce `__plural__` attribute on model classes to denote the spelling of the plural form.
<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->

## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Covered by tests.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
