### PR TITLE
Added endpoint to check for resource

### DIFF
--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -43,6 +43,10 @@ RESOURCE_READ = TypeVar("RESOURCE_READ", bound=SQLModel)
 RESOURCE_MODEL = TypeVar("RESOURCE_MODEL", bound=SQLModel)
 
 
+class ResourceExistsResponse(SQLModel):
+    exists: bool
+
+
 class ResourceRouter(abc.ABC):
     """
     Abstract class for FastAPI resource router.
@@ -168,6 +172,16 @@ class ResourceRouter(abc.ABC):
         )
 
         router.add_api_route(
+            path=f"/{self.resource_name_plural}/exists/v{self.version}/{{identifier}}",
+            endpoint=self.get_resource_exists_func(),
+            response_model=ResourceExistsResponse,
+            name=f"{self.resource_name} exists",
+            description=f"Check whether the {self.resource_name} identified by the AIoD identifier "
+            "exists.",
+            **default_kwargs,
+        )
+
+        router.add_api_route(
             path=f"/{self.resource_name_plural}/{{identifier}}",
             methods={"PUT"},
             endpoint=self.put_resource_func(),
@@ -264,17 +278,7 @@ class ResourceRouter(abc.ABC):
                     for media_obj in resource.media:
                         media_obj.binary_blob = None
 
-                if resource.aiod_entry.status != EntryStatus.PUBLISHED:
-                    if user is None:
-                        raise HTTPException(
-                            status_code=HTTPStatus.UNAUTHORIZED,
-                            detail="This asset is not published. It requires authentication to access.",
-                        )
-                    if not user_can_read(user, resource.aiod_entry):
-                        raise HTTPException(
-                            status_code=HTTPStatus.FORBIDDEN,
-                            detail="You are not allowed to view this resource.",
-                        )
+                self._ensure_resource_is_accessible(resource, user)
 
                 if schema != "aiod":
                     return self.schema_converters[schema].convert(session, resource)
@@ -409,6 +413,21 @@ class ResourceRouter(abc.ABC):
 
         return get_resource
 
+    def get_resource_exists_func(self):
+        """
+        Returns a function that can be used to check whether a resource exists.
+        """
+
+        def resource_exists(
+            identifier: str,
+            user: KeycloakUser | None = Depends(get_user_or_none),
+        ) -> ResourceExistsResponse:
+            self._raise_if_identifier_is_wrong_type(identifier)
+            exists = self.resource_exists(identifier=identifier, user=user, platform=None)
+            return ResourceExistsResponse(exists=exists)
+
+        return resource_exists
+
     def _raise_if_identifier_is_wrong_type(self, identifier: str):
         if not identifier.startswith(self.resource_class.__abbreviation__):
             hint = ""
@@ -422,6 +441,21 @@ class ResourceRouter(abc.ABC):
                     f"{self.resource_class.__abbreviation__!r}." + hint
                 ),
             )
+
+    def _ensure_resource_is_accessible(
+        self, resource: type[RESOURCE_MODEL], user: KeycloakUser | None
+    ) -> None:
+        if resource.aiod_entry.status != EntryStatus.PUBLISHED:
+            if user is None:
+                raise HTTPException(
+                    status_code=HTTPStatus.UNAUTHORIZED,
+                    detail="This asset is not published. It requires authentication to access.",
+                )
+            if not user_can_read(user, resource.aiod_entry):
+                raise HTTPException(
+                    status_code=HTTPStatus.FORBIDDEN,
+                    detail="You are not allowed to view this resource.",
+                )
 
     def get_platform_resource_func(self):
         """
@@ -510,6 +544,26 @@ class ResourceRouter(abc.ABC):
                 raise as_http_exception(e)
 
         return register_resource
+
+    def resource_exists(
+        self,
+        identifier: str,
+        user: KeycloakUser | None = None,
+        platform: str | None = None,
+    ) -> bool:
+        try:
+            with DbSession(autoflush=False) as session:
+                resource: type[RESOURCE_MODEL] = self._retrieve_resource(
+                    session, identifier, platform
+                )
+                self._ensure_resource_is_accessible(resource, user)
+                return True
+        except HTTPException as exc:
+            if exc.status_code == status.HTTP_404_NOT_FOUND:
+                return False
+            raise
+        except Exception as exc:
+            raise as_http_exception(exc)
 
     def create_resource(
         self,

--- a/src/tests/routers/generic/test_router_get.py
+++ b/src/tests/routers/generic/test_router_get.py
@@ -48,3 +48,33 @@ def test_get_draft_with_permission_is_allowed(client_test_resource: TestClient):
     with logged_in_user(ALICE):
         response = client_test_resource.get(f"/test_resources/{identifier}", headers={"Authorization": "fake-token"})
     assert response.status_code == HTTPStatus.OK
+
+
+def test_exists_returns_true_for_published_resource(
+    client_test_resource: TestClient, engine_test_resource_filled: str
+):
+    response = client_test_resource.get(f"/test_resources/exists/v0/{engine_test_resource_filled}")
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {"exists": True}
+
+
+def test_exists_returns_false_when_resource_missing(client_test_resource: TestClient):
+    response = client_test_resource.get("/test_resources/exists/v0/test_missing")
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {"exists": False}
+
+
+def test_exists_draft_requires_authentication(client_test_resource: TestClient):
+    identifier = register_asset(factory_test_resource(), owner=ALICE, status=EntryStatus.DRAFT)
+    response = client_test_resource.get(f"/test_resources/exists/v0/{identifier}")
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.json()
+
+
+def test_exists_draft_with_permission_allowed(client_test_resource: TestClient):
+    identifier = register_asset(factory_test_resource(), owner=ALICE, status=EntryStatus.DRAFT)
+    with logged_in_user(ALICE):
+        response = client_test_resource.get(
+            f"/test_resources/exists/v0/{identifier}", headers={"Authorization": "fake-token"}
+        )
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.json() == {"exists": True}


### PR DESCRIPTION
## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Added <!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: Interface <!-- Documentation/Interface/Internal/Other -->

Changelog Entry:  Added a generic ```/{resource}s/exists/v{version}/{identifier}``` endpoint wired into every ResourceRouter so clients can cheaply check if an asset is present while still enforcing the usual publication/permission rules<!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->

<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
Covered in pytest.


## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [ ] The PR title matches the changelog entry's one-line description.

## Related Issues
#498 
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
