### PR TITLE
Add REST API endpoint for role assignment

### DIFF
--- a/src/routers/user_router.py
+++ b/src/routers/user_router.py
@@ -1,15 +1,24 @@
 import datetime
+import re
 from typing import List
+from http import HTTPStatus
 
-from fastapi import APIRouter, Depends
-from pydantic import create_model, Field
+from fastapi import APIRouter, Depends, HTTPException, Body
+from pydantic import BaseModel, Field
+from pydantic import create_model
 from sqlalchemy import select
 from sqlmodel import Session
 
 from dependencies.pagination import PaginationParams
 from dependencies.sorting import SortingParams, SortDirection, Sort
 from routers.resource_routers import versioned_routers
-from authentication import KeycloakUser, get_user_or_raise
+from authentication import (
+    KeycloakUser,
+    get_user_or_raise,
+    get_user_by_username,
+    get_user_by_sub,
+    keycloak_api,
+)
 from database.authorization import Permission, PermissionType
 from database.session import get_session
 from database.model.concept.aiod_entry import AIoDEntryORM
@@ -17,6 +26,28 @@ from database.model.concept.concept import AIoDConcept
 from database.model.helper_functions import non_abstract_subclasses
 from routers.helper_functions import get_all_read_classes
 from versioning import Version
+from keycloak import KeycloakGetError, KeycloakError
+
+
+class RoleAssignmentRequest(BaseModel):
+    """Request body for assigning a Keycloak role to a user."""
+
+    user: str = Field(
+        description="Username or subject identifier of the target user.",
+        examples=["jsmith01", "4a80f256-3928-4cfa-ba66-5e22bb36fc01"],
+    )
+    role_name: str = Field(
+        description="Name of the Keycloak realm role to assign.",
+        examples=["review_aiod_resources", "admin_aiod_resources"],
+    )
+
+
+class RoleAssignmentResponse(BaseModel):
+    """Response after assigning a role to a user."""
+
+    message: str = Field(description="Confirmation message about the role assignment.")
+    user: str = Field(description="Username of the user who received the role.")
+    role_name: str = Field(description="Name of the role that was assigned.")
 
 
 def create(url_prefix: str, version: Version) -> APIRouter:
@@ -88,6 +119,107 @@ def create(url_prefix: str, version: Version) -> APIRouter:
             )
             for asset_name, assets in resources.items()
         }
+
+    @router.post(
+        "/user/roles",
+        tags=["User"],
+        description="Assign a Keycloak role to a user. Requires admin permissions.",
+        response_model=RoleAssignmentResponse,
+    )
+    def assign_role(
+        request: RoleAssignmentRequest = Body(
+            description="The user and role to assign.",
+        ),
+        current_user: KeycloakUser = Depends(get_user_or_raise),
+    ) -> RoleAssignmentResponse:
+        """
+        Assign a Keycloak realm role to a user.
+
+        This endpoint lets admins assign roles to users via the REST API instead of
+        having to use the Keycloak admin console. It checks that the requesting user
+        is an admin, validates that both the target user and role exist, and then
+        assigns the role in Keycloak.
+        """
+        if not current_user.is_admin:
+            raise HTTPException(
+                status_code=HTTPStatus.FORBIDDEN,
+                detail="You must be an administrator to assign roles to users.",
+            )
+
+        # Figure out if we got a username or a subject identifier (UUID)
+        sub_pattern = r"\S{8}(-\S{4}){3}-\S{12}"
+        if re.match(sub_pattern, request.user):
+            target_user = get_user_by_sub(request.user)
+        else:
+            target_user = get_user_by_username(request.user)
+
+        if not target_user:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND,
+                detail=f"User '{request.user}' not found.",
+            )
+
+        kc_admin = keycloak_api()
+
+        # Make sure the role actually exists in Keycloak before trying to assign it
+        try:
+            role = kc_admin.get_realm_role(request.role_name)
+        except KeycloakGetError as e:
+            if "not found" in str(e).lower() or e.error_message == "Role not found":
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=f"Role '{request.role_name}' not found in Keycloak.",
+                ) from e
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail=f"Error checking role existence: {str(e)}",
+            ) from e
+        except KeycloakError as e:
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail=f"Keycloak error: {str(e)}",
+            ) from e
+
+        # Check if the role is already assigned - saves us a Keycloak API call
+        try:
+            user_roles = kc_admin.get_user_realm_roles(user_id=target_user._subject_identifier)
+            existing_role_names = {r.get("name") for r in user_roles if r.get("name")}
+            if request.role_name in existing_role_names:
+                return RoleAssignmentResponse(
+                    message=f"Role '{request.role_name}' is already assigned to user '{target_user.name}'.",
+                    user=target_user.name,
+                    role_name=request.role_name,
+                )
+        except KeycloakError:
+            # If checking existing roles fails, we'll still try to assign
+            # Keycloak will handle it if there's a real problem
+            pass
+
+        # Actually assign the role
+        try:
+            kc_admin.assign_user_realm_roles(
+                user_id=target_user._subject_identifier,
+                roles=[role],
+            )
+        except KeycloakError as e:
+            # Sometimes Keycloak returns an error if the role is already assigned
+            error_msg = str(e).lower()
+            if "already" in error_msg or "duplicate" in error_msg:
+                return RoleAssignmentResponse(
+                    message=f"Role '{request.role_name}' is already assigned to user '{target_user.name}'.",
+                    user=target_user.name,
+                    role_name=request.role_name,
+                )
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail=f"Error assigning role to user: {str(e)}",
+            ) from e
+
+        return RoleAssignmentResponse(
+            message=f"Role '{request.role_name}' successfully assigned to user '{target_user.name}'.",
+            user=target_user.name,
+            role_name=request.role_name,
+        )
 
     return router
 

