### PR TITLE
Fix an issue that would crash the synchronization of a taxonomy if a data migration had caused a NULL entry into the taxonomy table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "aiod_metadata_catalogue"
 description = "A Metadata Catalogue for AI on Demand "
-version = "2.0.20250929"
+version = "2.0.20251003"
 requires-python = ">=3.11"
 authors = [
     { name = "Adrián Alcolea" },

--- a/src/setup_logger.py
+++ b/src/setup_logger.py
@@ -17,9 +17,9 @@ def setup_logger(config: dict | None = None):
         "Missing `log_level` setting in the [dev] section of the configuration.toml file."
     )
 
-    log_level: str = config["dev"]["log_level"]
+    log_level: str = config["dev"]["log_level"].upper()
     levels = logging.getLevelNamesMapping()
-    assert isinstance(log_level, str) and log_level.upper() in levels, (
+    assert isinstance(log_level, str) and log_level in levels, (
         f"The `dev.log_level` is set to {log_level!r} but should be one of {set(levels)!r}."
     )
 

--- a/src/taxonomies/synchronize_taxonomy.py
+++ b/src/taxonomies/synchronize_taxonomy.py
@@ -114,7 +114,9 @@ def synchronize(
     logging.info(f"Updating {taxonomy_type.__tablename__!r}")
     # We first invalidate everything, so only what is still in the file will remain 'official'
     db_definitions = {
-        term.name.casefold(): term for term in session.scalars(select(taxonomy_type)).all()
+        term.name.casefold(): term
+        for term in session.scalars(select(taxonomy_type)).all()
+        if term.name  # Due to migrations there may be one term which is null, but this is never in the json
     }
     added_terms = dict()
     for term_object in db_definitions.values():


### PR DESCRIPTION
<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type:Fixed <!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category:Internal <!-- Documentation/Interface/Internal/Other -->

Changelog Entry: <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->
Fix an issue that would crash the synchronization of a taxonomy if a data migration had caused a NULL entry into the taxonomy table. 

Since the `null` term is never present in the JSON file, it's fine if it is not present in `db_definitions` since it is never synced.
<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Quick review is fine.

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
