### PR TITLE
fix the typo contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,7 +71,7 @@ git clone https://github.com/USERNAME/AIOD-rest-api.git
 Always make sure to install your dependencies in a local environment, for example with the built in `venv` module:
 
 ```commandline
-python -m pip venv venv
+python -m venv venv
 source venv/bin/activate
 ```
 


### PR DESCRIPTION
This pull request updates the setup instructions in the `docs/contributing.md` file to correct the command for creating a Python virtual environment.

* Documentation update:
  * Fixed the example command for creating a virtual environment by replacing `python -m pip venv venv` with the correct `python -m venv venv` usage.