### PR TITLE
Added required_educational_competency to Educational Resources, enforce the use of Country taxonomy.

### DIFF
--- a/alembic/alembic/versions/a1dc2d11bf88_add_educational_competency.py
+++ b/alembic/alembic/versions/a1dc2d11bf88_add_educational_competency.py
@@ -20,8 +20,23 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    pass
+    op.add_column(
+        "educational_resource",
+        sa.Column("required_competency_level_identifier", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "educational_resource_required_competency_level_ibfk",
+        "educational_resource",
+        "educational_competency",
+        ["required_competency_level_identifier"],
+        ["identifier"],
+    )
 
 
 def downgrade() -> None:
-    pass
+    op.drop_constraint(
+        "educational_resource_required_competency_level_ibfk",
+        "educational_resource",
+        type_="foreignkey",
+    )
+    op.drop_column("educational_resource", "required_competency_level_identifier")

--- a/alembic/alembic/versions/a1dc2d11bf88_add_educational_competency.py
+++ b/alembic/alembic/versions/a1dc2d11bf88_add_educational_competency.py
@@ -1,0 +1,27 @@
+"""add educational competency
+
+Revision ID: a1dc2d11bf88
+Revises: d02aac64a5c7
+Create Date: 2025-09-25 09:44:35.566898
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1dc2d11bf88"
+down_revision: Union[str, None] = "d02aac64a5c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/alembic/versions/d02aac64a5c7_multi_asset_reviews.py
+++ b/alembic/alembic/versions/d02aac64a5c7_multi_asset_reviews.py
@@ -1,7 +1,7 @@
 """multi_asset_reviews
 
 Revision ID: d02aac64a5c7
-Revises: 1fd9b6a162c4
+Revises: 586692ca94e4
 Create Date: 2025-09-16 12:27:10.238574
 
 """
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "d02aac64a5c7"
-down_revision: Union[str, None] = "1fd9b6a162c4"
+down_revision: Union[str, None] = "586692ca94e4"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/alembic/versions/eb4e8cf555d9_convert_country_to_taxonomy.py
+++ b/alembic/alembic/versions/eb4e8cf555d9_convert_country_to_taxonomy.py
@@ -10,7 +10,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-
+from sqlalchemy import Column
 
 # revision identifiers, used by Alembic.
 revision: str = "eb4e8cf555d9"
@@ -20,8 +20,27 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    pass
+    # Migrate existing countries to country table as unofficial
+    op.execute(
+        "insert into country(name, definition, official) SELECT distinct(country), '', false from address;"
+    )
+    # Create new column that references the identifier
+    op.add_column("address", Column("country_identifier", sa.Integer(), nullable=True))
+
+    op.execute(
+        "update address a join country c on a.country=c.name set a.country_identifier=c.identifier;"
+    )
+
+    op.create_foreign_key(
+        "address_country_identifier_ibfk",
+        "address",
+        "country",
+        ["country_identifier"],
+        ["identifier"],
+    )
+    op.drop_column("address", "country")
 
 
 def downgrade() -> None:
     pass
+    # cannot go back since the country constraint is current 3 characters

--- a/alembic/alembic/versions/eb4e8cf555d9_convert_country_to_taxonomy.py
+++ b/alembic/alembic/versions/eb4e8cf555d9_convert_country_to_taxonomy.py
@@ -1,0 +1,27 @@
+"""convert country to taxonomy
+
+Revision ID: eb4e8cf555d9
+Revises: a1dc2d11bf88
+Create Date: 2025-09-25 09:44:51.192439
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "eb4e8cf555d9"
+down_revision: Union[str, None] = "a1dc2d11bf88"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/src/database/model/agent/location.py
+++ b/src/database/model/agent/location.py
@@ -1,11 +1,12 @@
 from typing import Optional
 
+from pydantic import validator
 from sqlalchemy import Column, Integer, ForeignKey, String
 from sqlmodel import SQLModel, Field, Relationship
 
 from database.model.field_length import NORMAL, SHORT, IDENTIFIER_LENGTH
-from database.model.relationships import OneToOne
-from database.model.serializers import CastDeserializer
+from database.model.relationships import OneToOne, ManyToOne
+from database.model.serializers import CastDeserializer, AttributeSerializer, FindByNameDeserializer
 from database.model.named_relation import create_taxonomy
 
 
@@ -80,13 +81,6 @@ class AddressBase(SQLModel):
         max_length=NORMAL,
         schema_extra={"example": "Wetstraat 170, 1040 Brussel"},
     )
