### PR TITLE
Extended the maximum length of a relevant_link of AI resources from 256 characters to 2000 characters.

### DIFF
--- a/alembic/alembic/versions/19f12fe539c7_extend_url.py
+++ b/alembic/alembic/versions/19f12fe539c7_extend_url.py
@@ -1,0 +1,49 @@
+"""extend-url
+
+Revision ID: 19f12fe539c7
+Revises: eb4e8cf555d9
+Create Date: 2025-10-05 06:14:48.308493
+
+"""
+
+import logging
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import String
+
+logger = logging.getLogger("alembic")
+
+# revision identifiers, used by Alembic.
+revision: str = "19f12fe539c7"
+down_revision: Union[str, None] = "eb4e8cf555d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    logger.info("Removing check constraint")
+    op.drop_constraint(
+        constraint_name="RelevantLink_name_lowercase",
+        table_name="relevant_link",
+        type_="check",
+    )
+    logger.info("Removing unique constraint")
+    op.drop_constraint(
+        constraint_name="ix_relevant_link_name",
+        table_name="relevant_link",
+        type_="unique",
+    )
+    logger.info("Updating Column")
+    op.alter_column(
+        table_name="relevant_link",
+        column_name="name",
+        type_=String(length=2000),
+        existing_nullable=True,
+        existing_server_default=None,
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/docs/developer/schema/attributes.md
+++ b/docs/developer/schema/attributes.md
@@ -34,6 +34,8 @@ Adding an attribute to an asset requires three things:
 
 This guide will discuss them in order, using the example of adding a `source` attribute to the `News` asset (see also [pull request](https://github.com/aiondemand/AIOD-rest-api/pull/395)).
 
+Updating an existing column/attribute follows similar steps, see for example this [pull request](https://github.com/aiondemand/AIOD-rest-api/pull/635).
+
 ### Updating the schema in Python
 
 Navigate to the asset definition you want to change. For simple attributes this is the class that ends in "Base", e.g., "NewsBase". There, add the attribute and define its metadata through adding type hints and setting it to a [SQLModel Field](https://sqlmodel.tiangolo.com/tutorial/create-db-and-table/#define-the-fields-columns). There are already examples in the code base of many different types of constraints (e.g., string minimum or maximum lengths, specifying defaults, and so on).

--- a/src/database/model/ai_resource/relevantlink.py
+++ b/src/database/model/ai_resource/relevantlink.py
@@ -1,7 +1,21 @@
-from database.model.named_relation import NamedRelation
+from sqlalchemy import Column, String
+from sqlmodel import SQLModel, Field
+
+MAX_URL_LENGTH = 2000
 
 
-class RelevantLink(NamedRelation, table=True):  # type: ignore [call-arg]
+# Unlike NamedRelation, URLs are:
+#  - generally unique
+#  - potentially much longer than the default 256 character limit
+#  - case sensitive
+class RelevantLink(SQLModel, table=True):  # type: ignore [call-arg]
     """An address of a resource on the web"""
 
     __tablename__ = "relevant_link"
+    identifier: int = Field(default=None, primary_key=True)
+    name: str = Field(
+        sa_column=Column(
+            String(length=MAX_URL_LENGTH)  # no collation: links may be case sensitive
+        ),
+        description="A URL for a page relevant to the resource.",
+    )


### PR DESCRIPTION
<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->
note: There is something to be said for updating the migration further to reduce a many-to-many link table, and instead have a relevant_link table per asset type. This should be more performant. But this works and we have more important things (we can always measure what performance imapct this has, but I reckon not so much -- in any case no worse than what already was).


## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Changed<!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Interface<!-- Documentation/Interface/Internal/Other -->

Changelog Entry: <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->
Extended the maximum length of a `relevant_link` of AI resources from 256 characters to [2000 characters](https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers).
<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
