### PR TITLE
add network involvement, activity level, involvement level to support TNO data migration

### DIFF
--- a/src/database/model/agent/involvement_level.py
+++ b/src/database/model/agent/involvement_level.py
@@ -1,0 +1,54 @@
+# database/model/agent/involvement_level.py
+
+from typing import Optional, TYPE_CHECKING
+from sqlmodel import SQLModel, Field, Relationship
+from database.model.concept.concept import AIoDConceptBase, AIoDConcept
+from database.model.agent.expertise import Expertise
+from database.model.relationships import ManyToOne
+from database.model.serializers import AttributeSerializer
+
+if TYPE_CHECKING:
+    from database.model.agent.organisation import Organisation
+
+
+class InvolvementLevel(SQLModel, table=True):  # type: ignore[call-arg]
+
+    __tablename__ = "involvement_level"
+
+    identifier: Optional[int] = Field(default=None, primary_key=True)
+
+    involvement_level: Optional[str] = Field(
+        default=None,
+        description="Involvement level (e.g., high, medium, low)."
+    )
+
+    organisation_identifier: str | None = Field(
+        default=None,
+        foreign_key="organisation.identifier",
+        description="Identifier of the organisation that has this involvement."
+    )
+
+    involvement_area_identifier: int | None = Field(
+        default=None,
+        foreign_key="expertise.identifier",
+        description="Expertise area involved in this level."
+    )
+    
+
+    organisation: Optional["Organisation"] = Relationship(
+        back_populates="involved_in_area"
+    )
+    involvement_area: Optional["Expertise"] = Relationship()
+
+
+    class RelationshipConfig:
+        organisation: Optional[str] = ManyToOne(
+            description="The organisation that has this membership.",
+            identifier_name="organisation_identifier",
+            _serializer=AttributeSerializer("identifier"),
+        )
+        involvement_area: Optional[int] = ManyToOne(
+            description="The expertise area involved in this level.",
+            identifier_name="involvement_area_identifier",
+            _serializer=AttributeSerializer("identifier"),
+        )

--- a/src/database/model/agent/involvement_level.py
+++ b/src/database/model/agent/involvement_level.py
@@ -5,41 +5,41 @@ from sqlmodel import SQLModel, Field, Relationship
 from database.model.concept.concept import AIoDConceptBase, AIoDConcept
 from database.model.agent.expertise import Expertise
 from database.model.relationships import ManyToOne
-from database.model.serializers import AttributeSerializer
+from database.model.serializers import (
+    AttributeSerializer,
+    FindByNameDeserializer,
+    FindByIdentifierDeserializer,
+)
+from sqlalchemy import Column, Integer, ForeignKey, String
+from database.model.field_length import NORMAL, SHORT, IDENTIFIER_LENGTH
 
 if TYPE_CHECKING:
     from database.model.agent.organisation import Organisation
 
 
 class InvolvementLevel(SQLModel, table=True):  # type: ignore[call-arg]
-
     __tablename__ = "involvement_level"
 
     identifier: Optional[int] = Field(default=None, primary_key=True)
 
     involvement_level: Optional[str] = Field(
-        default=None,
-        description="Involvement level (e.g., high, medium, low)."
+        default=None, description="Involvement level (e.g., high, medium, low)."
     )
 
     organisation_identifier: str | None = Field(
         default=None,
         foreign_key="organisation.identifier",
-        description="Identifier of the organisation that has this involvement."
+        description="Identifier of the organisation that has this involvement.",
     )
 
     involvement_area_identifier: int | None = Field(
         default=None,
         foreign_key="expertise.identifier",
-        description="Expertise area involved in this level."
+        description="Expertise area involved in this level.",
     )
-    
 
-    organisation: Optional["Organisation"] = Relationship(
-        back_populates="involved_in_area"
-    )
+    organisation: Optional["Organisation"] = Relationship(back_populates="involved_in_area")
     involvement_area: Optional["Expertise"] = Relationship()
-
 
     class RelationshipConfig:
         organisation: Optional[str] = ManyToOne(
@@ -47,8 +47,59 @@ class InvolvementLevel(SQLModel, table=True):  # type: ignore[call-arg]
             identifier_name="organisation_identifier",
             _serializer=AttributeSerializer("identifier"),
         )