-    country: str | None = Field(
-        default=None,
-        description="The country as ISO 3166-1 alpha-3",
-        schema_extra={"example": "BEL"},
-        min_length=3,
-        max_length=3,
-    )
 
 
 class AddressORM(AddressBase, table=True):  # type: ignore [call-arg]
@@ -94,16 +88,37 @@ class AddressORM(AddressBase, table=True):  # type: ignore [call-arg]
 
     identifier: int | None = Field(primary_key=True)
 
-    # TODO(jos): make country an enum. This is difficult though, because deserialization isn't
-    #  working on non-main entities
     location_identifier: int | None = Field(
         sa_column=Column(Integer, ForeignKey("location.identifier", ondelete="CASCADE"))
     )
     location: Optional["LocationORM"] = Relationship(back_populates="address")
+    country_identifier: int | None = Field(
+        foreign_key=f"{Country.__tablename__}.identifier",
+    )
+    country: Country | None = Relationship()  # type: ignore [valid-type]
+
+    class RelationshipConfig:
+        country: Optional[str] = ManyToOne(
+            description="The country the address is from.",
+            identifier_name="country_identifier",
+            _serializer=AttributeSerializer("name"),
+            deserializer=FindByNameDeserializer(Country),
+            example="Germany",
+        )
 
 
 class Address(AddressBase):
     """A postal address"""
+
+    country: str | None
+
+    @validator("country", pre=True)
+    def use_country_name(cls, v):
+        if isinstance(v, str):
+            return v
+        if isinstance(v, Country):
+            return v.name
+        raise TypeError(f"Expected country to be `str` or `Country`, not {type(v)}.")
 
 
 class LocationBase(SQLModel):

--- a/src/database/model/agent/organisation.py
+++ b/src/database/model/agent/organisation.py
@@ -107,7 +107,7 @@ class Organisation(OrganisationBase, Agent, table=True):  # type: ignore [call-a
             identifier_name="type_identifier",
             _serializer=AttributeSerializer("name"),
             deserializer=FindByNameDeserializer(OrganisationType),
-            example="Research Institution",
+            example="Research University",
         )
         member: list[str] = ManyToMany(
             description="The identifier of an agent (e.g. organisation or person) that is a "

--- a/src/database/model/agent/person.py
+++ b/src/database/model/agent/person.py
@@ -84,10 +84,10 @@ class Person(PersonBase, Agent, table=True):  # type: ignore [call-arg]
             on_delete_trigger_orphan_deletion=list,
         )
         languages: list[str] = ManyToMany(
-            description="A language this person masters, in ISO639-3",
+            description="A language this person masters",
             _serializer=AttributeSerializer("name"),
             deserializer=FindByNameDeserializerList(Language),
-            example=["eng", "fra", "spa"],
+            example=["Catalan", "Spanish", "English"],
             default_factory_pydantic=list,
         )
 

--- a/src/database/model/educational_resource/educational_resource.py
+++ b/src/database/model/educational_resource/educational_resource.py
@@ -87,6 +87,11 @@ class EducationalResource(EducationalResourceBase, AIResource, table=True):  # t
             from_identifier_type=str,
         )
     )
