### PR TITLE
 OpenAPI spec's `server` now works behind a (single) proxy.

### DIFF
--- a/docs/hosting/proxy.md
+++ b/docs/hosting/proxy.md
@@ -28,3 +28,11 @@ Here are examples on how to configure a proxy with the `/aiod` prefix and add th
         }
     }
     ```
+
+!!! warning "Multiple Proxies"
+
+    The REST API is not tested under multiple sequential or parallel proxies at the same time.
+    For sequential proxies, so long as the `x-forwarded-prefix` is preserved and augmented to represent each layer,
+    the REST API probably will work fine. For 'parallel' proxies (e.g., exposing the service both on `/aiod` and `/rest`)
+    the API likely remains functional, but the OpenAPI spec (and thus swagger pages) will only work for the one which is
+    requested first (see versioning.py::add_version_to_openapi).

--- a/src/versioning.py
+++ b/src/versioning.py
@@ -96,18 +96,25 @@ def add_version_to_openapi(versioned_api: FastAPI):
     else:
         version_prefix = f"/{versioned_api.version}"
 
+    # custom_openapi does not have access to the `request` information which
+    # details whether or not the application is behind a proxy (which has to
+    # be configured with a special header). But because `swagger` or `redoc`
+    # pages are called before they internally call `custom_openapi`, we relay
+    # the information through this variable. This does not work if the same app
+    # is hosted under different paths at the same time (the OpenAPI schema is
+    # only generated the first request). We could regenerate it every time,
+    # but this would still introduce a race-condition when multiple people call
+    # the swagger/redoc pages concurrently from different proxies.
+    root_path = ""
+
     def custom_openapi():
         if versioned_api.openapi_schema:
             return versioned_api.openapi_schema
         schema = versioned_api._openapi()
 
-        # We edit the servers instead of dropping them to preserve information
-        # on the root_path and hostname.
-        for server in schema.get("servers", []):
-            server["url"] = server["url"].removesuffix(version_prefix)
-        # If everything is simply relative to the hostname, then we can drop the
-        # server information, which ensures there isn't an empty dropdown menu.
-        if schema.get("servers", []) == [{"url": ""}]:
+        if root_path:
+            schema["servers"] = [{"url": root_path}]
+        elif "servers" in schema:
             del schema["servers"]
 
         versioned_api.openapi_schema = schema
@@ -128,6 +135,7 @@ def add_version_to_openapi(versioned_api: FastAPI):
     versioned_api.openapi = custom_openapi
 
     def overridden_swagger(request: Request):
+        nonlocal root_path
         root_path = request.headers.get("x-forwarded-prefix", "")
         show_versions = {"latest": f"{root_path}/docs"} | {
             version: f"{root_path}/{version}/docs"
@@ -161,6 +169,7 @@ def add_version_to_openapi(versioned_api: FastAPI):
     )
 
     def overridden_redoc(request: Request):
+        nonlocal root_path
         root_path = request.headers.get("x-forwarded-prefix", "")
         html = get_redoc_html(
             openapi_url=f"{root_path}{version_prefix}/openapi.json",


### PR DESCRIPTION
## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Fixed <!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Documentation <!-- Documentation/Interface/Internal/Other -->

Changelog Entry: <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->

OpenAPI spec's `server` now works behind a (single) proxy.
<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Code review is probably enough. If you want to try it, put the app behind a proxy (e.g., following the documentation and our nginx router) and try out the swagger pages. Without the patch, the swagger will page generates correctly but the calls will direct to `hostname` without the path suffix of the proxy. With the patch, it will correctly direct to `hostname/suffix`.

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