-        involvement_area: Optional[int] = ManyToOne(
+        involvement_area: Optional[str] = ManyToOne(
             description="The expertise area involved in this level.",
             identifier_name="involvement_area_identifier",
-            _serializer=AttributeSerializer("identifier"),
+            _serializer=AttributeSerializer("name"),
+            deserializer=FindByNameDeserializer(Expertise),
         )
+
+
+# Ignored code below (attempt to separate base and ORM models for better serilization):
+# class InvolvementLevelBase(SQLModel):
+#     involvement_level: Optional[str] = Field(
+#         default=None,
+#         description="Involvement level (e.g., high, medium, low)."
+#     )
+
+
+# class InvolvementLevelORM(InvolvementLevelBase, table=True):  # type: ignore[call-arg]
+#     __tablename__ = "involvement_level"
+
+#     identifier: Optional[int] = Field(default=None, primary_key=True)
+
+#     organisation_identifier: str | None = Field(
+#         sa_column=Column(
+#             String(IDENTIFIER_LENGTH),
+#             ForeignKey("organisation.identifier", ondelete="CASCADE"),
+#         )
+#     )
+#     organisation: Optional["Organisation"] = Relationship(
+#         back_populates="involved_in_area"
+#     )
+
+#     involvement_area_identifier: int | None = Field(
+#         sa_column=Column(Integer, ForeignKey("expertise.identifier", ondelete="CASCADE"))
+#     )
+#     involvement_area: Optional["Expertise"] = Relationship()
+
+#     class RelationshipConfig:
+#         organisation: Optional["Organisation"] = ManyToOne(
+#             description="The organisation that has this membership.",
+#             identifier_name="organisation_identifier",
+#             _serializer=AttributeSerializer("identifier"),
+#             deserializer=FindByIdentifierDeserializer("organisation"),
+#         )
+#         involvement_area: Optional["Expertise"] = ManyToOne(
+#             description="The expertise area involved in this level.",
+#             identifier_name="involvement_area_identifier",
+#             _serializer=AttributeSerializer("name"),
+#             deserializer=FindByNameDeserializer("expertise"),
+#         )
+
+
+# class InvolvementLevel(InvolvementLevelBase):
+#     """A representation of an organisation’s involvement in an area with a given level."""
+
+#     organisation: Optional["Organisation"] = Field(default=None)
+#     involvement_area: Optional["Expertise"] = Field(default=None)

--- a/src/database/model/agent/network_membership.py
+++ b/src/database/model/agent/network_membership.py
@@ -1,0 +1,52 @@
+from typing import Optional, List,TYPE_CHECKING
+from sqlmodel import SQLModel, Field, Relationship
+from database.model.concept.concept import AIoDConceptBase, AIoDConcept
+from database.model.agent.organisational_network import OrganisationalNetwork 
+from database.model.relationships import ManyToOne
+from database.model.serializers import (
+    AttributeSerializer
+)
+if TYPE_CHECKING:
+    from database.model.agent.organisation import Organisation
+
+
+class NetworkMembership(SQLModel, table=True):  # type: ignore[call-arg]
+    """
+    NetworkMembership links an Organisation to an OrganisationalNetwork and carries
+    the `with_network_role` property.
+    """
+    
+    __tablename__ = "network_membership"
+
+    identifier: Optional[int] = Field(default=None, primary_key=True)
+    
+    with_network_role: Optional[str] = Field(
+        default=None, description="Role of the organisation within the network (e.g. 'Founding Member')"
+    )
+    organisation_identifier: str | None = Field(
+        default=None,
+        foreign_key="organisation.identifier",
+        description="Identifier of the organisation that has this membership.",
+    )
+    in_network_identifier: str | None = Field(
+        default=None,
+        foreign_key="organisational_network.identifier",
+        description="Identifier of the organisational network.",
+    )
+    
+    organisation: Optional["Organisation"] = Relationship(back_populates="has_membership_in")
+    in_network: Optional["OrganisationalNetwork"] = Relationship()
+    
+    class RelationshipConfig():
+        organisation: Optional[str] = ManyToOne(
+            description="The organisation that has this membership.",
+            identifier_name="organisation_identifier",
+            _serializer=AttributeSerializer("identifier"),
+        )
+        in_network: Optional[str] = ManyToOne(
+            description="The organisational network this membership belongs to.",
+            identifier_name="in_network_identifier",
+            _serializer=AttributeSerializer("identifier"),
+        )
+
+

--- a/src/database/model/agent/network_membership.py
+++ b/src/database/model/agent/network_membership.py
@@ -1,9 +1,11 @@
-from typing import Optional, List, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 from sqlmodel import SQLModel, Field, Relationship
-from database.model.concept.concept import AIoDConceptBase, AIoDConcept
 from database.model.agent.organisational_network import OrganisationalNetwork
 from database.model.relationships import ManyToOne
-from database.model.serializers import AttributeSerializer, FindByNameDeserializer
+from database.model.serializers import (
+    AttributeSerializer,
+    StrictFindByNameFieldDeserializer,
+)
 
 if TYPE_CHECKING:
     from database.model.agent.organisation import Organisation
@@ -47,5 +49,5 @@ class NetworkMembership(SQLModel, table=True):  # type: ignore[call-arg]
             description="The organisational network this membership belongs to.",
             identifier_name="in_network_identifier",
             _serializer=AttributeSerializer("identifier"),
-            deserializer=FindByNameDeserializer(OrganisationalNetwork),
+            deserializer=StrictFindByNameFieldDeserializer(OrganisationalNetwork, field="name"),
         )

--- a/src/database/model/agent/network_membership.py
+++ b/src/database/model/agent/network_membership.py
@@ -1,11 +1,10 @@
-from typing import Optional, List,TYPE_CHECKING
+from typing import Optional, List, TYPE_CHECKING
 from sqlmodel import SQLModel, Field, Relationship
 from database.model.concept.concept import AIoDConceptBase, AIoDConcept
-from database.model.agent.organisational_network import OrganisationalNetwork 
+from database.model.agent.organisational_network import OrganisationalNetwork
 from database.model.relationships import ManyToOne
-from database.model.serializers import (
-    AttributeSerializer
-)
+from database.model.serializers import AttributeSerializer
+
 if TYPE_CHECKING:
     from database.model.agent.organisation import Organisation
 