+    required_competency_level_identifier: int | None = Field(
+        foreign_key=f"{EducationalCompetency.__tablename__}.identifier",
+        description="The required competency level for engaging with this resource.",
+    )
+    required_competency_level: EducationalCompetency | None = Relationship()  # type: ignore[valid-type]
     in_language: list[Language] = Relationship(  # type: ignore[valid-type]
         link_model=many_to_many_link_factory(
             table_from="educational_resource",
@@ -147,14 +152,21 @@ class EducationalResource(EducationalResourceBase, AIResource, table=True):  # t
             description="The level or levels of education for which this resource is intended.",
             _serializer=AttributeSerializer("name"),
             deserializer=FindByNameDeserializerList(EducationalLevel),
-            example=["primary school", "secondary school", "university"],
+            example=["Bachelor’s or equivalent level", "primary education"],
             default_factory_pydantic=list,
+        )
+        required_competency_level: Optional[str] = ManyToOne(
+            description="The required competency level for engaging with this resource.",
+            identifier_name="required_competency_level_identifier",
+            _serializer=AttributeSerializer("name"),
+            deserializer=FindByNameDeserializer(EducationalCompetency),
+            example="intermediate",
         )
         in_language: list[str] = ManyToMany(
             description="The language(s) of the educational resource, in ISO639-3.",
             _serializer=AttributeSerializer("name"),
             deserializer=FindByNameDeserializerList(Language),
-            example=["eng", "fra", "spa"],
+            example=["Catalan"],
             default_factory_pydantic=list,
         )
         location: list[Location] = ManyToMany(

--- a/src/tests/database/model/dataset/test_dataset_delete.py
+++ b/src/tests/database/model/dataset/test_dataset_delete.py
@@ -2,7 +2,7 @@ from sqlmodel import select
 from starlette.testclient import TestClient
 
 from database.model.agent.agent_table import AgentTable
-from database.model.agent.location import LocationORM, AddressORM, GeoORM
+from database.model.agent.location import LocationORM, AddressORM, GeoORM, Country
 from database.model.ai_asset.ai_asset_table import AIAssetTable
 from database.model.dataset.dataset import Dataset
 from database.model.dataset.size import DatasetSizeORM
@@ -15,7 +15,7 @@ def test_happy_path(client: TestClient):
         ai_asset_identifier=AIAssetTable(type="dataset"),
         name="dataset 1",
         spatial_coverage=LocationORM(
-            address=AddressORM(country="BEL"), geo=GeoORM(latitude=37.42242, longitude=-122.08585)
+            address=AddressORM(country=Country(name="Belgium")), geo=GeoORM(latitude=37.42242, longitude=-122.08585)
         ),
         size=DatasetSizeORM(unit="number of rows", value=10),
         funder=[AgentTable(type="person")],

--- a/src/tests/routers/generic/test_router_post.py
+++ b/src/tests/routers/generic/test_router_post.py
@@ -10,6 +10,7 @@ from tests.routers.resource_routers.test_router_organisation import with_organis
 from database.model.platform.platform_names import PlatformName
 from database.model.resource_read_and_create import resource_create
 from routers import resource_routers
+from versioning import Version
 
 
 @pytest.mark.parametrize(
@@ -254,9 +255,10 @@ def test_taxonomy_is_not_enforced_for_connector(
         assert response.status_code == HTTPStatus.OK, response.json()
 
 
+@pytest.mark.versions(Version.LATEST)
 @pytest.mark.parametrize(
     "router",
-    tested_routers := [r for r in resource_routers.router_list if r.resource_name != 'platform'],
+    tested_routers := [r for r in resource_routers.versioned_routers[Version.LATEST] if r.resource_name != 'platform'],
     ids=map(lambda r: r.resource_name, tested_routers),
 )
 def test_example_is_valid(router, client: TestClient, with_organisation_taxonomies):

--- a/src/tests/routers/resource_routers/test_router_contact.py
+++ b/src/tests/routers/resource_routers/test_router_contact.py
@@ -27,7 +27,7 @@ def test_happy_path(client: TestClient, body_asset: dict, auto_publish: None):
     body["telephone"] = ["0032 xxxx xxxx"]
     body["location"] = [
         {
-            "address": {"country": "NED", "street": "Street Name 10", "postal_code": "1234AB"},
+            "address": {"country": "Spain", "street": "Street Name 10", "postal_code": "1234AB"},
             "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},
         }
     ]
@@ -48,7 +48,7 @@ def test_happy_path(client: TestClient, body_asset: dict, auto_publish: None):
     assert response_json["telephone"] == ["0032 xxxx xxxx"]
     assert response_json["location"] == [
         {
-            "address": {"country": "NED", "street": "Street Name 10", "postal_code": "1234AB"},
+            "address": {"country": "Spain", "street": "Street Name 10", "postal_code": "1234AB"},
             "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},
         }
     ]

--- a/src/tests/routers/resource_routers/test_router_dataset.py
+++ b/src/tests/routers/resource_routers/test_router_dataset.py
@@ -28,7 +28,7 @@ def test_happy_path(
     body["funder"] = [person.identifier]
     body["size"] = {"unit": "Rows", "value": "100"}
     body["spatial_coverage"] = {
-        "address": {"country": "NED", "street": "Street Name 10", "postal_code": "1234AB"},
+        "address": {"country": "Spain", "street": "Street Name 10", "postal_code": "1234AB"},
         "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},
     }
 
@@ -48,7 +48,7 @@ def test_happy_path(
     assert response_json["funder"] == [person.identifier]
     assert response_json["size"] == {"unit": "Rows", "value": 100}
     assert response_json["spatial_coverage"] == {
-        "address": {"country": "NED", "street": "Street Name 10", "postal_code": "1234AB"},
+        "address": {"country": "Spain", "street": "Street Name 10", "postal_code": "1234AB"},
         "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},
     }
     # TODO: test delete

--- a/src/tests/routers/resource_routers/test_router_educational_resource.py
+++ b/src/tests/routers/resource_routers/test_router_educational_resource.py
@@ -19,7 +19,7 @@ def test_happy_path(
     body["in_language"] = ["nld", "eng"]
     locations = [
         {
-            "address": {"country": "NED", "street": "Street Name 10", "postal_code": "1234AB"},
+            "address": {"country": "Spain", "street": "Street Name 10", "postal_code": "1234AB"},
         },
         {
             "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},

--- a/src/tests/routers/resource_routers/test_router_event.py
+++ b/src/tests/routers/resource_routers/test_router_event.py
@@ -31,7 +31,7 @@ def test_happy_path(
     body["mode"] = "offline"
     locations = [
         {
-            "address": {"country": "NED", "street": "Street Name 10", "postal_code": "1234AB"},
+            "address": {"country": "Spain", "street": "Street Name 10", "postal_code": "1234AB"},
         },
         {
             "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},

--- a/src/tests/routers/resource_routers/test_router_organisation.py
+++ b/src/tests/routers/resource_routers/test_router_organisation.py
@@ -53,7 +53,7 @@ def test_happy_path(
     body["date_founded"] = "2023-01-01"
     body["legal_name"] = "A name for the organisation"
     body["ai_relevance"] = "Part of CLAIRE"
-    body["type"] = "Research Institute"
+    body["type"] = "Research University"
     body["turnover"] = "<1 million euros"
     with DbSession() as session:
         session.add(organisation)  # The new organisation will be a member of this organisation
@@ -79,7 +79,7 @@ def test_happy_path(
     assert response_json["date_founded"] == "2023-01-01"
     assert response_json["legal_name"] == "A name for the organisation"
     assert response_json["ai_relevance"] == "Part of CLAIRE"
-    assert response_json["type"] == "research institute"
+    assert response_json["type"] == "research university"
     assert response_json["turnover"] == "<1 million euros"
     assert response_json["member"] == body["member"]
     assert response_json["contact_details"] == body["contact_details"]

--- a/src/tests/routers/resource_routers/test_router_organisation.py
+++ b/src/tests/routers/resource_routers/test_router_organisation.py
@@ -88,7 +88,7 @@ def test_happy_path(
     assert response_json["contacts"][0]["email"] == ["a@b.com"]
     assert response_json["contacts"][0]["location"] == [
         {
-            "address": {"country": "NED", "street": "Street Name 10", "postal_code": "1234AB"},
+            "address": {"country": "Spain", "street": "Street Name 10", "postal_code": "1234AB"},
             "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},
         }
     ]

--- a/src/tests/testutils/default_instances.py
+++ b/src/tests/testutils/default_instances.py
@@ -103,7 +103,7 @@ def contact(body_concept, engine: Engine) -> Contact:
     body["telephone"] = ["0032 XXXX XXXX"]
     body["location"] = [
         {
-            "address": {"country": "NED", "street": "Street Name 10", "postal_code": "1234AB"},
+            "address": {"country": "Spain", "street": "Street Name 10", "postal_code": "1234AB"},
             "geo": {"latitude": 37.42242, "longitude": -122.08585, "elevation_millimeters": 2000},
         }
     ]

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -29,7 +29,8 @@ from database.model.news.news_category import NewsCategory
 from database.model.agent.organisation import OrganisationType
 from database.model.event.event import EventMode, EventStatus
 from database.model.agent.language import Language
-from database.model.educational_resource.educational_resource import EducationalLevel
+from database.model.educational_resource.educational_resource import EducationalLevel, \
+    EducationalCompetency
 from tests.testutils.test_resource import RouterTestResource, factory_test_resource
 from tests.testutils.users import bypass_reviewer_publish_everything
 from taxonomies.synchronize_taxonomy import Term
@@ -65,7 +66,7 @@ DEFAULT_LICENSE = [
     Term("CC-BY-4.0", "for use in tests", children=[]),
 ]
 DEFAULT_ORGANISATION_TYPE = [
-    Term("research institute", "for use in tests", children=[]),
+    Term("research university", "for use in tests", children=[]),
     Term("association", "for use in tests", children=[]),
 ]
 DEFAULT_EVENT_MODE = [
@@ -77,10 +78,18 @@ DEFAULT_EVENT_STATUS = [
 DEFAULT_LANGUAGE = [
     Term("nld","for use in tests", children=[]),
     Term("eng","for use in tests", children=[]),
+    Term("English","for use in tests", children=[]),
+    Term("Catalan","for use in tests", children=[]),
+    Term("Spanish","for use in tests", children=[]),
 ]
 DEFAULT_EDUCATIONAL_LEVEL = [
     Term("university","for use in tests", children=[]),
     Term("secondary school","for use in tests", children=[]),
+    Term("primary education","for use in tests", children=[]),
+    Term("Bachelor’s or equivalent level","for use in tests", children=[]),
+]
+DEFAULT_EDUCATIONAL_COMPETENCY = [
+    Term("intermediate","for use in tests", children=[]),
 ]
 DEFAULT_COUNTRY = [
     Term("NLD", "for use in tests", children=[])
@@ -143,6 +152,7 @@ def clear_db(request, engine: Engine):
             (EventStatus, DEFAULT_EVENT_STATUS),
             (Language, DEFAULT_LANGUAGE),
             (EducationalLevel, DEFAULT_EDUCATIONAL_LEVEL),
+            (EducationalCompetency, DEFAULT_EDUCATIONAL_COMPETENCY),
         ]:
             for term in terms:
                 session.add(taxonomy(**term._asdict(), official=True))

--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -31,6 +31,7 @@ from database.model.event.event import EventMode, EventStatus
 from database.model.agent.language import Language
 from database.model.educational_resource.educational_resource import EducationalLevel, \
     EducationalCompetency
+from database.model.agent.location import Country
 from tests.testutils.test_resource import RouterTestResource, factory_test_resource
 from tests.testutils.users import bypass_reviewer_publish_everything
 from taxonomies.synchronize_taxonomy import Term
@@ -92,7 +93,7 @@ DEFAULT_EDUCATIONAL_COMPETENCY = [
     Term("intermediate","for use in tests", children=[]),
 ]
 DEFAULT_COUNTRY = [
-    Term("NLD", "for use in tests", children=[])
+    Term("Spain", "for use in tests", children=[])
 ]
 
 @pytest.fixture(scope="session")
@@ -153,6 +154,7 @@ def clear_db(request, engine: Engine):
             (Language, DEFAULT_LANGUAGE),
             (EducationalLevel, DEFAULT_EDUCATIONAL_LEVEL),
             (EducationalCompetency, DEFAULT_EDUCATIONAL_COMPETENCY),
+            (Country, DEFAULT_COUNTRY),
         ]:
             for term in terms:
                 session.add(taxonomy(**term._asdict(), official=True))


### PR DESCRIPTION
<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


Work in progress: 
 - [x] Add `required_educational_competency`
 - [x] Enforce use of `Country` taxonomy
 - [x] Add migration script

## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Changed<!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Interface<!-- Documentation/Interface/Internal/Other -->

Changelog Entry: <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->

Added `required_educational_competency` to Educational Resources, enforce the use of `Country` taxonomy.
<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Please try to migrate a database with populated data.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Closes #604 