### PR TITLE
Users can now update assets with attached media that contains images.

### DIFF
--- a/src/database/model/ai_asset/distribution.py
+++ b/src/database/model/ai_asset/distribution.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Type
 
 from fastapi.encoders import jsonable_encoder
-from pydantic import create_model
+from pydantic import create_model, validator
 from sqlalchemy import Column, ForeignKey, String, LargeBinary
 from sqlmodel import Field
 
@@ -63,6 +63,14 @@ class DistributionBase(AIoDConceptBase):
         ),
         sa_column=Column(LargeBinary),
     )
+
+    @validator("binary_blob", pre=True, always=True)
+    def decode_string_to_bytes(cls, v) -> bytes | None:
+        if v is None or isinstance(v, bytes):
+            return v
+        if not isinstance(v, str):
+            raise TypeError("`binary_blob` can only be bytes, str, or None.")
+        return base64.b64decode(v)
 
     def dict(self, *args, **kwargs):
         # Defining it as a `Config` does not work for some reason.

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -545,7 +545,16 @@ class ResourceRouter(abc.ABC):
                 try:
                     resource: Any = self._retrieve_resource(session, identifier)
                     if not user.is_connector:
-                        _raise_if_contains_binary_blob(resource_create_instance)
+                        if hasattr(resource_create_instance, "media"):
+                            if not resource_create_instance.media:  # type: ignore[attr-defined]
+                                # This does create the problem that a user cannot remove all media through this endpoint :/
+                                resource_create_instance.media = resource.media  # type: ignore[attr-defined]
+                            elif set(m.binary_blob for m in resource_create_instance.media) != set(  # type: ignore[attr-defined]
+                                m.binary_blob for m in resource.media
+                            ):
+                                _raise_if_contains_binary_blob(resource_create_instance)
+                        else:
+                            _raise_if_contains_binary_blob(resource_create_instance)
                     if not (
                         user_can_write(user, resource.aiod_entry)
                         or user.has_role(f"update_{self.resource_name_plural}")

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -544,7 +544,8 @@ class ResourceRouter(abc.ABC):
             with DbSession() as session:
                 try:
                     resource: Any = self._retrieve_resource(session, identifier)
-                    _raise_if_contains_binary_blob(resource_create_instance)
+                    if not user.is_connector:
+                        _raise_if_contains_binary_blob(resource_create_instance)
                     if not (
                         user_can_write(user, resource.aiod_entry)
                         or user.has_role(f"update_{self.resource_name_plural}")

--- a/src/tests/routers/resource_routers/test_router_organisation.py
+++ b/src/tests/routers/resource_routers/test_router_organisation.py
@@ -160,6 +160,199 @@ def test_organisation_post_image(
         )
     assert response.status_code == HTTPStatus.OK, response.json()
 
+def test_organisation_post_image_too_large(
+    client: TestClient,
+    organisation: Organisation
+    ):
+
+    identifier = register_asset(organisation)
+
+    large_content = b"x" * (1 * 1024 * 1024 + 1)
+    large_image = io.BytesIO(large_content)
+    large_image.name = "big_logo.png"
+
+    with logged_in_user():
+        response = client.post(
+            f"/organisations/{identifier}/image",
+            params={"name": "big_logo"},
+            files={"file": ("big_logo.png", large_image, "image/png")},
+            headers={"Authorization": "Fake token"},
+        )
+
+    assert response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert response.json()["detail"] == "File too large (max 1MB)."
+
+
+def test_organisation_post_image_incorrect_type(client: TestClient, organisation: Organisation):
+
+    identifier = register_asset(organisation)
+    pdf_data = io.BytesIO(b"%PDF-1.4 test-pdf content")
+
+    with logged_in_user():
+        response = client.post(
+            f"/organisations/{identifier}/image",
+            params={"name": "wrong_logo_type"},
+            files={"file": ("wrong_logo_type.pdf", pdf_data, "application/pdf")},
+            headers={"Authorization": "Fake token"},
+        )
+
+    assert response.status_code == HTTPStatus.UNSUPPORTED_MEDIA_TYPE
+    assert response.json()["detail"] == f"Unsupported file type application/pdf. Allowed image types: {ALLOWED_IMAGE_TYPES}."
+
+
+def test_organisation_put_image(
+    client: TestClient,
+    organisation: Organisation,
+    ):
+
+    identifier = register_asset(organisation)
+
+    fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n...")  # fake PNG bytes
+    fake_image.name = "logo.png"
+
+    with logged_in_user():
+        response = client.post(
+            f"/organisations/{identifier}/image",
+            params={"name": "logo"},
+            files={"file": ("logo.png", fake_image, "image/png")},
+            headers={"Authorization": "Fake token"},
+        )
+
+        response = client.put(
+            f"/organisations/{identifier}/image",
+            params={"name": "logo"},
+            files={"file": ("logo.png", fake_image, "image/png")},
+            headers={"Authorization": "Fake token"},
+        )
+
+        assert response.status_code == HTTPStatus.OK, response.json()
+
+def test_organisation_put_image_non_existent(
+    client: TestClient,
+    organisation: Organisation,
+    ):
+
+    identifier = register_asset(organisation)
+
+    fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n...")  # fake PNG bytes
+    fake_image.name = "logo.png"
+
+    with logged_in_user():
+
+        response = client.put(
+            f"/organisations/{identifier}/image",
+            params={"name": "LOGO"},
+            files={"file": ("logo.png", fake_image, "image/png")},
+            headers={"Authorization": "Fake token"},
+        )
+        assert response.status_code == HTTPStatus.NOT_FOUND
+        assert response.json()["detail"] == "No image with the name 'LOGO' found in the database."
+
+
+@pytest.mark.parametrize("get_image", [False, True])
+def test_organisation_get_with_and_without_image(client: TestClient, organisation: Organisation, get_image: bool):
+
+    identifier = register_asset(organisation)
+
+    fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n...")  # fake PNG bytes
+    fake_image.name = "logo.png"
+
+    with logged_in_user():
+        response = client.post(
+            f"/organisations/{identifier}/image",
+            params={"name": "logo"},
+            files={"file": ("logo.png", fake_image, "image/png")},
+            headers={"Authorization": "Fake token"},
+        )
+
+    assert response.status_code == HTTPStatus.OK, response.json()
+
+    response = client.get(f"/organisations/{identifier}?get_image={str(get_image).lower()}")
+    assert response.status_code == HTTPStatus.OK
+
+    response = response.json()
+
+    if get_image:
+        assert response["media"][1]["binary_blob"]
+    else:
+        assert not response["media"][1].get("binary_blob")
+
+    assert response["media"][1]["name"] == "logo"
+    assert response["media"][1]["encoding_format"] == "image/png"
+
+
+def test_organisation_get_image(
+    client: TestClient,
+    organisation: Organisation
+    ):
+
+    identifier = register_asset(organisation)
+
+    fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n...")
+
+    with logged_in_user():
+        response = client.post(
+            f"/organisations/{identifier}/image",
+            params={"name": "logo"},
+            files={"file": ("logo.png", fake_image, "image/png")},
+            headers={"Authorization": "Fake token"},
+        )
+
+
+    response = client.get(
+        f"/organisations/{identifier}/image"
+    )
+    assert response.status_code == HTTPStatus.OK
+    response = response.json()
+    assert response[0]["binary_blob"]
+    assert response[0]["name"] == "logo"
+    assert response[0]["encoding_format"] == "image/png"
+
+
+def test_organisation_get_image_non_existent(
+    client: TestClient,
+    organisation: Organisation,
+    ):
+
+    identifier = register_asset(organisation)
+    response = client.get(
+        f"/organisations/{identifier}/image"
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == []
+
+
+def test_organisation_delete_image(
+    client: TestClient,
+    organisation: Organisation
+    ):
+
+    identifier = register_asset(organisation)
+    fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n...")
+
+    with logged_in_user():
+        response = client.post(
+            f"/organisations/{identifier}/image",
+            params={"name": "logo"},
+            files={"file": ("logo.png", fake_image, "image/png")},
+            headers={"Authorization": "Fake token"},
+        )
+
+        response = client.delete(
+            f"/organisations/{identifier}/image",
+            params={"name": "logo"},
+            headers={"Authorization": "Fake token"},
+        )
+        assert response.status_code == HTTPStatus.OK
+
+        second_delete_response = client.delete(
+            f"/organisations/{identifier}/image",
+            params={"name": "logo"},
+            headers={"Authorization": "Fake token"},
+        )
+        assert second_delete_response.status_code == HTTPStatus.NOT_FOUND
+        assert "No image with the name" in second_delete_response.json()["detail"]
+
 
 def test_organisation_put_without_media_keeps_media(
         client: TestClient,

--- a/src/tests/routers/resource_routers/test_router_organisation.py
+++ b/src/tests/routers/resource_routers/test_router_organisation.py
@@ -1,6 +1,7 @@
 import copy
 from unittest.mock import Mock
 
+from fastapi.encoders import jsonable_encoder
 from starlette.testclient import TestClient
 
 from database.model.agent.contact import Contact
@@ -159,51 +160,12 @@ def test_organisation_post_image(
         )
     assert response.status_code == HTTPStatus.OK, response.json()
 
-def test_organisation_post_image_too_large(
-    client: TestClient,
-    organisation: Organisation
-    ):
 
-    identifier = register_asset(organisation)
-
-    large_content = b"x" * (1 * 1024 * 1024 + 1)
-    large_image = io.BytesIO(large_content)
-    large_image.name = "big_logo.png"
-
-    with logged_in_user():
-        response = client.post(
-            f"/organisations/{identifier}/image",
-            params={"name": "big_logo"},
-            files={"file": ("big_logo.png", large_image, "image/png")},
-            headers={"Authorization": "Fake token"},
-        )
-
-    assert response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
-    assert response.json()["detail"] == "File too large (max 1MB)."
-
-
-def test_organisation_post_image_incorrect_type(client: TestClient, organisation: Organisation):
-
-    identifier = register_asset(organisation)
-    pdf_data = io.BytesIO(b"%PDF-1.4 test-pdf content")
-
-    with logged_in_user():
-        response = client.post(
-            f"/organisations/{identifier}/image",
-            params={"name": "wrong_logo_type"},
-            files={"file": ("wrong_logo_type.pdf", pdf_data, "application/pdf")},
-            headers={"Authorization": "Fake token"},
-        )
-
-    assert response.status_code == HTTPStatus.UNSUPPORTED_MEDIA_TYPE
-    assert response.json()["detail"] == f"Unsupported file type application/pdf. Allowed image types: {ALLOWED_IMAGE_TYPES}."
-
-
-def test_organisation_put_image(
-    client: TestClient,
-    organisation: Organisation,
-    ):
-
+def test_organisation_put_without_media_keeps_media(
+        client: TestClient,
+        organisation: Organisation,
+):
+    organisation.media = []
     identifier = register_asset(organisation)
 
     fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n...")  # fake PNG bytes
@@ -216,41 +178,29 @@ def test_organisation_put_image(
             files={"file": ("logo.png", fake_image, "image/png")},
             headers={"Authorization": "Fake token"},
         )
-
-        response = client.put(
-            f"/organisations/{identifier}/image",
-            params={"name": "logo"},
-            files={"file": ("logo.png", fake_image, "image/png")},
-            headers={"Authorization": "Fake token"},
-        )
-
         assert response.status_code == HTTPStatus.OK, response.json()
 
-def test_organisation_put_image_non_existent(
-    client: TestClient,
-    organisation: Organisation,
-    ):
-
-    identifier = register_asset(organisation)
-
-    fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n...")  # fake PNG bytes
-    fake_image.name = "logo.png"
-
-    with logged_in_user():
-
+        organisation.name = "new name"
         response = client.put(
-            f"/organisations/{identifier}/image",
-            params={"name": "LOGO"},
-            files={"file": ("logo.png", fake_image, "image/png")},
+            f"/organisations/{identifier}",
+            json=jsonable_encoder(organisation.dict()),
             headers={"Authorization": "Fake token"},
         )
-        assert response.status_code == HTTPStatus.NOT_FOUND
-        assert response.json()["detail"] == "No image with the name 'LOGO' found in the database."
+        assert response.status_code == HTTPStatus.OK, response.json()
+        response = client.get(
+            f"/organisations/{identifier}",
+            headers={"Authorization": "Fake token"},
+        )
+        assert response.status_code == HTTPStatus.OK, response.json()
+        assert response.json()["name"] == "new name", response.json()
+        assert response.json()["media"], response.json()
 
 
-@pytest.mark.parametrize("get_image", [False, True])
-def test_organisation_get_with_and_without_image(client: TestClient, organisation: Organisation, get_image: bool):
-
+def test_organisation_put_with_media_keeps_media_if_no_new_binary(
+        client: TestClient,
+        organisation: Organisation,
+):
+    organisation.media = []
     identifier = register_asset(organisation)
 
     fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n...")  # fake PNG bytes
@@ -263,91 +213,28 @@ def test_organisation_get_with_and_without_image(client: TestClient, organisatio
             files={"file": ("logo.png", fake_image, "image/png")},
             headers={"Authorization": "Fake token"},
         )
+        assert response.status_code == HTTPStatus.OK, response.json()
 
-    assert response.status_code == HTTPStatus.OK, response.json()
-
-    response = client.get(f"/organisations/{identifier}?get_image={str(get_image).lower()}")
-    assert response.status_code == HTTPStatus.OK
-
-    response = response.json()
-
-    if get_image:
-        assert response["media"][1]["binary_blob"]
-    else:
-        assert not response["media"][1].get("binary_blob")
-
-    assert response["media"][1]["name"] == "logo"
-    assert response["media"][1]["encoding_format"] == "image/png"
-
-
-def test_organisation_get_image(
-    client: TestClient,
-    organisation: Organisation
-    ):
-
-    identifier = register_asset(organisation)
-
-    fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n...")
-
-    with logged_in_user():
-        response = client.post(
-            f"/organisations/{identifier}/image",
-            params={"name": "logo"},
-            files={"file": ("logo.png", fake_image, "image/png")},
+        response = client.get(
+            f"/organisations/{identifier}?get_image=true",
             headers={"Authorization": "Fake token"},
         )
-
-
-    response = client.get(
-        f"/organisations/{identifier}/image"
-    )
-    assert response.status_code == HTTPStatus.OK
-    response = response.json()
-    assert response[0]["binary_blob"]
-    assert response[0]["name"] == "logo"
-    assert response[0]["encoding_format"] == "image/png"
-
-
-def test_organisation_get_image_non_existent(
-    client: TestClient,
-    organisation: Organisation,
-    ):
-
-    identifier = register_asset(organisation)
-    response = client.get(
-        f"/organisations/{identifier}/image"
-    )
-    assert response.status_code == HTTPStatus.OK
-    assert response.json() == []
-
-
-def test_organisation_delete_image(
-    client: TestClient,
-    organisation: Organisation
-    ):
-
-    identifier = register_asset(organisation)
-    fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n...")
-
-    with logged_in_user():
-        response = client.post(
-            f"/organisations/{identifier}/image",
-            params={"name": "logo"},
-            files={"file": ("logo.png", fake_image, "image/png")},
+        org = response.json()
+        del org["aiod_entry"]
+        org["media"].append(
+            {"name": "foo", "binary_blob": "bar="},
+        )
+        response = client.put(
+            f"/organisations/{identifier}",
+            json=org,
             headers={"Authorization": "Fake token"},
         )
+        assert response.status_code == HTTPStatus.BAD_REQUEST, "No new binary may be added through a PUT request"
 
-        response = client.delete(
-            f"/organisations/{identifier}/image",
-            params={"name": "logo"},
+        org["media"].pop()
+        response = client.put(
+            f"/organisations/{identifier}",
+            json=org,
             headers={"Authorization": "Fake token"},
         )
-        assert response.status_code == HTTPStatus.OK
-
-        second_delete_response = client.delete(
-            f"/organisations/{identifier}/image",
-            params={"name": "logo"},
-            headers={"Authorization": "Fake token"},
-        )
-        assert second_delete_response.status_code == HTTPStatus.NOT_FOUND
-        assert "No image with the name" in second_delete_response.json()["detail"]
+        assert response.status_code == HTTPStatus.OK, response.json()


### PR DESCRIPTION
The whole handling of media assets is quite messy at this point. We should revise this. But for now I think it's OK for the hands-on sessions next week.

## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Fixed<!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Interface<!-- Documentation/Interface/Internal/Other -->

  Changelog Entry: Users can now update assets with attached media that contains images.

If you are updating an asset with binary media (e.g., an Organisation with an image), you can either:
 - leave `media` empty, in which case existing links to media are preserved.
 - specify `media` by including all linked media that has binary blobs, and _any_ media that does not. This allows you to update the content_url based media content, but not the binary blob based ones. Those can only be modified through their dedicated endpoints.



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
See unit test:
 - create an organisation
 - add an image to it
 - update the organisation (without specifying its media)

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