@@ -15,13 +14,14 @@ class NetworkMembership(SQLModel, table=True):  # type: ignore[call-arg]
     NetworkMembership links an Organisation to an OrganisationalNetwork and carries
     the `with_network_role` property.
     """
-    
+
     __tablename__ = "network_membership"
 
     identifier: Optional[int] = Field(default=None, primary_key=True)
-    
+
     with_network_role: Optional[str] = Field(
-        default=None, description="Role of the organisation within the network (e.g. 'Founding Member')"
+        default=None,
+        description="Role of the organisation within the network (e.g. 'Founding Member')",
     )
     organisation_identifier: str | None = Field(
         default=None,
@@ -33,11 +33,11 @@ class NetworkMembership(SQLModel, table=True):  # type: ignore[call-arg]
         foreign_key="organisational_network.identifier",
         description="Identifier of the organisational network.",
     )
-    
+
     organisation: Optional["Organisation"] = Relationship(back_populates="has_membership_in")
     in_network: Optional["OrganisationalNetwork"] = Relationship()
-    
-    class RelationshipConfig():
+
+    class RelationshipConfig:
         organisation: Optional[str] = ManyToOne(
             description="The organisation that has this membership.",
             identifier_name="organisation_identifier",
@@ -48,5 +48,3 @@ class NetworkMembership(SQLModel, table=True):  # type: ignore[call-arg]
             identifier_name="in_network_identifier",
             _serializer=AttributeSerializer("identifier"),
         )
-
-

--- a/src/database/model/agent/network_membership.py
+++ b/src/database/model/agent/network_membership.py
@@ -3,7 +3,7 @@ from sqlmodel import SQLModel, Field, Relationship
 from database.model.concept.concept import AIoDConceptBase, AIoDConcept
 from database.model.agent.organisational_network import OrganisationalNetwork
 from database.model.relationships import ManyToOne
-from database.model.serializers import AttributeSerializer
+from database.model.serializers import AttributeSerializer, FindByNameDeserializer
 
 if TYPE_CHECKING:
     from database.model.agent.organisation import Organisation
@@ -47,4 +47,5 @@ class NetworkMembership(SQLModel, table=True):  # type: ignore[call-arg]
             description="The organisational network this membership belongs to.",
             identifier_name="in_network_identifier",
             _serializer=AttributeSerializer("identifier"),
+            deserializer=FindByNameDeserializer(OrganisationalNetwork),
         )

--- a/src/database/model/agent/organisation.py
+++ b/src/database/model/agent/organisation.py
@@ -17,6 +17,10 @@ from database.model.serializers import (
     FindByIdentifierDeserializerList,
 )
 from versioning import Version, VersionedResource, VersionedResourceCollection
+from typing import cast
+from sqlmodel import SQLModel
+from database.model.resource_read_and_create import resource_read, resource_create
+from versioning import schema_transform
 
 
 OrganisationInvolvementLevel: type[Taxonomy] = create_taxonomy(
@@ -106,30 +110,27 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
         description="The employee size bracket of the organisation.",
     )
     number_of_employees: Optional[NumberOfEmployees] = Relationship()  # type: ignore[valid-type]
-    
+
     has_activity_type_identifier: int | None = Field(
-    default=None,
-    foreign_key="organisation_activity_type.identifier",
-    description="The activity type of the organisation.",
+        default=None,
+        foreign_key="organisation_activity_type.identifier",
+        description="The activity type of the organisation.",
     )
     has_activity_type: Optional[OrganisationActivityType] = Relationship()  # type: ignore[valid-type]
-    
+
     involved_in_area_identifier: int | None = Field(
-    default=None,
-    foreign_key="organisation_involvement_level.identifier",
-    description="The involvement level of the organisation in a specific area.",
+        default=None,
+        foreign_key="organisation_involvement_level.identifier",
+        description="The involvement level of the organisation in a specific area.",
     )
     involved_in_area: Optional[OrganisationInvolvementLevel] = Relationship()  # type: ignore[valid-type]
-    
+
     has_membership_in_identifier: int | None = Field(
         default=None,
         foreign_key="organisation_network_membership.identifier",
-        description="The network membership(s) of the organisation.",
+        description="The network membership of the organisation.",
     )
     has_membership_in: Optional[OrganisationNetworkMembership] = Relationship()  # type: ignore[valid-type]
-
-
-
 
     class RelationshipConfig(Agent.RelationshipConfig):
         contact_details: str | None = OneToOne(
@@ -170,7 +171,7 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
             deserializer=FindByNameDeserializer(NumberOfEmployees),
             example="<10",
         )
-        
+
         has_activity_type: Optional[str] = ManyToOne(
             description="The activity type of the organisation.",
             identifier_name="has_activity_type_identifier",
@@ -186,7 +187,7 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
             deserializer=FindByNameDeserializer(OrganisationInvolvementLevel),
             example="Strategic Partner",
         )
-        
+
         has_membership_in: Optional[str] = ManyToOne(
             description="The membership(s) of the organisation in networks.",
             identifier_name="has_membership_in_identifier",
@@ -196,15 +197,52 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
         )
 
 
-
-
-
 deserializer = FindByIdentifierDeserializer(Organisation)
 Contact.RelationshipConfig.organisation.deserializer = deserializer  # type: ignore
 
+
+def organisation_v3_to_v2() -> VersionedResource:
+    """Drop new fields (has_activity_type, involved_in_area, has_membership_in) for V2 compatibility."""
+
+    OrganisationV2Read = schema_transform(
+        resource_read(Organisation),
+        "OrganisationV2Read",
+        remove_fields=[
+            "has_activity_type",
+            "involved_in_area",
+            "has_membership_in",
+        ],
+    )
+
+    OrganisationV2Create = schema_transform(
+        resource_create(Organisation),
+        "OrganisationV2Create",
+        remove_fields=[
+            "has_activity_type",
+            "involved_in_area",
+            "has_membership_in",
+        ],
+    )
+
+    def orm_to_read(org: Organisation) -> OrganisationV2Read:  # type: ignore[valid-type]
+        read = resource_read(Organisation).model_validate(org).model_dump()
+        for f in ["has_activity_type", "involved_in_area", "has_membership_in"]:
+            read.pop(f, None)
+        return OrganisationV2Read.model_validate(read)
+
+    def create_to_orm(org: OrganisationV2Create) -> Organisation:  # type: ignore[valid-type]
+        fields = cast(SQLModel, org).model_dump()
+        return Organisation.model_validate(fields)
+
+    return VersionedResource(
+        Organisation, OrganisationV2Create, OrganisationV2Read, create_to_orm, orm_to_read
+    )
+
+
 organisation_versions = VersionedResourceCollection(
     {
-        Version.V2: VersionedResource(Organisation),
+        Version.V3: VersionedResource(Organisation),
+        Version.V2: organisation_v3_to_v2(),
         Version.LATEST: VersionedResource(Organisation),
     }
 )

--- a/src/database/model/agent/organisation.py
+++ b/src/database/model/agent/organisation.py
@@ -19,6 +19,18 @@ from database.model.serializers import (
 from versioning import Version, VersionedResource, VersionedResourceCollection
 
 
+OrganisationInvolvementLevel: type[Taxonomy] = create_taxonomy(
+    class_name="OrganisationInvolvementLevel",
+    table_name="organisation_involvement_level",
+    plural_name="organisation involvement levels",
+)
+
+OrganisationNetworkMembership: type[Taxonomy] = create_taxonomy(
+    class_name="OrganisationNetworkMembership",
+    table_name="organisation_network_membership",
+    plural_name="organisation network memberships",
+)
+
 OrganisationType: type[Taxonomy] = create_taxonomy(
     class_name="OrganisationType",
     table_name="organisation_type",
@@ -94,6 +106,30 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
         description="The employee size bracket of the organisation.",
     )
     number_of_employees: Optional[NumberOfEmployees] = Relationship()  # type: ignore[valid-type]
+    
+    has_activity_type_identifier: int | None = Field(
+    default=None,
+    foreign_key="organisation_activity_type.identifier",
+    description="The activity type of the organisation.",
+    )
+    has_activity_type: Optional[OrganisationActivityType] = Relationship()  # type: ignore[valid-type]
+    
+    involved_in_area_identifier: int | None = Field(
+    default=None,
+    foreign_key="organisation_involvement_level.identifier",
+    description="The involvement level of the organisation in a specific area.",
+    )
+    involved_in_area: Optional[OrganisationInvolvementLevel] = Relationship()  # type: ignore[valid-type]
+    
+    has_membership_in_identifier: int | None = Field(
+        default=None,
+        foreign_key="organisation_network_membership.identifier",
+        description="The network membership(s) of the organisation.",
+    )
+    has_membership_in: Optional[OrganisationNetworkMembership] = Relationship()  # type: ignore[valid-type]
+
+
+
 
     class RelationshipConfig(Agent.RelationshipConfig):
         contact_details: str | None = OneToOne(
@@ -134,6 +170,33 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
             deserializer=FindByNameDeserializer(NumberOfEmployees),
             example="<10",
         )
+        
+        has_activity_type: Optional[str] = ManyToOne(
+            description="The activity type of the organisation.",
+            identifier_name="has_activity_type_identifier",
+            _serializer=AttributeSerializer("name"),
+            deserializer=FindByNameDeserializer(OrganisationActivityType),
+            example="Research",
+        )
+
+        involved_in_area: Optional[str] = ManyToOne(
+            description="The involvement level of the organisation in a specific area.",
+            identifier_name="involved_in_area_identifier",
+            _serializer=AttributeSerializer("name"),
+            deserializer=FindByNameDeserializer(OrganisationInvolvementLevel),
+            example="Strategic Partner",
+        )
+        
+        has_membership_in: Optional[str] = ManyToOne(
+            description="The membership(s) of the organisation in networks.",
+            identifier_name="has_membership_in_identifier",
+            _serializer=AttributeSerializer("name"),
+            deserializer=FindByNameDeserializer(OrganisationNetworkMembership),
+            example="CLAIRE Network",
+        )
+
+
+
 
 
 deserializer = FindByIdentifierDeserializer(Organisation)

--- a/src/database/model/agent/organisation.py
+++ b/src/database/model/agent/organisation.py
@@ -23,13 +23,14 @@ from database.model.resource_read_and_create import resource_read, resource_crea
 from versioning import schema_transform
 
 from database.model.agent.network_membership import NetworkMembership
+from database.model.agent.involvement_level import InvolvementLevel
 from database.model.serializers import CastDeserializerList
 
-OrganisationInvolvementLevel: type[Taxonomy] = create_taxonomy(
-    class_name="OrganisationInvolvementLevel",
-    table_name="organisation_involvement_level",
-    plural_name="organisation involvement levels",
-)
+# OrganisationInvolvementLevel: type[Taxonomy] = create_taxonomy(
+#     class_name="OrganisationInvolvementLevel",
+#     table_name="organisation_involvement_level",
+#     plural_name="organisation involvement levels",
+# )
 
 # OrganisationNetworkMembership: type[Taxonomy] = create_taxonomy(
 #     class_name="OrganisationNetworkMembership",
@@ -120,12 +121,11 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
     )
     has_activity_type: Optional[OrganisationActivityType] = Relationship()  # type: ignore[valid-type]
 
-    involved_in_area_identifier: int | None = Field(
-        default=None,
-        foreign_key="organisation_involvement_level.identifier",
-        description="The involvement level of the organisation in a specific area.",
+    involved_in_area: list[InvolvementLevel] = Relationship(
+        sa_relationship_kwargs={
+            "primaryjoin": "Organisation.identifier==InvolvementLevel.organisation_identifier"
+        }
     )
-    involved_in_area: Optional[OrganisationInvolvementLevel] = Relationship()  # type: ignore[valid-type]
 
     has_membership_in: list[NetworkMembership] = Relationship(
         sa_relationship_kwargs={
@@ -181,12 +181,11 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
             example="Applied research",
         )
 
-        involved_in_area: Optional[str] = ManyToOne(
-            description="The involvement level of the organisation in a specific area.",
-            identifier_name="involved_in_area_identifier",
-            _serializer=AttributeSerializer("name"),
-            deserializer=FindByNameDeserializer(OrganisationInvolvementLevel),
-            example="Strategic Partner",
+        involved_in_area: list[InvolvementLevel] = OneToMany(
+            description="The involvement levels that link this organisation to specific expertise areas.",
+            _serializer=AttributeSerializer("identifier"),
+            deserializer=CastDeserializerList(InvolvementLevel),
+            default_factory_pydantic=list,
         )
 
         has_membership_in: list[NetworkMembership] = OneToMany(
@@ -210,7 +209,7 @@ def organisation_v3_to_v2() -> VersionedResource:
         remove_fields=[
             "has_activity_type",
             "involved_in_area",
-            # "has_membership_in",
+            "has_membership_in",
         ],
     )
 
@@ -220,16 +219,13 @@ def organisation_v3_to_v2() -> VersionedResource:
         remove_fields=[
             "has_activity_type",
             "involved_in_area",
-            # "has_membership_in",
+            "has_membership_in",
         ],
     )
 
     def orm_to_read(org: Organisation) -> OrganisationV2Read:  # type: ignore[valid-type]
         read = resource_read(Organisation).model_validate(org).model_dump()
-        for f in [
-            "has_activity_type",
-            "involved_in_area",
-        ]:  # "has_membership_in"]:
+        for f in ["has_activity_type", "involved_in_area", "has_membership_in"]:
             read.pop(f, None)
         return OrganisationV2Read.model_validate(read)
 
@@ -245,7 +241,7 @@ def organisation_v3_to_v2() -> VersionedResource:
 organisation_versions = VersionedResourceCollection(
     {
         Version.V3: VersionedResource(Organisation),
-        # Version.V2: organisation_v3_to_v2(),
+        Version.V2: organisation_v3_to_v2(),
         Version.LATEST: VersionedResource(Organisation),
     }
 )

--- a/src/database/model/agent/organisation.py
+++ b/src/database/model/agent/organisation.py
@@ -15,6 +15,7 @@ from database.model.serializers import (
     FindByNameDeserializer,
     FindByIdentifierDeserializer,
     FindByIdentifierDeserializerList,
+    MultiAttributeSerializer,
 )
 from versioning import Version, VersionedResource, VersionedResourceCollection
 from typing import cast
@@ -26,17 +27,6 @@ from database.model.agent.network_membership import NetworkMembership
 from database.model.agent.involvement_level import InvolvementLevel
 from database.model.serializers import CastDeserializerList
 
-# OrganisationInvolvementLevel: type[Taxonomy] = create_taxonomy(
-#     class_name="OrganisationInvolvementLevel",
-#     table_name="organisation_involvement_level",
-#     plural_name="organisation involvement levels",
-# )
-
-# OrganisationNetworkMembership: type[Taxonomy] = create_taxonomy(
-#     class_name="OrganisationNetworkMembership",
-#     table_name="organisation_network_membership",
-#     plural_name="organisation network memberships",
-# )
 
 OrganisationType: type[Taxonomy] = create_taxonomy(
     class_name="OrganisationType",
@@ -121,17 +111,17 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
     )
     has_activity_type: Optional[OrganisationActivityType] = Relationship()  # type: ignore[valid-type]
 
-    involved_in_area: list[InvolvementLevel] = Relationship(
-        sa_relationship_kwargs={
-            "primaryjoin": "Organisation.identifier==InvolvementLevel.organisation_identifier"
-        }
-    )
+    # involved_in_area: list[InvolvementLevel] = Relationship(
+    #     back_populates="organisation",
+    #     sa_relationship_kwargs={
+    #     "lazy": "selectin",
+    #     "primaryjoin": "Organisation.identifier == foreign(InvolvementLevel.organisation_identifier)"
+    # }
+    # )
 
-    has_membership_in: list[NetworkMembership] = Relationship(
-        sa_relationship_kwargs={
-            "primaryjoin": "Organisation.identifier==NetworkMembership.organisation_identifier"
-        }
-    )
+    involved_in_area: list["InvolvementLevel"] = Relationship(back_populates="organisation")
+
+    has_membership_in: list[NetworkMembership] = Relationship(back_populates="organisation")
 
     class RelationshipConfig(Agent.RelationshipConfig):
         contact_details: str | None = OneToOne(
@@ -183,14 +173,15 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
 
         involved_in_area: list[InvolvementLevel] = OneToMany(
             description="The involvement levels that link this organisation to specific expertise areas.",
-            _serializer=AttributeSerializer("identifier"),
+            # _serializer=MultiAttributeSerializer({
+            # "involvement_level":"involvement_level", "involvement_area":"involvement_area.name"}),
             deserializer=CastDeserializerList(InvolvementLevel),
             default_factory_pydantic=list,
         )
 
         has_membership_in: list[NetworkMembership] = OneToMany(
             description="The memberships that link this organisation to organisational networks.",
-            _serializer=AttributeSerializer("identifier"),
+            # _serializer=AttributeSerializer("identifier"),
             deserializer=CastDeserializerList(NetworkMembership),
             default_factory_pydantic=list,
         )
@@ -245,3 +236,70 @@ organisation_versions = VersionedResourceCollection(
         Version.LATEST: VersionedResource(Organisation),
     }
 )
+
+# {
+#   "platform": null,
+#   "platform_resource_identifier": null,
+#   "name": "The name of this resource",
+#   "date_published": "2022-01-01T15:15:00.000",
+#   "same_as": "https://www.example.com/resource/this_resource",
+#   "date_founded": "2022-01-01",
+#   "legal_name": "The Organisation Name",
+#   "ai_relevance": "Part of CLAIRE, focussing on explainable AI.",
+#   "aiod_entry": null,
+#   "alternate_name": [
+#     "alias 1",
+#     "alias 2"
+#   ],
+#   "application_area": [
+#     "Fraud Prevention",
+#     "Voice Assistance",
+#     "Disease Classification"
+#   ],
+#   "contact": [],
+#   "contact_details": null,
+#   "creator": [],
+#   "description": null,
+#   "has_activity_type": "Applied research",
+# "has_membership_in": [
+#   {
+#     "with_network_role": "Beneficiary",
+#     "in_network": "AI4Media"
+#   },
+#   {
+#     "with_network_role": "Associated partner",
+#     "in_network": "ELISE"
+#   }
+# ],
+#   "has_part": [],
+#   "industrial_sector": [
+#     "Pharmaceuticals",
+#     "Computer Programming",
+#     "Cybersecurity"
+#   ],
+#   "involved_in_area": [{"involvement_level": "low", "involvement_area": "computervision"}],
+#   "is_part_of": [],
+#   "keyword": [
+#     "keyword1",
+#     "keyword2"
+#   ],
+#   "media": [],
+#   "member": [],
+#   "note": [],
+#   "number_of_employees": "<10",
+#   "relevant_link": [
+#     "https://www.example.com/a_relevant_link",
+#     "https://www.example.com/another_relevant_link"
+#   ],
+#   "relevant_resource": [],
+#   "relevant_to": [],
+#   "research_area": [
+#     "AI Services",
+#     "Multi-agent Systems"
+#   ],
+#   "scientific_domain": [
+#     "Computer and Information Sciences",
+#     "Mathematics"
+#   ],
+#   "turnover": ">5 million euros"
+# }

--- a/src/database/model/agent/organisation.py
+++ b/src/database/model/agent/organisation.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from sqlmodel import Field, Relationship
 
@@ -9,7 +9,7 @@ from database.model.agent.agent_table import AgentTable
 from database.model.agent.contact import Contact
 from database.model.field_length import NORMAL, LONG
 from database.model.helper_functions import many_to_many_link_factory
-from database.model.relationships import ManyToOne, ManyToMany, OneToOne
+from database.model.relationships import ManyToOne, ManyToMany, OneToOne, OneToMany
 from database.model.serializers import (
     AttributeSerializer,
     FindByNameDeserializer,
@@ -22,6 +22,8 @@ from sqlmodel import SQLModel
 from database.model.resource_read_and_create import resource_read, resource_create
 from versioning import schema_transform
 
+from database.model.agent.network_membership import NetworkMembership
+from database.model.serializers import CastDeserializerList
 
 OrganisationInvolvementLevel: type[Taxonomy] = create_taxonomy(
     class_name="OrganisationInvolvementLevel",
@@ -29,11 +31,11 @@ OrganisationInvolvementLevel: type[Taxonomy] = create_taxonomy(
     plural_name="organisation involvement levels",
 )
 
-OrganisationNetworkMembership: type[Taxonomy] = create_taxonomy(
-    class_name="OrganisationNetworkMembership",
-    table_name="organisation_network_membership",
-    plural_name="organisation network memberships",
-)
+# OrganisationNetworkMembership: type[Taxonomy] = create_taxonomy(
+#     class_name="OrganisationNetworkMembership",
+#     table_name="organisation_network_membership",
+#     plural_name="organisation network memberships",
+# )
 
 OrganisationType: type[Taxonomy] = create_taxonomy(
     class_name="OrganisationType",
@@ -125,12 +127,11 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
     )
     involved_in_area: Optional[OrganisationInvolvementLevel] = Relationship()  # type: ignore[valid-type]
 
-    has_membership_in_identifier: int | None = Field(
-        default=None,
-        foreign_key="organisation_network_membership.identifier",
-        description="The network membership of the organisation.",
+    has_membership_in: list[NetworkMembership] = Relationship(
+        sa_relationship_kwargs={
+            "primaryjoin": "Organisation.identifier==NetworkMembership.organisation_identifier"
+        }
     )
-    has_membership_in: Optional[OrganisationNetworkMembership] = Relationship()  # type: ignore[valid-type]
 
     class RelationshipConfig(Agent.RelationshipConfig):
         contact_details: str | None = OneToOne(
@@ -177,7 +178,7 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
             identifier_name="has_activity_type_identifier",
             _serializer=AttributeSerializer("name"),
             deserializer=FindByNameDeserializer(OrganisationActivityType),
-            example="Research",
+            example="Applied research",
         )
 
         involved_in_area: Optional[str] = ManyToOne(
@@ -188,12 +189,11 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
             example="Strategic Partner",
         )
 
-        has_membership_in: Optional[str] = ManyToOne(
-            description="The membership(s) of the organisation in networks.",
-            identifier_name="has_membership_in_identifier",
-            _serializer=AttributeSerializer("name"),
-            deserializer=FindByNameDeserializer(OrganisationNetworkMembership),
-            example="CLAIRE Network",
+        has_membership_in: list[NetworkMembership] = OneToMany(
+            description="The memberships that link this organisation to organisational networks.",
+            _serializer=AttributeSerializer("identifier"),
+            deserializer=CastDeserializerList(NetworkMembership),
+            default_factory_pydantic=list,
         )
 
 
@@ -210,7 +210,7 @@ def organisation_v3_to_v2() -> VersionedResource:
         remove_fields=[
             "has_activity_type",
             "involved_in_area",
-            "has_membership_in",
+            # "has_membership_in",
         ],
     )
 
@@ -220,13 +220,16 @@ def organisation_v3_to_v2() -> VersionedResource:
         remove_fields=[
             "has_activity_type",
             "involved_in_area",
-            "has_membership_in",
+            # "has_membership_in",
         ],
     )
 
     def orm_to_read(org: Organisation) -> OrganisationV2Read:  # type: ignore[valid-type]
         read = resource_read(Organisation).model_validate(org).model_dump()
-        for f in ["has_activity_type", "involved_in_area", "has_membership_in"]:
+        for f in [
+            "has_activity_type",
+            "involved_in_area",
+        ]:  # "has_membership_in"]:
             read.pop(f, None)
         return OrganisationV2Read.model_validate(read)
 
@@ -242,7 +245,7 @@ def organisation_v3_to_v2() -> VersionedResource:
 organisation_versions = VersionedResourceCollection(
     {
         Version.V3: VersionedResource(Organisation),
-        Version.V2: organisation_v3_to_v2(),
+        # Version.V2: organisation_v3_to_v2(),
         Version.LATEST: VersionedResource(Organisation),
     }
 )

--- a/src/database/model/agent/organisation.py
+++ b/src/database/model/agent/organisation.py
@@ -27,7 +27,6 @@ from database.model.agent.network_membership import NetworkMembership
 from database.model.agent.involvement_level import InvolvementLevel
 from database.model.serializers import CastDeserializerList
 
-
 OrganisationType: type[Taxonomy] = create_taxonomy(
     class_name="OrganisationType",
     table_name="organisation_type",
@@ -111,14 +110,6 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
     )
     has_activity_type: Optional[OrganisationActivityType] = Relationship()  # type: ignore[valid-type]
 
-    # involved_in_area: list[InvolvementLevel] = Relationship(
-    #     back_populates="organisation",
-    #     sa_relationship_kwargs={
-    #     "lazy": "selectin",
-    #     "primaryjoin": "Organisation.identifier == foreign(InvolvementLevel.organisation_identifier)"
-    # }
-    # )
-
     involved_in_area: list["InvolvementLevel"] = Relationship(back_populates="organisation")
 
     has_membership_in: list[NetworkMembership] = Relationship(back_populates="organisation")
@@ -179,9 +170,9 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
             default_factory_pydantic=list,
         )
 
+    
         has_membership_in: list[NetworkMembership] = OneToMany(
             description="The memberships that link this organisation to organisational networks.",
-            # _serializer=AttributeSerializer("identifier"),
             deserializer=CastDeserializerList(NetworkMembership),
             default_factory_pydantic=list,
         )

--- a/src/database/model/agent/organisational_network.py
+++ b/src/database/model/agent/organisational_network.py
@@ -1,4 +1,3 @@
-
 from typing import Optional, TYPE_CHECKING, List
 from sqlmodel import Field, Relationship
 from database.model.agent.agent import Agent, AgentBase
@@ -8,11 +7,12 @@ from versioning import Version, VersionedResource, VersionedResourceCollection
 class OrganisationalNetworkBase(AgentBase):
     pass
 
+
 class OrganisationalNetwork(OrganisationalNetworkBase, Agent, table=True):  # type: ignore
     __tablename__ = "organisational_network"
     __abbreviation__ = "net"
     __plural__ = "organisational_networks"
-    
+
     class RelationshipConfig(Agent.RelationshipConfig):
         pass
 

--- a/src/database/model/agent/organisational_network.py
+++ b/src/database/model/agent/organisational_network.py
@@ -1,5 +1,3 @@
-from typing import Optional, TYPE_CHECKING, List
-from sqlmodel import Field, Relationship
 from database.model.agent.agent import Agent, AgentBase
 from versioning import Version, VersionedResource, VersionedResourceCollection
 
@@ -20,6 +18,6 @@ class OrganisationalNetwork(OrganisationalNetworkBase, Agent, table=True):  # ty
 organisational_network_versions = VersionedResourceCollection(
     {
         Version.LATEST: VersionedResource(OrganisationalNetwork),
-        Version.V2: VersionedResource(OrganisationalNetwork),
+        Version.V3: VersionedResource(OrganisationalNetwork),
     }
 )

--- a/src/database/model/agent/organisational_network.py
+++ b/src/database/model/agent/organisational_network.py
@@ -1,0 +1,25 @@
+
+from typing import Optional, TYPE_CHECKING, List
+from sqlmodel import Field, Relationship
+from database.model.agent.agent import Agent, AgentBase
+from versioning import Version, VersionedResource, VersionedResourceCollection
+
+
+class OrganisationalNetworkBase(AgentBase):
+    pass
+
+class OrganisationalNetwork(OrganisationalNetworkBase, Agent, table=True):  # type: ignore
+    __tablename__ = "organisational_network"
+    __abbreviation__ = "net"
+    __plural__ = "organisational_networks"
+    
+    class RelationshipConfig(Agent.RelationshipConfig):
+        pass
+
+
+organisational_network_versions = VersionedResourceCollection(
+    {
+        Version.LATEST: VersionedResource(OrganisationalNetwork),
+        Version.V2: VersionedResource(OrganisationalNetwork),
+    }
+)

--- a/src/database/model/serializers.py
+++ b/src/database/model/serializers.py
@@ -36,6 +36,26 @@ class DeSerializer(abc.ABC, Generic[MODEL]):
         pass
 
 
+class MultiAttributeSerializer(Serializer):
+    """Serialize by using multiple attributes of the object.
+
+    For instance, if using `MultiAttributeSerializer(['identifier', 'name'])`, a dictionary
+    with both the identifier and name of this object will be shown to the user."""
+
+    def __init__(self, attribute_names: dict[str, str]):
+        self.attribute_map = attribute_names
+
+    def serialize(self, model: MODEL) -> Any:
+        attributes = {}
+        for key, path in self.attribute_map.items():
+            obj = model
+            *path_parts, last = path.split(".")
+            for part in path_parts:
+                obj = getattr(obj, part)
+            attributes[key] = getattr(obj, last)
+        return attributes
+
+
 class AttributeSerializer(Serializer):
     """Serialize by using only the value of this attribute.
 

