### PR TITLE
Introduce one endpoint for all review requests: `/submissions`

### DIFF
--- a/alembic/alembic/versions/d02aac64a5c7_multi_asset_reviews.py
+++ b/alembic/alembic/versions/d02aac64a5c7_multi_asset_reviews.py
@@ -1,0 +1,95 @@
+"""multi_asset_reviews
+
+Revision ID: d02aac64a5c7
+Revises: 1fd9b6a162c4
+Create Date: 2025-09-16 12:27:10.238574
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d02aac64a5c7"
+down_revision: Union[str, None] = "1fd9b6a162c4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # We use a nuclear approach as there are no reviews in the database anyway:
+    op.drop_table("review")
+    op.drop_table("submission")
+
+    # We could leave it at the above an rely on SQLAlchemy to create the tables below.
+    # However, this increases the complexity of the deployment so make it explicit:
+    op.create_table(
+        "submission",
+        sa.Column("identifier", sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column("request_date", sa.DateTime(), nullable=False),
+        sa.Column("comment", sa.String(256), nullable=False),
+        sa.Column("requestee_identifier", sa.String(255), nullable=True),
+        sa.PrimaryKeyConstraint("identifier"),
+        sa.ForeignKeyConstraint(
+            ["requestee_identifier"],
+            ["user.subject_identifier"],
+            name="submission_ibfk_1",
+            ondelete="SET NULL",
+        ),
+    )
+    op.create_index("requestee_identifier", "submission", ["requestee_identifier"])
+
+    op.create_table(
+        "review",
+        sa.Column("comment", sa.String(1800), nullable=False),
+        sa.Column(
+            "decision",
+            sa.Enum("ACCEPTED", "REJECTED", "RETRACTED", name="review_decision"),
+            nullable=True,
+        ),
+        sa.Column("identifier", sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column("decision_date", sa.DateTime(), nullable=False),
+        sa.Column("reviewer_identifier", sa.String(255), nullable=False),
+        sa.Column("submission_identifier", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("identifier"),
+        sa.ForeignKeyConstraint(
+            ["reviewer_identifier"], ["user.subject_identifier"], name="review_ibfk_1"
+        ),
+        sa.ForeignKeyConstraint(
+            ["submission_identifier"], ["submission.identifier"], name="review_ibfk_2"
+        ),
+    )
+    op.create_index("reviewer_identifier", "review", ["reviewer_identifier"])
+    op.create_index("submission_identifier", "review", ["submission_identifier"])
+
+    op.create_table(
+        "asset_review",
+        sa.Column("asset_identifier", sa.String(255), nullable=False),
+        sa.Column("aiod_entry_identifier", sa.Integer(), nullable=False),
+        sa.Column("review_identifier", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("aiod_entry_identifier", "review_identifier"),
+        sa.ForeignKeyConstraint(
+            ["aiod_entry_identifier"],
+            ["aiod_entry.identifier"],
+            name="asset_review_ibfk_1",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["review_identifier"],
+            ["submission.identifier"],
+            name="asset_review_ibfk_2",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index("review_identifier", "asset_review", ["review_identifier"])
+
+
+def downgrade() -> None:
+    op.drop_table("review")
+    op.drop_table("asset_review")
+    op.drop_table("submission")
+
+    # just start the server and the tables will be created automatically.

--- a/docs/using/upload.md
+++ b/docs/using/upload.md
@@ -61,16 +61,17 @@ can do this by making a `POST` request to the `/submissions` endpoint.
 You are required to include the identifier in the request body,
 and may include a comment to the reviewer of up to 256 characters in the body of the
 `POST` request, this should generally not be necessary but may be useful to provide
-some clarification:
+some clarification. You may supply more than one asset identifier at once,
+these assets will then be accepted and rejected together.
 
 ```json
 {
-  "asset_identifier": "case_n8DhfFgMYv4beBnVurHa13ZS",
+  "asset_identifiers": ["case_n8DhfFgMYv4beBnVurHa13ZS"],
   "comment": "Clarification the reviewer should be aware of."
 }
 ```
 
-When you request a submission, you also get a response with the submission's identifier.
+When you request a submission, you get a response with the submission's identifier.
 
 ```json
 {
@@ -102,12 +103,10 @@ For example, if the submission identifier we received was '1', we can query
   "identifier": 1,
   "request_date": "2025-03-20T09:09:54",
   "aiod_entry_identifier": 212,
-  "asset_type": "case_study",
-  "asset_identifier": "case_n8DhfFgMYv4beBnVurHa13ZS",
   "reviews": [],
-  "asset": {
+  "assets": [{
     ...
-  }
+  }]
 }
 ```
 No reviews have yet been performed on the submission, as indicated by the empty list
@@ -122,8 +121,7 @@ to the `submissions` endpoint, which will result in a response such as:
     "identifier": 1,
     "request_date": "2025-03-20T09:09:54",
     "aiod_entry_identifier": 212,
-    "asset_type": "case_study",
-    "asset_identifier": "case_n8DhfFgMYv4beBnVurHa13ZS",
+    "asset_identifiers": ["case_n8DhfFgMYv4beBnVurHa13ZS"],
   }
 ]
 ```
@@ -158,8 +156,6 @@ endpoint will provide you with the reviewer feedback, e.g.:
   "identifier": 1,
   "request_date": "2025-03-20T09:09:54",
   "aiod_entry_identifier": 212,
-  "asset_type": "case_study",
-  "asset_identifier": "case_n8DhfFgMYv4beBnVurHa13ZS",
   "reviews": [
     {
       "comment": "Several critical fields have incomplete information. Please improve the description, and add a house number to the address.",
@@ -169,7 +165,7 @@ endpoint will provide you with the reviewer feedback, e.g.:
       "submission_identifier": 1
     }
   ],
-  "asset": { ... }
+  "assets": [{ ... }]
 }
 ```
 You'll find reviewer comments under "reviews".

--- a/docs/using/upload.md
+++ b/docs/using/upload.md
@@ -41,31 +41,31 @@ of the endpoints, including their exact addresses and schemas used.
 The sections below describe the process in more detail.
 
 ### Registering the Asset
-You upload your assets to `/ASSET/v1` using a `POST` request that contains
+You upload your assets to `/ASSET` using a `POST` request that contains
 in the JSON body all the required data for the asset type. A successful response
 should look something like this:
 
 ```json
 {
-  "identifier": 3
+  "identifier": "case_n8DhfFgMYv4beBnVurHa13ZS"
 }
 ```
 
 Take a note of the identifier assigned to the asset, as you will need it to request a review in the next step.
 The asset is now in draft mode, which means that other users cannot see it but you can, and you may still edit it.
-To edit the asset, use the `PUT` endpoints for `/ASSET/v1`.
+To edit the asset, use the `PUT` endpoints for `/ASSET`.
 
 ### Requesting a Review
 When you want to publish the asset, you can submit it for review. You
-can do this by making a `POST` request to the `/ASSET/submit/v1/IDENTIFIER` endpoint.
-Here you need to replace `IDENTIFIER` with the identifier of the asset you retrieved
-in the last step.
-You may include a comment to the reviewer of up to 256 characters in the body of the
+can do this by making a `POST` request to the `/submissions` endpoint.
+You are required to include the identifier in the request body,
+and may include a comment to the reviewer of up to 256 characters in the body of the
 `POST` request, this should generally not be necessary but may be useful to provide
 some clarification:
 
 ```json
 {
+  "asset_identifier": "case_n8DhfFgMYv4beBnVurHa13ZS",
   "comment": "Clarification the reviewer should be aware of."
 }
 ```
@@ -92,10 +92,10 @@ in their review.
 
 You can check that status of your pending submission in two ways.
 First, you can request the status for that review specifically using the
-`/submissions/v1/IDENTIFIER` endpoint, where `IDENTIFIER` needs to replaced with the
+`/submissions/IDENTIFIER` endpoint, where `IDENTIFIER` needs to replaced with the
 identifier of the _submission_ (not the asset!).
 For example, if the submission identifier we received was '1', we can query
-`submissions/v1/1` and retrieve its status which would look something like:
+`submissions/1` and retrieve its status which would look something like:
 ```json
 {
   "comment": "Clarification the reviewer should be aware of.",
@@ -103,6 +103,7 @@ For example, if the submission identifier we received was '1', we can query
   "request_date": "2025-03-20T09:09:54",
   "aiod_entry_identifier": 212,
   "asset_type": "case_study",
+  "asset_identifier": "case_n8DhfFgMYv4beBnVurHa13ZS",
   "reviews": [],
   "asset": {
     ...
@@ -113,7 +114,7 @@ No reviews have yet been performed on the submission, as indicated by the empty 
 of reviews (`"reviews": []`).
 
 Alternatively, you can request an overview of all your submissions with a `GET` request
-to the `submissions/v1` endpoint, which will result in a response such as:
+to the `submissions` endpoint, which will result in a response such as:
 ```json
 [
   {
@@ -121,7 +122,8 @@ to the `submissions/v1` endpoint, which will result in a response such as:
     "identifier": 1,
     "request_date": "2025-03-20T09:09:54",
     "aiod_entry_identifier": 212,
-    "asset_type": "case_study"
+    "asset_type": "case_study",
+    "asset_identifier": "case_n8DhfFgMYv4beBnVurHa13ZS",
   }
 ]
 ```
@@ -129,7 +131,7 @@ This endpoint fetches and returns minimal information of the submission, which m
 more lightweight for creating an overview. However, it does not return the status of the
 submissions directly. Instead, you may use query parameters to request only a subset of
 the submissions, such as those that still require a review (i.e., pending submissions)
-by querying `submissions/v1/?mode=pending`.
+by querying `submissions?mode=pending`.
 Please refer to the endpoint documentation for other options.
 
 Users are only ever able to view information about their own submissions.
@@ -141,14 +143,14 @@ is likely revealing).
 #### Retracting a Submission
 Sometimes you may want to retract a submitted asset before a reviewer manages to review it.
 For example, to correct a mistake in the original submission. You can retract an asset from
-review at any time by doing a `POST` request to the `/submissions/retract/v1/SUBMISSION_IDENTIFIER`
+review at any time by doing a `POST` request to the `/submissions/retract/SUBMISSION_IDENTIFIER`
 endpoint.
 
 A retracted submission is treated the same as a rejected submission. The asset is put back
-into draft status and will not be reviewed until the you submit a new review request.
+into draft status and will not be reviewed until you submit a new review request.
 
 ### A Rejected Submission
-You may find that your submission gets rejected. In that case, the `submissions/v1/IDENTIFIER`
+You may find that your submission gets rejected. In that case, the `submissions/IDENTIFIER`
 endpoint will provide you with the reviewer feedback, e.g.:
 ```json
 {
@@ -157,6 +159,7 @@ endpoint will provide you with the reviewer feedback, e.g.:
   "request_date": "2025-03-20T09:09:54",
   "aiod_entry_identifier": 212,
   "asset_type": "case_study",
+  "asset_identifier": "case_n8DhfFgMYv4beBnVurHa13ZS",
   "reviews": [
     {
       "comment": "Several critical fields have incomplete information. Please improve the description, and add a house number to the address.",
@@ -170,7 +173,7 @@ endpoint will provide you with the reviewer feedback, e.g.:
 }
 ```
 You'll find reviewer comments under "reviews".
-You may subsequently edit your asset using `PUT` requests to `/ASSET/v1` to address
+You may subsequently edit your asset using `PUT` requests to `/ASSET` to address
 the reviewer feedback, and then request a new review following the regular submission
 process.
 
@@ -182,17 +185,17 @@ The only restriction is that a reviewer cannot review their own submission.
 
 For reviewers, the main endpoints of interest are:
 
-  * `/submissions/v1` to fetch identifiers of submissions which require a review.
+  * `/submissions` to fetch identifiers of submissions which require a review.
 The `?mode=oldest` parameter can be used to fetch the submission which has been waiting for a review the longest.
-  * `/submissions/v1/{identifier}` to get more detailed information on the submission,
+  * `/submissions/{identifier}` to get more detailed information on the submission,
 in particular this will provide also the asset body to review.
   * `/reviews/v1` the endpoint through which reviews can be made using `POST` requests.
 
 Given a submission identifier (obtained from either `/submissions` endpoint mentioned above),
-the review can post a review to `/reviews/v1`. This requires the user to make a decision
+the review can post a review to `/reviews`. This requires the user to make a decision
 to accept or reject the submission, and optionally leave a comment. When rejecting an
 asset, a comment is strongly encouraged, otherwise the user will not know how to improve
-their submission. An example body of the `POST` request to `/reviews/v1` could look like:
+their submission. An example body of the `POST` request to `/reviews` could look like:
 ```json
 {
   "comment": "Several critical fields have incomplete information. Please improve the description, and add a house number to the address.",

--- a/src/database/review.py
+++ b/src/database/review.py
@@ -154,9 +154,13 @@ class SubmissionView(SubmissionBase):
         # ResourceRead classes are only defined at runtime (generated dynamically).
         @staticmethod
         def schema_extra(schema: dict[str, Any], _: type["SubmissionView"]) -> None:
-            schema["properties"]["asset"] = {
-                "title": "Asset under review",
-                "description": "The type of the object can be found in SubmissionView.asset_type.",
-                "type": "object",
-                "anyOf": get_all_asset_schemas(),
+            schema["properties"]["assets"] = {
+                "type": "array",
+                "title": "Assets under review",
+                "items": {
+                    "title": "Asset",
+                    "description": "The type of the object can be derived from its identifier.",
+                    "type": "object",
+                    "anyOf": get_all_asset_schemas(),
+                },
             }

--- a/src/database/review.py
+++ b/src/database/review.py
@@ -6,7 +6,7 @@ import sqlalchemy
 from sqlalchemy import Column, select
 from sqlmodel import SQLModel, Field, Relationship, Session
 
-from database.model.field_length import NORMAL, LONG
+from database.model.field_length import NORMAL, LONG, IDENTIFIER_LENGTH
 from database.model.concept.concept import AIoDConcept
 from database.model.helper_functions import non_abstract_subclasses
 from routers.helper_functions import get_all_asset_schemas
@@ -53,9 +53,25 @@ class Review(ReviewBase, table=True):  # type: ignore [call-arg]
     submission: "Submission" = Relationship(back_populates="reviews")
 
 
+class SubmissionCreateV2(SQLModel):
+    """User provided information to submit a review request."""
+
+    comment: str = Field(
+        description="Optional. Comment to the reviewer to motivate the submission or provide clarification.",
+        max_length=NORMAL,
+        default="",
+        schema_extra={"example": "'IA' is not a typo, it's for L'intelligence artificielle."},
+    )
+
+
 class SubmissionCreate(SQLModel):
     """User provided information to submit a review request."""
 
+    asset_identifier: str = Field(
+        description="The identifier of the asset to submit for review",
+        max_length=IDENTIFIER_LENGTH,
+        schema_extra={"example": "case_n8DhfFgMYv4beBnVurHa13ZS"},
+    )
     comment: str = Field(
         description="Optional. Comment to the reviewer to motivate the submission or provide clarification.",
         max_length=NORMAL,

--- a/src/database/review.py
+++ b/src/database/review.py
@@ -93,13 +93,17 @@ class SubmissionBase(SQLModel):
     )
 
 
-class AssetReview(SQLModel, table=True):
+class AssetReview(SQLModel, table=True):  # type: ignore[call-arg]
     __tablename__ = "asset_review"
     asset_identifier: str = Field()
     # If the entry corresponding to the thing it reviews is removed,
     # then we also want to permanently remove the review data.
-    aiod_entry_identifier: int = Field(primary_key=True, nullable=False, foreign_key="aiod_entry.identifier", ondelete="CASCADE")
-    review_identifier: int = Field(primary_key=True, nullable=False, foreign_key="submission.identifier", ondelete="CASCADE")
+    aiod_entry_identifier: int = Field(
+        primary_key=True, nullable=False, foreign_key="aiod_entry.identifier", ondelete="CASCADE"
+    )
+    review_identifier: int = Field(
+        primary_key=True, nullable=False, foreign_key="submission.identifier", ondelete="CASCADE"
+    )
 
 
 class Submission(SubmissionBase, table=True):  # type: ignore [call-arg]
@@ -126,8 +130,8 @@ class Submission(SubmissionBase, table=True):  # type: ignore [call-arg]
 
         assets = []
         for identifier in [a.asset_identifier for a in self._assets]:
-            prefix, _ = identifier.split('_')
-            asset_type = get_asset_type_by_abbreviation().get(prefix)
+            prefix, _ = identifier.split("_")
+            asset_type = get_asset_type_by_abbreviation()[prefix]
             schema = schema_by_name[asset_type.__tablename__]
             assets.append(session.get(schema, identifier))
         return assets

--- a/src/database/review.py
+++ b/src/database/review.py
@@ -91,10 +91,6 @@ class SubmissionBase(SQLModel):
         default="",
         schema_extra={"example": "'IA' is not a typo, it's for L'intelligence artificielle."},
     )
-    # This is primarily a convenience for the SubmissionView, can we make it a property there?
-    asset_type: str = Field(
-        description="The name of the table of the resource. E.g. 'dataset' or 'person'"
-    )
 
 
 class AssetReview(SQLModel, table=True):

--- a/src/database/review.py
+++ b/src/database/review.py
@@ -3,13 +3,13 @@ from datetime import datetime, timezone
 from typing import Any
 
 import sqlalchemy
-from sqlalchemy import Column, select
+from sqlalchemy import Column
 from sqlmodel import SQLModel, Field, Relationship, Session
 
-from database.model.field_length import NORMAL, LONG, IDENTIFIER_LENGTH
+from database.model.field_length import NORMAL, LONG
 from database.model.concept.concept import AIoDConcept
 from database.model.helper_functions import non_abstract_subclasses
-from routers.helper_functions import get_all_asset_schemas
+from routers.helper_functions import get_all_asset_schemas, get_asset_type_by_abbreviation
 
 REQUIRED_NUMBER_OF_REVIEWS = 1
 
@@ -67,10 +67,10 @@ class SubmissionCreateV2(SQLModel):
 class SubmissionCreate(SQLModel):
     """User provided information to submit a review request."""
 
-    asset_identifier: str = Field(
-        description="The identifier of the asset to submit for review",
-        max_length=IDENTIFIER_LENGTH,
-        schema_extra={"example": "case_n8DhfFgMYv4beBnVurHa13ZS"},
+    asset_identifiers: list[str] = Field(
+        description="List of identifiers of the assets to submit for review",
+        min_length=1,
+        schema_extra={"example": ["case_n8DhfFgMYv4beBnVurHa13ZS"]},
     )
     comment: str = Field(
         description="Optional. Comment to the reviewer to motivate the submission or provide clarification.",
@@ -80,18 +80,30 @@ class SubmissionCreate(SQLModel):
     )
 
 
-class SubmissionBase(SubmissionCreate):
+class SubmissionBase(SQLModel):
     """A review request, requested by a user to publish an asset/change."""
 
     identifier: int = Field(primary_key=True, default=None)
     request_date: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-
-    # If the entry corresponding to the thing it reviews is removed,
-    # then we also want to permanently remove the review data.
-    aiod_entry_identifier: int = Field(foreign_key="aiod_entry.identifier", ondelete="CASCADE")
+    comment: str = Field(
+        description="Optional. Comment to the reviewer to motivate the submission or provide clarification.",
+        max_length=NORMAL,
+        default="",
+        schema_extra={"example": "'IA' is not a typo, it's for L'intelligence artificielle."},
+    )
+    # This is primarily a convenience for the SubmissionView, can we make it a property there?
     asset_type: str = Field(
         description="The name of the table of the resource. E.g. 'dataset' or 'person'"
     )
+
+
+class AssetReview(SQLModel, table=True):
+    __tablename__ = "asset_review"
+    asset_identifier: str = Field()
+    # If the entry corresponding to the thing it reviews is removed,
+    # then we also want to permanently remove the review data.
+    aiod_entry_identifier: int = Field(primary_key=True, nullable=False, foreign_key="aiod_entry.identifier", ondelete="CASCADE")
+    review_identifier: int = Field(primary_key=True, nullable=False, foreign_key="submission.identifier", ondelete="CASCADE")
 
 
 class Submission(SubmissionBase, table=True):  # type: ignore [call-arg]
@@ -104,9 +116,10 @@ class Submission(SubmissionBase, table=True):  # type: ignore [call-arg]
     )
 
     reviews: list[Review] = Relationship(back_populates="submission")
+    _assets: list[AssetReview] = Relationship()
 
     @property
-    def asset(self) -> AIoDConcept:
+    def assets(self) -> list[AIoDConcept]:
         # I could not find a way to just use a Relationship directly on account of it needing
         # to be defined on creation but the asset_type is only known at runtime.
         # We still mimic the behavior of a lazy-loaded relationship by fetching the session
@@ -114,10 +127,14 @@ class Submission(SubmissionBase, table=True):  # type: ignore [call-arg]
         session = Session.object_session(self)
         available_schemas: list[AIoDConcept] = list(non_abstract_subclasses(AIoDConcept))
         schema_by_name = {schema.__tablename__: schema for schema in available_schemas}
-        schema = schema_by_name[self.asset_type]
 
-        query = select(schema).where(schema.aiod_entry_identifier == self.aiod_entry_identifier)
-        return session.scalars(query).one()
+        assets = []
+        for identifier in [a.asset_identifier for a in self._assets]:
+            prefix, _ = identifier.split('_')
+            asset_type = get_asset_type_by_abbreviation().get(prefix)
+            schema = schema_by_name[asset_type.__tablename__]
+            assets.append(session.get(schema, identifier))
+        return assets
 
     @property
     def is_pending(self):
@@ -130,7 +147,7 @@ class SubmissionView(SubmissionBase):
     # only return AIoDConcept fields to the user, instead of all supplied attributes.
     # E.g., a publication's issn is now returned but would not if it was AIoDConcept.
     # Instead we use the configuration below to set the schema annotations.
-    asset: Any = Field()
+    assets: Any = Field()
 
     class Config:
         # This allows us to set the schema generation at runtime, which is necessary since the

--- a/src/routers/helper_functions.py
+++ b/src/routers/helper_functions.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING
+
 from database.model.concept.concept import AIoDConcept
 from database.model.helper_functions import non_abstract_subclasses
 from functools import cache
 from versioning import Version
+
+if TYPE_CHECKING:
+    from routers import ResourceRouter
 
 
 def get_all_read_classes(version: Version = Version.LATEST) -> dict[str, AIoDConcept]:
@@ -31,3 +36,11 @@ def get_asset_type_by_abbreviation() -> dict[str, type[AIoDConcept]]:
         for cls in non_abstract_subclasses(AIoDConcept)
         if hasattr(cls, "__abbreviation__")
     }
+
+
+@cache
+def get_router_by_type() -> dict[type[AIoDConcept], type["ResourceRouter"]]:
+    from routers.resource_routers import versioned_routers  # avoid cyclical import
+
+    routers = versioned_routers[Version.LATEST]
+    return {r.resource_class: r for r in routers}

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -646,7 +646,6 @@ class ResourceRouter(abc.ABC):
                 review_request = Submission(
                     requestee_identifier=user._subject_identifier,
                     comment=submission.comment if submission else "",
-                    asset_type=self.resource_name,
                 )
                 review_request._assets.append(
                     AssetReview(

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -24,7 +24,7 @@ from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
 from database.model.serializers import deserialize_resource_relationships
-from database.review import Submission, SubmissionCreateV2
+from database.review import Submission, SubmissionCreateV2, AssetReview
 from database.session import DbSession
 from dependencies.filtering import ResourceFilters, ResourceFiltersParams
 from dependencies.pagination import Pagination, PaginationParams
@@ -645,10 +645,14 @@ class ResourceRouter(abc.ABC):
                 resource.aiod_entry.status = EntryStatus.SUBMITTED
                 review_request = Submission(
                     requestee_identifier=user._subject_identifier,
-                    aiod_entry_identifier=resource.aiod_entry.identifier,
                     comment=submission.comment if submission else "",
                     asset_type=self.resource_name,
-                    asset_identifier=identifier,
+                )
+                review_request._assets.append(
+                    AssetReview(
+                        asset_identifier=resource.identifier,
+                        aiod_entry_identifier=resource.aiod_entry.identifier,
+                    )
                 )
                 session.add(review_request)
                 session.commit()

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -24,7 +24,7 @@ from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
 from database.model.serializers import deserialize_resource_relationships
-from database.review import Submission, SubmissionCreate
+from database.review import Submission, SubmissionCreateV2
 from database.session import DbSession
 from dependencies.filtering import ResourceFilters, ResourceFiltersParams
 from dependencies.pagination import Pagination, PaginationParams
@@ -132,14 +132,19 @@ class ResourceRouter(abc.ABC):
             **default_kwargs,
         )
 
-        router.add_api_route(
-            path=f"/{self.resource_name_plural}/submit/{{identifier}}",
-            methods={"POST"},
-            endpoint=self.get_submit_func(),
-            name=self.resource_name,
-            description=f"Submit a {self.resource_name} for review.",
-            **default_kwargs,
-        )
+        if version == Version.V2:
+            router.add_api_route(
+                path=f"/{self.resource_name_plural}/submit/{{identifier}}",
+                methods={"POST"},
+                endpoint=self.get_submit_func(),
+                name=self.resource_name,
+                description=(
+                    "DEPRECATED: Use `POST /submissions` instead. <br>"
+                    f"Submit a {self.resource_name} for review."
+                ),
+                deprecated=True,
+                **default_kwargs,
+            )
 
         router.add_api_route(
             path=f"/{self.resource_name_plural}",
@@ -619,7 +624,7 @@ class ResourceRouter(abc.ABC):
 
         def submit_resource(
             identifier: str,
-            submission: SubmissionCreate | None = None,
+            submission: SubmissionCreateV2 | None = None,
             user: KeycloakUser = Depends(get_user_or_raise),
         ):
             with DbSession() as session:
@@ -643,6 +648,7 @@ class ResourceRouter(abc.ABC):
                     aiod_entry_identifier=resource.aiod_entry.identifier,
                     comment=submission.comment if submission else "",
                     asset_type=self.resource_name,
+                    asset_identifier=identifier,
                 )
                 session.add(review_request)
                 session.commit()

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -17,6 +17,7 @@ from database.review import (
     ReviewCreate,
     Decision,
     SubmissionCreate,
+    AssetReview,
 )
 from database.model.concept.aiod_entry import EntryStatus, AIoDEntryORM
 from routers.helper_functions import get_asset_type_by_abbreviation, get_router_by_type
@@ -139,7 +140,12 @@ def _submit_resource(
     submission: SubmissionCreate,
     user: KeycloakUser = Depends(get_user_or_raise),
 ):
-    identifier = submission.asset_identifier
+    if len(submission.asset_identifiers) > 1:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_IMPLEMENTED,
+            detail="Bundling review requests is not implemented yet.",
+        )
+    identifier = submission.asset_identifiers[0]
     resource_type = get_asset_type_by_abbreviation().get(identifier.split("_")[0])
     if not resource_type:
         raise HTTPException(
@@ -171,10 +177,11 @@ def _submit_resource(
         resource.aiod_entry.status = EntryStatus.SUBMITTED
         review_request = Submission(
             requestee_identifier=user._subject_identifier,
-            aiod_entry_identifier=resource.aiod_entry.identifier,
             comment=submission.comment,
             asset_type=router.resource_name,
-            asset_identifier=submission.asset_identifier,
+        )
+        review_request._assets.append(
+            AssetReview(asset_identifier=resource.identifier, aiod_entry_identifier=resource.aiod_entry.identifier)
         )
         session.add(review_request)
         session.commit()

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -140,49 +140,46 @@ def _submit_resource(
     submission: SubmissionCreate,
     user: KeycloakUser = Depends(get_user_or_raise),
 ):
-    if len(submission.asset_identifiers) > 1:
-        raise HTTPException(
-            status_code=HTTPStatus.NOT_IMPLEMENTED,
-            detail="Bundling review requests is not implemented yet.",
-        )
-    identifier = submission.asset_identifiers[0]
-    resource_type = get_asset_type_by_abbreviation().get(identifier.split("_")[0])
-    if not resource_type:
-        raise HTTPException(
-            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-            detail=f"{identifier} is not a valid resource identifier.",
-        )
-    router = get_router_by_type().get(resource_type)
-    if not router:
-        raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            detail=f"Router for {resource_type!r} not found, please contact the developers.",
-        )
+    id_to_type = {
+        identifier: get_asset_type_by_abbreviation().get(identifier.split("_")[0])
+        for identifier in submission.asset_identifiers
+    }
+    # if not resource_type:
+    #     raise HTTPException(
+    #         status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+    #         detail=f"{identifier} is not a valid resource identifier.",
+    #     )
+    # if len(submission.asset_identifiers) > 1:
+    #     raise HTTPException(
+    #         status_code=HTTPStatus.NOT_IMPLEMENTED,
+    #         detail="Bundling review requests is not implemented yet.",
+    #     )
 
     with DbSession() as session:
-        resource = router._retrieve_resource(identifier=identifier, session=session)  # type: ignore
-
-        if not resource.aiod_entry.status == EntryStatus.DRAFT:
-            msg = (
-                f"Cannot submit {router.resource_name} {identifier} "
-                f"since it has '{resource.aiod_entry.status}' status."
-            )
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=msg)
-
-        if not user_can_administer(user, resource.aiod_entry):
-            # Could choose to instead give same error as if resource does not exist.
-            msg = f"You do not have permission to submit {router.resource_name} {identifier}."
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=msg)
-
-        resource.aiod_entry.status = EntryStatus.SUBMITTED
         review_request = Submission(
             requestee_identifier=user._subject_identifier,
             comment=submission.comment,
-            asset_type=router.resource_name,
         )
-        review_request._assets.append(
-            AssetReview(asset_identifier=resource.identifier, aiod_entry_identifier=resource.aiod_entry.identifier)
-        )
+        for identifier, asset_type in id_to_type.items():
+            router = get_router_by_type()[asset_type]
+            resource = router._retrieve_resource(identifier=identifier, session=session)  # type: ignore
+
+            if not resource.aiod_entry.status == EntryStatus.DRAFT:
+                msg = (
+                    f"Cannot submit {router.resource_name} {identifier} "
+                    f"since it has '{resource.aiod_entry.status}' status."
+                )
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=msg)
+
+            if not user_can_administer(user, resource.aiod_entry):
+                # Could choose to instead give same error as if resource does not exist.
+                msg = f"You do not have permission to submit {router.resource_name} {identifier}."
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=msg)
+
+            resource.aiod_entry.status = EntryStatus.SUBMITTED
+            review_request._assets.append(
+                AssetReview(asset_identifier=resource.identifier, aiod_entry_identifier=resource.aiod_entry.identifier)
+            )
         session.add(review_request)
         session.commit()
         return {"submission_identifier": review_request.identifier}

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -20,6 +20,7 @@ from database.review import (
     AssetReview,
 )
 from database.model.concept.aiod_entry import EntryStatus, AIoDEntryORM
+from model.concept.concept import AIoDConcept
 from routers.helper_functions import get_asset_type_by_abbreviation, get_router_by_type
 from versioning import Version
 
@@ -145,8 +146,7 @@ def _submit_resource(
         for identifier in submission.asset_identifiers
     }
     invalid_identifier = next(
-        (identifier for identifier, type_ in id_to_type.items() if type_ is None),
-        None
+        (identifier for identifier, type_ in id_to_type.items() if type_ is None), None
     )
     if invalid_identifier:
         raise HTTPException(
@@ -160,7 +160,7 @@ def _submit_resource(
             comment=submission.comment,
         )
         for identifier, asset_type in id_to_type.items():
-            router = get_router_by_type()[asset_type]
+            router = get_router_by_type()[cast(type[AIoDConcept], asset_type)]
             resource = router._retrieve_resource(identifier=identifier, session=session)  # type: ignore
 
             if not resource.aiod_entry.status == EntryStatus.DRAFT:
@@ -177,7 +177,10 @@ def _submit_resource(
 
             resource.aiod_entry.status = EntryStatus.SUBMITTED
             review_request._assets.append(
-                AssetReview(asset_identifier=resource.identifier, aiod_entry_identifier=resource.aiod_entry.identifier)
+                AssetReview(
+                    asset_identifier=resource.identifier,
+                    aiod_entry_identifier=resource.aiod_entry.identifier,
+                )
             )
         session.add(review_request)
         session.commit()
@@ -209,14 +212,16 @@ def _review_resource(
     register_user(user, session)
 
     for asset_to_review in submission._assets:
-        aiod_entry = cast(AIoDEntryORM, session.get(AIoDEntryORM, asset_to_review.aiod_entry_identifier))
+        aiod_entry = cast(
+            AIoDEntryORM, session.get(AIoDEntryORM, asset_to_review.aiod_entry_identifier)
+        )
         if user_can_write(user, aiod_entry):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=(
                     f"Review request contains asset {asset_to_review.asset_identifier!r}, "
                     "which you own. You do not have permission to review your own assets.",
-                )
+                ),
             )
 
         if review.decision == Decision.ACCEPTED:
@@ -245,7 +250,7 @@ def retract_submission(
         if submission is None:
             return HTTPException(
                 status_code=HTTPStatus.NOT_FOUND,
-                detail=f"Submission {submission_identifier} not found."
+                detail=f"Submission {submission_identifier} not found.",
             )
 
         if not submission.is_pending:

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -144,16 +144,15 @@ def _submit_resource(
         identifier: get_asset_type_by_abbreviation().get(identifier.split("_")[0])
         for identifier in submission.asset_identifiers
     }
-    # if not resource_type:
-    #     raise HTTPException(
-    #         status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-    #         detail=f"{identifier} is not a valid resource identifier.",
-    #     )
-    # if len(submission.asset_identifiers) > 1:
-    #     raise HTTPException(
-    #         status_code=HTTPStatus.NOT_IMPLEMENTED,
-    #         detail="Bundling review requests is not implemented yet.",
-    #     )
+    invalid_identifier = next(
+        (identifier for identifier, type_ in id_to_type.items() if type_ is None),
+        None
+    )
+    if invalid_identifier:
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail=f"{invalid_identifier} is not a valid resource identifier.",
+        )
 
     with DbSession() as session:
         review_request = Submission(
@@ -209,18 +208,22 @@ def _review_resource(
         )
     register_user(user, session)
 
-    aiod_entry = cast(AIoDEntryORM, session.get(AIoDEntryORM, submission.aiod_entry_identifier))
-    if user_can_write(user, aiod_entry):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You do not have permission to review your own assets.",
-        )
+    for asset_to_review in submission._assets:
+        aiod_entry = cast(AIoDEntryORM, session.get(AIoDEntryORM, asset_to_review.aiod_entry_identifier))
+        if user_can_write(user, aiod_entry):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=(
+                    f"Review request contains asset {asset_to_review.asset_identifier!r}, "
+                    "which you own. You do not have permission to review your own assets.",
+                )
+            )
 
-    if review.decision == Decision.ACCEPTED:
-        new_status = EntryStatus.PUBLISHED
-    else:
-        new_status = EntryStatus.DRAFT
-    aiod_entry.status = new_status
+        if review.decision == Decision.ACCEPTED:
+            new_status = EntryStatus.PUBLISHED
+        else:
+            new_status = EntryStatus.DRAFT
+        aiod_entry.status = new_status
 
     review = Review(
         reviewer_identifier=user._subject_identifier,
@@ -239,16 +242,21 @@ def retract_submission(
 ):
     with DbSession() as session:
         submission = session.get(Submission, submission_identifier)
-        if not user_can_administer(user, submission.asset.aiod_entry):
-            # Could choose to instead give same error as if resource does not exist.
-            msg = f"You do not have permission to retract {submission.asset_type} {submission.asset.identifier}."
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=msg)
+        if submission is None:
+            return HTTPException(
+                status_code=HTTPStatus.NOT_FOUND,
+                detail=f"Submission {submission_identifier} not found."
+            )
 
-        if submission is None or not submission.is_pending:
+        if not submission.is_pending:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Cannot retract this asset, as it is not under review.",
+                detail="Cannot retract this submission, as it is not under review.",
             )
+
+        if not any(user_can_administer(user, a.aiod_entry_identifier) for a in submission._assets):
+            msg = f"You must be administrator of at least one asset in the review to retract the submission."
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=msg)
 
         retraction = Review(
             decision=Decision.RETRACTED,

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -20,7 +20,7 @@ from database.review import (
     AssetReview,
 )
 from database.model.concept.aiod_entry import EntryStatus, AIoDEntryORM
-from model.concept.concept import AIoDConcept
+from database.model.concept.concept import AIoDConcept
 from routers.helper_functions import get_asset_type_by_abbreviation, get_router_by_type
 from versioning import Version
 
@@ -220,7 +220,7 @@ def _review_resource(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=(
                     f"Review request contains asset {asset_to_review.asset_identifier!r}, "
-                    "which you own. You do not have permission to review your own assets.",
+                    "which you own. You do not have permission to review your own assets."
                 ),
             )
 
@@ -259,7 +259,10 @@ def retract_submission(
                 detail="Cannot retract this submission, as it is not under review.",
             )
 
-        if not any(user_can_administer(user, a.aiod_entry_identifier) for a in submission._assets):
+        if not any(
+            user_can_administer(user, session.get(AIoDEntryORM, a.aiod_entry_identifier))
+            for a in submission._assets
+        ):
             msg = f"You must be administrator of at least one asset in the review to retract the submission."
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=msg)
 
@@ -268,7 +271,8 @@ def retract_submission(
             reviewer_identifier=user._subject_identifier,
             submission_identifier=submission.identifier,
         )
-        submission.asset.aiod_entry.status = EntryStatus.DRAFT
+        for asset in submission.assets:
+            asset.aiod_entry.status = EntryStatus.DRAFT
         session.add(retraction)
         session.commit()
         return {

--- a/src/routers/review_router.py
+++ b/src/routers/review_router.py
@@ -16,8 +16,10 @@ from database.review import (
     SubmissionBase,
     ReviewCreate,
     Decision,
+    SubmissionCreate,
 )
 from database.model.concept.aiod_entry import EntryStatus, AIoDEntryORM
+from routers.helper_functions import get_asset_type_by_abbreviation, get_router_by_type
 from versioning import Version
 
 
@@ -50,6 +52,13 @@ def create(url_prefix: str, version: Version) -> APIRouter:
         description="Review an asset.",
         response_model=Review,
     )(_review_resource)
+
+    router.post(
+        path=f"/submissions",
+        tags=["Reviewing"],
+        description=f"Submit an asset for review.",
+    )(_submit_resource)
+
     return router
 
 
@@ -124,6 +133,52 @@ def get_submission(
             detail=f"You do not have permission to view submission with identifier {identifier}.",
         )
     return submission
+
+
+def _submit_resource(
+    submission: SubmissionCreate,
+    user: KeycloakUser = Depends(get_user_or_raise),
+):
+    identifier = submission.asset_identifier
+    resource_type = get_asset_type_by_abbreviation().get(identifier.split("_")[0])
+    if not resource_type:
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail=f"{identifier} is not a valid resource identifier.",
+        )
+    router = get_router_by_type().get(resource_type)
+    if not router:
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail=f"Router for {resource_type!r} not found, please contact the developers.",
+        )
+
+    with DbSession() as session:
+        resource = router._retrieve_resource(identifier=identifier, session=session)  # type: ignore
+
+        if not resource.aiod_entry.status == EntryStatus.DRAFT:
+            msg = (
+                f"Cannot submit {router.resource_name} {identifier} "
+                f"since it has '{resource.aiod_entry.status}' status."
+            )
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=msg)
+
+        if not user_can_administer(user, resource.aiod_entry):
+            # Could choose to instead give same error as if resource does not exist.
+            msg = f"You do not have permission to submit {router.resource_name} {identifier}."
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=msg)
+
+        resource.aiod_entry.status = EntryStatus.SUBMITTED
+        review_request = Submission(
+            requestee_identifier=user._subject_identifier,
+            aiod_entry_identifier=resource.aiod_entry.identifier,
+            comment=submission.comment,
+            asset_type=router.resource_name,
+            asset_identifier=submission.asset_identifier,
+        )
+        session.add(review_request)
+        session.commit()
+        return {"submission_identifier": review_request.identifier}
 
 
 def _review_resource(

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -17,6 +17,7 @@ from database.model.knowledge_asset.publication import Publication
 from routers.review_router import ListMode
 from tests.testutils.users import ALICE, BOB, REVIEWER, _register_user_in_db, \
     logged_in_user, register_asset
+from versioning import Version
 
 
 def test_user_must_be_logged_in_to_publish(client, publication):
@@ -63,10 +64,11 @@ def test_drafts_are_private(
     # with and without authentication
 
 
+@pytest.mark.versions(Version.V2)
 @pytest.mark.parametrize(
     "comment", [None, "foo"]
 )
-def test_user_can_submit_draft_for_review(comment, client, publication):
+def test_user_can_submit_draft_for_review_v2(comment, client, publication):
     identifier = register_asset(publication, owner=ALICE, status=EntryStatus.DRAFT)
     content = f'{{"comment": "{comment}"}}' if comment else None
 
@@ -88,13 +90,41 @@ def test_user_can_submit_draft_for_review(comment, client, publication):
         assert sub["comment"] == (comment if comment else ""), "Comment should be stored."
 
 
+@pytest.mark.parametrize(
+    "comment", [None, "foo"]
+)
+def test_user_can_submit_draft_for_review(comment, client, publication):
+    identifier = register_asset(publication, owner=ALICE, status=EntryStatus.DRAFT)
+    content = {"asset_identifier": identifier}
+    if comment:
+        content["comment"] = comment
+
+    with logged_in_user(ALICE):
+        submission = client.post(
+            f"/submissions",
+            headers={"Authorization": "Fake token"},
+            json=content,
+        )
+        assert submission.status_code == HTTPStatus.OK, submission.json()
+        assert "submission_identifier" in submission.json()
+
+    with logged_in_user(REVIEWER):
+        queue = client.get("/submissions", headers={"Authorization": "Fake token"})
+        assert queue.status_code == HTTPStatus.OK, queue.json()
+        assert len(queue.json()) == 1, "A successful request should result in a submission."
+        [sub] = queue.json()
+        assert "requestee_identifier" not in sub, "Submissions should not review who submitted."
+        assert sub["comment"] == (comment if comment else ""), "Comment should be stored."
+
+
 def test_user_can_not_submit_other_for_review(client, publication):
     identifier = register_asset(publication, owner=ALICE, status=EntryStatus.DRAFT)
 
     with logged_in_user(BOB):
         submission = client.post(
-            f"/publications/submit/{identifier}",
+            f"/submissions",
             headers={"Authorization": "Fake token"},
+            json={"asset_identifier": identifier},
         )
         assert submission.status_code == HTTPStatus.FORBIDDEN, submission.json()
 
@@ -122,7 +152,7 @@ def test_a_submitted_asset_is_pending_for_review(client, publication):
         assert len(queue.json()) == 1, "A submitted asset should be pending until a review is done."
 
 def test_get_submission_by_id(client, publication):
-    register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
+    identifier = register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
 
     with logged_in_user(REVIEWER):
         submission = client.get("/submissions/1", headers={"Authorization": "Fake token"})
@@ -139,6 +169,7 @@ def test_get_submission_by_id(client, publication):
             "aiod_entry_identifier": 1,
             "comment": "",
             "asset_type": "publication",
+            "asset_identifier": identifier,
         }
         assert reviews == [
             {

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -124,7 +124,7 @@ def test_user_can_not_submit_other_for_review(client, publication):
         submission = client.post(
             f"/submissions",
             headers={"Authorization": "Fake token"},
-            json={"asset_identifier": identifier},
+            json={"asset_identifiers": [identifier]},
         )
         assert submission.status_code == HTTPStatus.FORBIDDEN, submission.json()
 
@@ -163,13 +163,10 @@ def test_get_submission_by_id(client, publication):
         review_date = submission_dict["reviews"][0].pop("decision_date")
         assert submission_date < review_date
         reviews = submission_dict.pop("reviews")
-        asset = submission_dict.pop("asset")
+        assets = submission_dict.pop("assets")
         assert submission_dict == {
             "identifier": 1,
-            "aiod_entry_identifier": 1,
             "comment": "",
-            "asset_type": "publication",
-            "asset_identifier": identifier,
         }
         assert reviews == [
             {
@@ -181,7 +178,8 @@ def test_get_submission_by_id(client, publication):
         ]
         # Convert to loaded JSON, including e.g., stringification of dates
         publication_json = json.loads(publication.json())
-        assert asset == publication_json
+        assert assets == [publication_json]
+
 
 def test_get_submission_by_id_must_be_reviewer_or_owner(client, publication):
     register_asset(publication, owner=ALICE, status=EntryStatus.SUBMITTED)
@@ -230,6 +228,7 @@ def test_submission_by_state_respects_privacy(user: KeycloakUser, mode: ListMode
         returned_submissions = [submission["identifier"] for submission in queue.json()]
         assert returned_submissions == assets, f"{reason} Response: {queue.json()}"
 
+
 def test_an_published_asset_is_not_pending_for_review(client, publication):
     register_asset(publication, owner=ALICE, status=EntryStatus.PUBLISHED)
 
@@ -272,7 +271,7 @@ def test_retrieving_single_submission_works(user: KeycloakUser, mode: ListMode, 
     with logged_in_user(user):
         queue = client.get(f"/submissions?mode={mode}", headers={"Authorization": "Fake token"})
         assert queue.status_code == HTTPStatus.OK, queue.json()
-        assert queue.json()[0]["aiod_entry_identifier"] == asset, reason
+        assert queue.json()[0]["identifier"] == asset, reason
 
 
 def test_user_can_retract_assets(client, publication):
@@ -312,6 +311,7 @@ def test_user_can_always_delete_asset(status: EntryStatus, publication, client):
             headers={"Authorization": "Fake token"},
         )
         assert response.status_code == HTTPStatus.OK, response.json()
+
 
 def test_user_can_edit_asset_in_draft(publication, client):
     identifier = register_asset(publication, owner=ALICE, status=EntryStatus.DRAFT)

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -10,7 +10,7 @@ from authentication import KeycloakUser
 from database.authorization import (
     PermissionType, user_can_read, user_can_write, user_can_administer, set_permission,
 )
-from database.model.concept.aiod_entry import EntryStatus, AIoDEntryORM
+from database.model.concept.aiod_entry import EntryStatus
 from database.review import Decision, ReviewCreate
 from database.session import DbSession
 from database.model.knowledge_asset.publication import Publication
@@ -115,6 +115,37 @@ def test_user_can_submit_draft_for_review(comment, client, publication):
         [sub] = queue.json()
         assert "requestee_identifier" not in sub, "Submissions should not review who submitted."
         assert sub["comment"] == (comment if comment else ""), "Comment should be stored."
+
+
+def test_user_needs_to_own_all_assets_for_submission(client, publication_factory):
+    own = register_asset(publication_factory(), owner=ALICE, status=EntryStatus.DRAFT)
+    bobs_publication = publication_factory()
+    other = register_asset(bobs_publication, owner=BOB, status=EntryStatus.DRAFT)
+    content: dict[str, str | list[str]] = {"asset_identifiers": [own, other]}
+
+    with logged_in_user(ALICE):
+        submission = client.post(
+            f"/submissions",
+            headers={"Authorization": "Fake token"},
+            json=content,
+        )
+        reason = "Request should be rejected because Alice does not own `other`."
+        assert submission.status_code == HTTPStatus.FORBIDDEN, reason
+        assert "You do not have permission" in submission.json()["detail"]
+
+    with DbSession() as session:
+        session.add(bobs_publication)
+        set_permission(user=ALICE, resource=bobs_publication.aiod_entry, session=session, type_=PermissionType.ADMIN)
+        session.commit()
+
+    with logged_in_user(ALICE):
+        submission = client.post(
+            f"/submissions",
+            headers={"Authorization": "Fake token"},
+            json=content,
+        )
+        reason = "Request should be accepted because Alice does now co-owns `other`."
+        assert submission.status_code == HTTPStatus.OK, reason
 
 
 def test_user_can_not_submit_other_for_review(client, publication):
@@ -299,6 +330,35 @@ def test_other_user_can_not_retract_assets(client, publication):
             f"/submissions/retract/1", headers={"Authorization": "Fake token"}
         )
         assert response.status_code == HTTPStatus.FORBIDDEN, response.json()
+
+
+def test_user_needs_only_one_asset_to_retract(client, publication_factory):
+    own = register_asset(publication_factory(), owner=ALICE, status=EntryStatus.DRAFT)
+    bobs_publication = publication_factory()
+    other = register_asset(bobs_publication, owner=BOB, status=EntryStatus.DRAFT)
+    with DbSession() as session:
+        session.add(bobs_publication)
+        set_permission(user=ALICE, resource=bobs_publication.aiod_entry, session=session, type_=PermissionType.ADMIN)
+        session.commit()
+
+    content: dict[str, str | list[str]] = {"asset_identifiers": [own, other]}
+    with logged_in_user(ALICE):
+        submission = client.post(
+            f"/submissions",
+            headers={"Authorization": "Fake token"},
+            json=content,
+        )
+        assert submission.status_code == HTTPStatus.OK
+    submission_identifier = submission.json()["submission_identifier"]
+
+    with logged_in_user(BOB):
+        submission = client.post(
+            f"/submissions/retract/{submission_identifier}",
+            headers={"Authorization": "Fake token"},
+            json=content,
+        )
+        reason = "Since Bob owns one of the two assets, he can retract the submission."
+        assert submission.status_code == HTTPStatus.OK, reason
 
 
 @pytest.mark.parametrize("status", EntryStatus)

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -95,7 +95,7 @@ def test_user_can_submit_draft_for_review_v2(comment, client, publication):
 )
 def test_user_can_submit_draft_for_review(comment, client, publication):
     identifier = register_asset(publication, owner=ALICE, status=EntryStatus.DRAFT)
-    content = {"asset_identifier": identifier}
+    content: dict[str, str | list[str]] = {"asset_identifiers": [identifier]}
     if comment:
         content["comment"] = comment
 

--- a/src/tests/testutils/users.py
+++ b/src/tests/testutils/users.py
@@ -85,7 +85,7 @@ def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser | None = None, 
                 requestee_identifier=owner._subject_identifier,
                 aiod_entry_identifier=asset.aiod_entry.identifier,
                 asset_type=asset.__tablename__,
-                asset_identifier=asset.identifier,
+                asset_identifiers=[asset.identifier],
             )
             session.add(submission)
             if status == EntryStatus.PUBLISHED:

--- a/src/tests/testutils/users.py
+++ b/src/tests/testutils/users.py
@@ -11,6 +11,7 @@ from database.model.concept.aiod_entry import EntryStatus, AIoDEntryORM
 from database.model.concept.concept import AIoDConcept
 from database.review import Submission, Review, Decision
 from database.session import DbSession
+from database.review import AssetReview
 
 ALICE = KeycloakUser("Alice", set(), "alice-sub")
 BOB = KeycloakUser("Bob", set(), "bob-sub")
@@ -81,11 +82,9 @@ def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser | None = None, 
 
         asset.aiod_entry.status = status
         if status in [EntryStatus.SUBMITTED, EntryStatus.PUBLISHED, EntryStatus.REJECTED]:
-            submission = Submission(
-                requestee_identifier=owner._subject_identifier,
-                aiod_entry_identifier=asset.aiod_entry.identifier,
-                asset_type=asset.__tablename__,
-                asset_identifiers=[asset.identifier],
+            submission = Submission(requestee_identifier=owner._subject_identifier)
+            submission._assets.append(
+                AssetReview(asset_identifier=asset.identifier, aiod_entry_identifier=asset.aiod_entry.identifier)
             )
             session.add(submission)
             if status == EntryStatus.PUBLISHED:

--- a/src/tests/testutils/users.py
+++ b/src/tests/testutils/users.py
@@ -85,6 +85,7 @@ def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser | None = None, 
                 requestee_identifier=owner._subject_identifier,
                 aiod_entry_identifier=asset.aiod_entry.identifier,
                 asset_type=asset.__tablename__,
+                asset_identifier=asset.identifier,
             )
             session.add(submission)
             if status == EntryStatus.PUBLISHED:


### PR DESCRIPTION
<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Added, Deprecated <!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Interface<!-- Documentation/Interface/Internal/Other -->

Changelog Entry: <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->
Introduce one endpoint for all review requests: `/submissions`

The old style to request a review by the `/ASSET_TYPE/submit/{identifier}` endpoint is now deprecated and will be removed in version 3. Instead use the `/submissions` endpoint and include the asset's identifier in the body like so:
```json
{
  "asset_identifiers": ["case_n8DhfFgMYv4beBnVurHa13ZS"],
  "comment": "Clarification the reviewer should be aware of."
}
```
You may now include more than one asset per review request, which can be useful to e.g., review Publication and Experiment together.
You must have administrator right to all assets in the review request.
If you have administrator right to at least one asset of a review request, you may retract the review.

## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Covered by tests.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Closes #548 