### PR TITLE
Remove the Masking of Personal Emails 

### DIFF
--- a/src/routers/resource_routers/contact_router.py
+++ b/src/routers/resource_routers/contact_router.py
@@ -4,7 +4,6 @@ from database.model.agent.contact import Contact, contact_versions
 from database.model.agent.email import Email
 from database.model.agent.organisation import Organisation
 from database.model.agent.person import Person
-from database.model.platform.platform_names import PlatformName
 from routers.resource_router import ResourceRouter
 
 from sqlmodel import Session
@@ -45,14 +44,9 @@ class ContactRouter(ResourceRouter):
     ) -> Sequence[type[Contact]]:
         """
         Only authenticated users can see the contact email.
-        For the old ai4europe_cms platform, only users with "full_view_ai4europe_cms_resources" role
-        can view the contact emails.
         """
         for contact in resources:
-            if not user or (
-                (contact.platform == PlatformName.ai4europe_cms)
-                and not user.has_role("full_view_ai4europe_cms_resources")
-            ):
+            if not user and contact.email:
                 contact.email = [Email(name="******")]
         return resources
 

--- a/src/routers/resource_routers/person_router.py
+++ b/src/routers/resource_routers/person_router.py
@@ -1,7 +1,6 @@
 from typing import Sequence
 from sqlmodel import Session
 from database.model.agent.person import Person, person_versions
-from database.model.platform.platform_names import PlatformName
 from routers.resource_router import ResourceRouter
 from authentication import KeycloakUser
 
@@ -28,16 +27,9 @@ class PersonRouter(ResourceRouter):
         resources: Sequence[type[Person]], session: Session, user: KeycloakUser | None
     ) -> Sequence[type[Person]]:
         """
-        For the old ai4europe_cms platform, only users with "full_view_ai4europe_cms_resources"
-        role can see the person's sensitive information.
+        Personal details are visible to all users.
+        Email addresses are handled by the ContactRouter and are only visible to authenticated users.
         """
-        for person in resources:
-            if (person.platform == PlatformName.ai4europe_cms) and not (
-                user and user.has_role("full_view_ai4europe_cms_resources")
-            ):
-                person.name = "******"
-                person.given_name = "******"
-                person.surname = "******"
         return resources
 
 

--- a/src/tests/routers/resource_routers/test_router_contact.py
+++ b/src/tests/routers/resource_routers/test_router_contact.py
@@ -6,13 +6,11 @@ from unittest.mock import Mock
 
 from starlette.testclient import TestClient
 
-from authentication import keycloak_openid
 from database.model.agent.contact import Contact
 from database.model.agent.email import Email
 from database.model.platform.platform import Platform
 from database.session import DbSession
 from tests.testutils.default_instances import _create_class_with_body
-from tests.testutils.default_sqlalchemy import AI4EUROPE_CMS_TOKEN
 from tests.testutils.users import logged_in_user
 
 