--- a/src/database/model/serializers.py
+++ b/src/database/model/serializers.py
@@ -10,6 +10,7 @@ from starlette.status import HTTP_404_NOT_FOUND
 from authentication import KeycloakUser
 from database.model.helper_functions import get_relationships
 from database.model.named_relation import NamedRelation, Taxonomy
+from sqlalchemy.inspection import inspect
 
 MODEL = TypeVar("MODEL", bound=SQLModel)
 
@@ -240,6 +241,47 @@ class CastDeserializer(DeSerializer[SQLModel]):
         resource = self.clazz.from_orm(serialized)
         deserialize_resource_relationships(session, self.clazz, resource, serialized, user)
         return resource
+
+
+class StrictFindByNameFieldDeserializer:
+    """
+    Deserializer that resolves input values to an existing database record by name.
+
+    - Accepts either a string (e.g. "AI4Media") or a dict with a name field 
+      (e.g. {"name": "AI4Media"}).
+    - Looks up the given name in the specified model's table using a 
+      case-insensitive match.
+    - Raises ValueError if no matching record exists, instead of creating a new one 
+      (strict mode).
+    - Returns either the record identifier (default) or the full ORM instance if 
+      return_instance=True.
+    """
+    
+    def __init__(self, model, field="name", return_instance=False):
+        self.model = model
+        self.field = field
+        self.return_instance = return_instance  
+        
+    def deserialize(self, session, serialized, user=None):
+        # unwrap dict {"name": "..."} to string
+        if isinstance(serialized, dict) and self.field in serialized:
+            serialized = serialized[self.field]
+
+        if not isinstance(serialized, str):
+            raise ValueError(f"Expected {self.field} as string, got {serialized!r}")
+
+        instance = (
+            session.query(self.model)
+            .filter(getattr(self.model, self.field).ilike(serialized))
+            .first()
+        )
+
+        if not instance:
+            raise ValueError(
+                f"{self.model.__name__} with {self.field}='{serialized}' does not exist"
+            )
+
+        return instance if self.return_instance else instance.identifier
 
 
 class CastDeserializerList(CastDeserializer):