--- a/src/routers/user_router.py
+++ b/src/routers/user_router.py
@@ -182,11 +182,16 @@ def create(url_prefix: str, version: Version) -> APIRouter:
 
         # Check if the role is already assigned - saves us a Keycloak API call
         try:
-            user_roles = kc_admin.get_user_realm_roles(user_id=target_user._subject_identifier)
+            user_roles = kc_admin.get_user_realm_roles(
+                user_id=target_user._subject_identifier
+            )
             existing_role_names = {r.get("name") for r in user_roles if r.get("name")}
             if request.role_name in existing_role_names:
                 return RoleAssignmentResponse(
-                    message=f"Role '{request.role_name}' is already assigned to user '{target_user.name}'.",
+                    message=(
+                        f"Role '{request.role_name}' is already assigned to "
+                        f"user '{target_user.name}'."
+                    ),
                     user=target_user.name,
                     role_name=request.role_name,
                 )
@@ -206,7 +211,10 @@ def create(url_prefix: str, version: Version) -> APIRouter:
             error_msg = str(e).lower()
             if "already" in error_msg or "duplicate" in error_msg:
                 return RoleAssignmentResponse(
-                    message=f"Role '{request.role_name}' is already assigned to user '{target_user.name}'.",
+                    message=(
+                        f"Role '{request.role_name}' is already assigned to "
+                        f"user '{target_user.name}'."
+                    ),
                     user=target_user.name,
                     role_name=request.role_name,
                 )
@@ -216,7 +224,10 @@ def create(url_prefix: str, version: Version) -> APIRouter:
             ) from e
 
         return RoleAssignmentResponse(
-            message=f"Role '{request.role_name}' successfully assigned to user '{target_user.name}'.",
+            message=(
+                f"Role '{request.role_name}' successfully assigned to "
+                f"user '{target_user.name}'."
+            ),
             user=target_user.name,
             role_name=request.role_name,
         )


### PR DESCRIPTION

# Add support for role assignment through REST API

This PR adds a new REST API endpoint that allows administrators to assign Keycloak roles to users programmatically, eliminating the need to use the Keycloak admin interface for role management.

## Changes

### New Endpoint
- **Endpoint**: `POST /user/roles`
- **Authentication**: Required (Bearer token)
- **Authorization**: Admin only (requires `admin_aiod_resources` role)
- **Request Body**:
  ```json
  {
    "user": "username_or_subject_identifier",
    "role_name": "role_name"
  }
  ```
- **Response**:
  ```json
  {
    "message": "Role 'role_name' successfully assigned to user 'username'.",
    "user": "username",
    "role_name": "role_name"
  }
  ```

### Implementation Details

1. **Request/Response Models** (`src/routers/user_router.py`):
   - `RoleAssignmentRequest`: Validates input (user identifier and role name)
   - `RoleAssignmentResponse`: Returns confirmation with user and role details

2. **Role Assignment Endpoint**:
   - Verifies the requesting user has admin permissions
   - Validates that the target user exists (supports both username and subject identifier)
   - Validates that the role exists in Keycloak
   - Checks if role is already assigned (idempotent behavior)
   - Assigns the role using KeycloakAdmin API

3. **Error Handling**:
   - `403 Forbidden`: Non-admin users attempting to assign roles
   - `404 Not Found`: Target user doesn't exist
   - `404 Not Found`: Role doesn't exist in Keycloak
   - `500 Internal Server Error`: Keycloak API errors with detailed messages
   - Graceful handling of already-assigned roles (returns success message)


## Example Usage

```bash
# Assign a role to a user
curl -X POST "https://api.aiod.eu/user/roles" \
  -H "Authorization: Bearer <admin_token>" \
  -H "Content-Type: application/json" \
  -d '{
    "user": "jsmith01",
    "role_name": "review_aiod_resources"
  }'
```

## Related

Closes #637 