@@ -218,17 +216,8 @@ def test_email_privacy_for_ai4europe_cms(
     headers = {"Authorization": "Fake token"}
 
     endpoint = endpoint.replace("/1", f"/{contact.identifier}")
-    response = client.get(endpoint, headers=headers)
-    response_json = response.json()
-    if isinstance(response_json, list):
-        response_json = response_json[0]
 
-    assert response.status_code == 200, response_json
-    assert len(response_json) > 0, response_json
-    assert response_json["email"] == ["******"]
-
-    keycloak_openid.introspect = AI4EUROPE_CMS_TOKEN
-
+    # Test that authenticated users can see emails
     response = client.get(endpoint, headers=headers)
     response_json = response.json()
     if isinstance(response_json, list):
@@ -237,6 +226,16 @@ def test_email_privacy_for_ai4europe_cms(
     assert response.status_code == 200, response_json
     assert len(response_json) > 0, response_json
     assert response_json["email"] == ["fake@email.com", "fake2@email.com"]
+
+    # Test that unauthenticated users (guests) see masked emails
+    response = client.get(endpoint)
+    response_json = response.json()
+    if isinstance(response_json, list):
+        response_json = response_json[0]
+
+    assert response.status_code == 200, response_json
+    assert len(response_json) > 0, response_json
+    assert response_json["email"] == ["******"]
 
 
 def test_empty_country(client: TestClient, body_asset: dict, auto_publish: None):

--- a/src/tests/routers/resource_routers/test_router_person.py
+++ b/src/tests/routers/resource_routers/test_router_person.py
@@ -4,13 +4,11 @@ from unittest.mock import Mock
 import pytest
 from starlette.testclient import TestClient
 
-from authentication import keycloak_openid
 from database.model.agent.contact import Contact
 from database.model.agent.person import Person
 from database.model.agent.organisation import Organisation
 from database.model.platform.platform import Platform
 from database.session import DbSession
-from tests.testutils.default_sqlalchemy import AI4EUROPE_CMS_TOKEN
 
 
 def test_happy_path(
@@ -79,9 +77,9 @@ def test_privacy_for_ai4europe_cms(
     endpoint: str,
     auto_publish: None,
 ):
-    """Test to ensure that only authenticated users with "full_view_ai4europe_cms_resources" role
-    can visualise fields such as name, given_name and surname of a person migrated from
-    the old ai4europe_cms platform.
+    """Test to ensure that personal details (name, given_name, surname) are visible to all users,
+    including for persons migrated from the old ai4europe_cms platform.
+    Email addresses are handled by ContactRouter and are only visible to authenticated users.
     """
 
     with DbSession() as session:
@@ -99,17 +97,19 @@ def test_privacy_for_ai4europe_cms(
     headers = {"Authorization": "Fake token"}
 
     endpoint = endpoint.replace("/1", f"/{person.identifier}")
+
+    # Test that personal details are visible to authenticated users
     response = client.get(endpoint, headers=headers)
     response_json = response.json()
     response_json = [response_json] if isinstance(response_json, dict) else response_json
     assert response.status_code == 200, response_json
     for person_dict in response_json:
-        assert person_dict["name"] == "******"
-        assert person_dict["given_name"] == "******"
-        assert person_dict["surname"] == "******"
+        assert person_dict["name"] == "Joe Doe"
+        assert person_dict["given_name"] == "Joe"
+        assert person_dict["surname"] == "Doe"
 
-    keycloak_openid.introspect = AI4EUROPE_CMS_TOKEN
-    response = client.get(endpoint, headers=headers)
+    # Test that personal details are also visible to unauthenticated users (guests)
+    response = client.get(endpoint)
     response_json = response.json()
     response_json = [response_json] if isinstance(response_json, dict) else response_json
     assert response.status_code == 200, response_json


### PR DESCRIPTION

## Change(s)
Removed privacy masking for personal details from ai4europe_cms contacts and persons. Email addresses remain protected and are only visible to authenticated users.
Previously, the REST API masked personal details (name, given_name, surname) for contacts and persons imported from the
 ai4europe_cms platform. Only users with the `full_view_ai4europe_cms_resources` role could view:
  - Email addresses for contacts
  - Personal identifying information for persons
We now have permission to show these details publicly, so the special masking has been removed.

Change Type: <!-- Added/Changed/Deprecated/Removed/Fixed/Security -->
Fixed

Change Category: <!-- Documentation/Interface/Internal/Other -->
Internal

Changelog Entry: 
 ContactRouter (`src/routers/resource_routers/contact_router.py`)
  - Removed platform-specific masking for ai4europe_cms contacts
  - Email addresses now visible to **all authenticated users** (no special role required)
  - Email addresses remain **masked as `["******"]`** for unauthenticated users (guests)
  -  Contacts with no emails no longer show masked placeholder `["******"]`

  PersonRouter (`src/routers/resource_routers/person_router.py`)
  - Removed masking of personal details (name, given_name, surname)
  - Personal details now visible to **all users** (both authenticated and unauthenticated)

  ### Test Updates
  - Updated `test_email_privacy_for_ai4europe_cms` to verify:
    - Authenticated users can see real email addresses
    - Unauthenticated users see masked emails `["******"]`
  - Updated `test_privacy_for_ai4europe_cms` to verify:
    - Personal details visible to both authenticated and unauthenticated users



## How to Test
All tests are running and passing

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues

Fixes #664 