--- a/src/routers/resource_routers/__init__.py
+++ b/src/routers/resource_routers/__init__.py
@@ -17,6 +17,10 @@ from .service_router import ServiceRouter, service_routers
 from .team_router import TeamRouter, team_routers
 from .resource_bundle_router import ResourceBundleRouter, resource_bundle_routers
 from .. import ResourceRouter
+from .organisational_network_router import (
+    OrganisationalNetworkRouter,
+    organisational_network_routers,
+)
 
 all_routers = [value for attr, value in locals().items() if attr.endswith("_routers")]
 

--- a/src/routers/resource_routers/organisational_network_router.py
+++ b/src/routers/resource_routers/organisational_network_router.py
@@ -1,4 +1,7 @@
-from database.model.agent.organisational_network import OrganisationalNetwork, organisational_network_versions
+from database.model.agent.organisational_network import (
+    OrganisationalNetwork,
+    organisational_network_versions,
+)
 from routers.resource_router import ResourceRouter
 
 
@@ -18,6 +21,7 @@ class OrganisationalNetworkRouter(ResourceRouter):
     @property
     def resource_class(self) -> type[OrganisationalNetwork]:
         return OrganisationalNetwork
+
 
 organisational_network_routers = {
     version: OrganisationalNetworkRouter(versioned_resource)

--- a/src/routers/resource_routers/organisational_network_router.py
+++ b/src/routers/resource_routers/organisational_network_router.py
@@ -1,0 +1,25 @@
+from database.model.agent.organisational_network import OrganisationalNetwork, organisational_network_versions
+from routers.resource_router import ResourceRouter
+
+
+class OrganisationalNetworkRouter(ResourceRouter):
+    @property
+    def version(self) -> int:
+        return 1
+
+    @property
+    def resource_name(self) -> str:
+        return "organisational_network"
+
+    @property
+    def resource_name_plural(self) -> str:
+        return "organisational_networks"
+
+    @property
+    def resource_class(self) -> type[OrganisationalNetwork]:
+        return OrganisationalNetwork
+
+organisational_network_routers = {
+    version: OrganisationalNetworkRouter(versioned_resource)
+    for version, versioned_resource in organisational_network_versions.items()
+}

--- a/src/taxonomies/synchronize_taxonomy.py
+++ b/src/taxonomies/synchronize_taxonomy.py
@@ -21,7 +21,6 @@ from database.model.agent.organisation import (
     Turnover,
     OrganisationType,
     OrganisationActivityType,
-    OrganisationInvolvementLevel,
 )
 from database.model.event.event import EventStatus, EventMode
 from database.model.agent.language import Language
@@ -67,7 +66,6 @@ type_by_name: dict[str, type] = {
     "Educational Competency": EducationalCompetency,
     "Organisation Activity Type": OrganisationActivityType,
     "Country": Country,
-    "Organisation Involvement Level": OrganisationInvolvementLevel,
 }
 
 

--- a/src/taxonomies/synchronize_taxonomy.py
+++ b/src/taxonomies/synchronize_taxonomy.py
@@ -21,6 +21,7 @@ from database.model.agent.organisation import (
     Turnover,
     OrganisationType,
     OrganisationActivityType,
+    OrganisationInvolvementLevel
 )
 from database.model.event.event import EventStatus, EventMode
 from database.model.agent.language import Language
@@ -66,6 +67,7 @@ type_by_name: dict[str, type] = {
     "Educational Competency": EducationalCompetency,
     "Organisation Activity Type": OrganisationActivityType,
     "Country": Country,
+    "Organisation Involvement Level": OrganisationInvolvementLevel,
 }
 
 

--- a/src/taxonomies/synchronize_taxonomy.py
+++ b/src/taxonomies/synchronize_taxonomy.py
@@ -21,7 +21,7 @@ from database.model.agent.organisation import (
     Turnover,
     OrganisationType,
     OrganisationActivityType,
-    OrganisationInvolvementLevel
+    OrganisationInvolvementLevel,
 )
 from database.model.event.event import EventStatus, EventMode
 from database.model.agent.language import Language

--- a/src/tests/routers/resource_routers/test_router_organisation.py
+++ b/src/tests/routers/resource_routers/test_router_organisation.py
@@ -55,9 +55,19 @@ def test_happy_path(
     body["ai_relevance"] = "Part of CLAIRE"
     body["type"] = "Research Institute"
     body["turnover"] = "<1 million euros"
-    # body["has_activity_type"] = "Research"
-    # body["involved_in_area"] = "Strategic Partner"
-    # body["has_membership_in"] = "CLAIRE Network"
+    body["has_activity_type"] = "Applied research"
+    body["involved_in_area"] = [{
+        "involvement_level": "high",
+        "involvement_area": "Computer Vision"
+    }]
+    body["has_membership_in"] = [{
+        "with_network_role": "Beneficiary",
+        "in_network": "AI4Media"
+    },
+    {
+        "with_network_role": "Associated partner",
+        "in_network": "ELISE"
+    }]
 
     with DbSession() as session:
         session.add(organisation)  # The new organisation will be a member of this organisation

--- a/src/tests/routers/resource_routers/test_router_organisation.py
+++ b/src/tests/routers/resource_routers/test_router_organisation.py
@@ -55,6 +55,10 @@ def test_happy_path(
     body["ai_relevance"] = "Part of CLAIRE"
     body["type"] = "Research Institute"
     body["turnover"] = "<1 million euros"
+    # body["has_activity_type"] = "Research"
+    # body["involved_in_area"] = "Strategic Partner"
+    # body["has_membership_in"] = "CLAIRE Network"
+
     with DbSession() as session:
         session.add(organisation)  # The new organisation will be a member of this organisation
         session.add(contact)
@@ -92,6 +96,9 @@ def test_happy_path(
             "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},
         }
     ]
+    # assert body["has_activity_type"] == "Research"
+    # assert body["involved_in_area"] == "Strategic Partner"
+    # assert body["has_membership_in"] == "CLAIRE Network"
 
     # response = client.delete("/organisations/1", headers={"Authorization": "Fake token"})
     # assert response.status_code == 200

--- a/src/tests/routers/resource_routers/test_router_organisation.py
+++ b/src/tests/routers/resource_routers/test_router_organisation.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 from starlette.testclient import TestClient
 
 from database.model.agent.contact import Contact
-from database.model.agent.organisation import Organisation, Turnover,NumberOfEmployees
+from database.model.agent.organisation import Organisation, Turnover,NumberOfEmployees, OrganisationActivityType
 from database.session import DbSession
 
 import pytest
@@ -14,8 +14,10 @@ from routers.resource_routers.organisation_router import ALLOWED_IMAGE_TYPES
 from http import HTTPStatus
 
 from taxonomies.synchronize_taxonomy import synchronize
+from database.model.agent.organisational_network import OrganisationalNetwork
 
 STANDARD_TURNOVER_VALUES = ["<1 million euros", ">1 million euros", ">3 million euros", ">5 million euros", ">50 million euros", ">1.5 billion euros"]
+STANDARD_ACTIVITY_TYPE = ["fundamental research", "applied research", "consultancy", "educational activities", "product/solution development", "other"]
 
 @pytest.fixture
 def with_organisation_taxonomies():
@@ -35,10 +37,19 @@ def with_organisation_taxonomies():
                 for value in STANDARD_TURNOVER_VALUES
             ],
             session
+
+        )
+        synchronize(
+            OrganisationActivityType,
+            [
+                OrganisationActivityType(name=value,definition="", official=True, children=[])
+                for value in STANDARD_ACTIVITY_TYPE
+            ],
+            session
+
         )
         session.commit()
     yield
