### PR TITLE
Set defaults for `ADMIN` and `REVIEWER` roles

### DIFF
--- a/src/authentication.py
+++ b/src/authentication.py
@@ -35,8 +35,8 @@ load_dotenv()
 
 oidc = OpenIdConnect(openIdConnectUrl=KEYCLOAK_CONFIG.get("openid_connect_url"), auto_error=False)
 
-REVIEWER_ROLE = os.getenv("REVIEWER_ROLE_NAME")
-ADMIN_ROLE = os.getenv("ADMIN_ROLE_NAME")
+REVIEWER_ROLE = os.getenv("REVIEWER_ROLE_NAME", "review_aiod_resources")
+ADMIN_ROLE = os.getenv("ADMIN_ROLE_NAME", "admin_aiod_resources")
 client_secret = os.getenv("KEYCLOAK_CLIENT_SECRET")
 
 keycloak_openid = KeycloakOpenID(

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import os
 import pathlib
 import tomllib
 from collections import deque
@@ -12,11 +13,13 @@ from typing import Any, Sequence
 _log_lines: deque[tuple[int, str]] = deque()
 logger = logging.getLogger(__file__)
 
+_log_lines.append((logging.INFO, f"REVIEWER_ROLE_NAME={os.getenv('REVIEWER_ROLE_NAME')}"))
+_log_lines.append((logging.INFO, f"ADMIN_ROLE_NAME={os.getenv('ADMIN_ROLE_NAME')}"))
+
 default_config_path = pathlib.Path(__file__).parent / "config.default.toml"
 with open(default_config_path, "rb") as fh:
     DEFAULT_CONFIG = tomllib.load(fh)
     _log_lines.append((logging.INFO, f"Loaded default configuration from {default_config_path}"))
-    logger.info("Actually Foo")
 
 OVERRIDE_CONFIG_PATH = pathlib.Path(__file__).parent / "config.override.toml"
 if OVERRIDE_CONFIG_PATH.exists() and OVERRIDE_CONFIG_PATH.is_file():


### PR DESCRIPTION

## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Fixed<!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Internal<!-- Documentation/Interface/Internal/Other -->

Changelog Entry: Set defaults for `ADMIN` and `REVIEWER` roles



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Covered by CI: the docker CI failed without it because both were not set and thus resulted in `None` being the token for either role. Which made every reviewer an admin and vice versa. See https://github.com/aiondemand/AIOD-rest-api/actions/runs/18935726469

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