-
 
 def test_happy_path(
     client: TestClient,
@@ -47,7 +58,8 @@ def test_happy_path(
     contact: Contact,
     body_agent: dict,
     auto_publish: None,
-    with_organisation_taxonomies,
+    with_organisation_taxonomies
+    # organisational_network: OrganisationalNetwork,
 ):
     body = copy.copy(body_agent)
     body["date_founded"] = "2023-01-01"
@@ -55,29 +67,26 @@ def test_happy_path(
     body["ai_relevance"] = "Part of CLAIRE"
     body["type"] = "Research Institute"
     body["turnover"] = "<1 million euros"
-    body["has_activity_type"] = "Applied research"
+    body["has_activity_type"] = "applied research"
     body["involved_in_area"] = [{
         "involvement_level": "high",
         "involvement_area": "Computer Vision"
     }]
-    body["has_membership_in"] = [{
-        "with_network_role": "Beneficiary",
-        "in_network": "AI4Media"
-    },
-    {
-        "with_network_role": "Associated partner",
-        "in_network": "ELISE"
-    }]
+    body["has_membership_in"] = [
+        {"with_network_role": "Beneficiary", "in_network": {"name": "ai4media"}}
+    ]
 
-    with DbSession() as session:
+    with DbSession() as session: 
         session.add(organisation)  # The new organisation will be a member of this organisation
         session.add(contact)
+        
         session.commit()
 
         body["member"] = [organisation.identifier]
         body["contact_details"] = contact.identifier
         body["contact"] = [contact.identifier]
-
+        
+    breakpoint()
     response = client.post("/organisations", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()
     identifier = response.json()['identifier']
@@ -106,9 +115,18 @@ def test_happy_path(
             "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},
         }
     ]
-    # assert body["has_activity_type"] == "Research"
-    # assert body["involved_in_area"] == "Strategic Partner"
-    # assert body["has_membership_in"] == "CLAIRE Network"
+    breakpoint()
+    assert response_json["has_activity_type"] == "Applied research"
+    assert response_json["involved_in_area"][0]["involvement_level"] == "high"
+    assert response_json["involved_in_area"][0]["involvement_area_identifier"] == 1
+    # assert response_json["involved_in_area"][0]["involvement_area"] == "Computer Vision"
+    
+    assert {m["with_network_role"] for m in response_json["has_membership_in"]} == {
+    "Beneficiary",
+    "Associated partner"
+    }
+
+
 
     # response = client.delete("/organisations/1", headers={"Authorization": "Fake token"})
     # assert response.status_code == 200
@@ -116,7 +134,7 @@ def test_happy_path(
     # assert response.status_code == 200, response.json()
     # response_json = response.json()
     # TODO(jos): make sure Agent is deleted on CASCADE
-
+    breakpoint()
     body["type"] = "Association"
     response = client.put(f"organisations/{identifier}", json=body, headers={"Authorization": "Fake token"})
     assert response.status_code == 200, response.json()

--- a/src/tests/testutils/default_instances.py
+++ b/src/tests/testutils/default_instances.py
@@ -15,6 +15,7 @@ from sqlalchemy.engine import Engine
 
 from database.model.agent.contact import Contact
 from database.model.agent.organisation import Organisation
+from database.model.agent.organisational_network import OrganisationalNetwork
 from database.model.agent.person import Person
 from database.model.dataset.dataset import Dataset
 from database.model.knowledge_asset.publication import Publication
@@ -127,6 +128,16 @@ def organisation(body_agent: dict) -> Organisation:
     body["ai_relevance"] = "Description of relevance in AI"
     return _create_class_with_body(Organisation, body)
 
+@pytest.fixture
+def organisational_network(body_agent: dict) -> list[OrganisationalNetwork]:
+    """Create two organisational networks and return the created model instances."""
+    body = copy.deepcopy(body_agent)
+    nets = []
+    for name in ("AI4Media", "ELISE"):
+        body = {"name": name}
+        net = _create_class_with_body(OrganisationalNetwork, body)
+        nets.append(net)
+    return nets
 
 @pytest.fixture
 def person(body_agent: dict) -> Person:


### PR DESCRIPTION
<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change(s)
<!-- Briefly describe the change of this PR If there are multiple changes, please describe them separately. -->
Change Type: <!-- Added/Changed/Deprecated/Removed/Fixed/Security --> 
Added

Change Category: <!-- Documentation/Interface/Internal/Other -->
Interface

Changelog Entry: <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->
1. Added `organisational_network` model and `network_membership` table, thereby adding `has_membership_in` field in `organisation`.
2. Added `involvement_level` and `involved_in_area` fields in `organisation`. 
3. Added `activity_type` taxonomy and `has_activity_type` field in `organisation`. 
4. Added `V2` backwards compatibility function in `organisation`. 

Will raise a separate PR to use a better serialiser to output the `field_name` instead of `identifier` in `has_membership_in` and `involved_in_area` fields. 

<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Covered in pytest. 
To test locally, please do the database migration. 

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [ ] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
