### PR TITLE
Remove ai4europe_cms Platform-Specific Privacy Masking

### DIFF
--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -742,10 +742,12 @@ class ResourceRouter(abc.ABC):
         where_clause = and_(
             is_(self.resource_class.date_deleted, None),
             (self.resource_class.platform == platform) if platform is not None else True,
-            AIoDEntryORM.date_modified >= resource_filters.date_modified_after
+            AIoDEntryORM.date_modified
+            >= datetime.datetime.combine(resource_filters.date_modified_after, datetime.time.min)
             if resource_filters.date_modified_after is not None
             else True,
-            AIoDEntryORM.date_modified < resource_filters.date_modified_before
+            AIoDEntryORM.date_modified
+            < datetime.datetime.combine(resource_filters.date_modified_before, datetime.time.min)
             if resource_filters.date_modified_before is not None
             else True,
             AIoDEntryORM.status == EntryStatus.PUBLISHED,

--- a/src/routers/resource_routers/contact_router.py
+++ b/src/routers/resource_routers/contact_router.py
@@ -4,7 +4,6 @@ from database.model.agent.contact import Contact, contact_versions
 from database.model.agent.email import Email
 from database.model.agent.organisation import Organisation
 from database.model.agent.person import Person
-from database.model.platform.platform_names import PlatformName
 from routers.resource_router import ResourceRouter
 
 from sqlmodel import Session
@@ -45,14 +44,9 @@ class ContactRouter(ResourceRouter):
     ) -> Sequence[type[Contact]]:
         """
         Only authenticated users can see the contact email.
-        For the old ai4europe_cms platform, only users with "full_view_ai4europe_cms_resources" role
-        can view the contact emails.
         """
         for contact in resources:
-            if not user or (
-                (contact.platform == PlatformName.ai4europe_cms)
-                and not user.has_role("full_view_ai4europe_cms_resources")
-            ):
+            if not user:
                 contact.email = [Email(name="******")]
         return resources
 

--- a/src/routers/resource_routers/person_router.py
+++ b/src/routers/resource_routers/person_router.py
@@ -1,9 +1,5 @@
-from typing import Sequence
-from sqlmodel import Session
 from database.model.agent.person import Person, person_versions
-from database.model.platform.platform_names import PlatformName
 from routers.resource_router import ResourceRouter
-from authentication import KeycloakUser
 
 
 class PersonRouter(ResourceRouter):
@@ -22,23 +18,6 @@ class PersonRouter(ResourceRouter):
     @property
     def resource_class(self) -> type[Person]:
         return Person
-
-    @staticmethod
-    def _mask_or_filter(
-        resources: Sequence[type[Person]], session: Session, user: KeycloakUser | None
-    ) -> Sequence[type[Person]]:
-        """
-        For the old ai4europe_cms platform, only users with "full_view_ai4europe_cms_resources"
-        role can see the person's sensitive information.
-        """
-        for person in resources:
-            if (person.platform == PlatformName.ai4europe_cms) and not (
-                user and user.has_role("full_view_ai4europe_cms_resources")
-            ):
-                person.name = "******"
-                person.given_name = "******"
-                person.surname = "******"
-        return resources
 
 
 person_routers = {

--- a/src/tests/routers/resource_routers/test_resource_router.py
+++ b/src/tests/routers/resource_routers/test_resource_router.py
@@ -1,5 +1,5 @@
 import itertools
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock
 
 import pytest
@@ -32,21 +32,21 @@ from tests.testutils.users import register_asset
 @pytest.mark.parametrize(
     "resource_filters,expected_count",
     [
-        ({"date_modified_after": datetime.today().strftime("%Y-%m-%d")}, 1),
-        ({"date_modified_before": datetime.today().strftime("%Y-%m-%d")}, 0),
-        ({"date_modified_after": (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d")}, 0),
-        ({"date_modified_before": (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d")}, 1),
+        ({"date_modified_after": datetime.now(timezone.utc).date().strftime("%Y-%m-%d")}, 1),
+        ({"date_modified_before": datetime.now(timezone.utc).date().strftime("%Y-%m-%d")}, 0),
+        ({"date_modified_after": (datetime.now(timezone.utc).date() + timedelta(days=1)).strftime("%Y-%m-%d")}, 0),
+        ({"date_modified_before": (datetime.now(timezone.utc).date() + timedelta(days=1)).strftime("%Y-%m-%d")}, 1),
         (
             {
-                "date_modified_after": datetime.today().strftime("%Y-%m-%d"),
-                "date_modified_before": datetime.today().strftime("%Y-%m-%d"),
+                "date_modified_after": datetime.now(timezone.utc).date().strftime("%Y-%m-%d"),
+                "date_modified_before": datetime.now(timezone.utc).date().strftime("%Y-%m-%d"),
             },
             0,
         ),
         (
             {
-                "date_modified_after": datetime.today().strftime("%Y-%m-%d"),
-                "date_modified_before": (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d"),
+                "date_modified_after": datetime.now(timezone.utc).date().strftime("%Y-%m-%d"),
+                "date_modified_before": (datetime.now(timezone.utc).date() + timedelta(days=1)).strftime("%Y-%m-%d"),
             },
             1,
         ),

--- a/src/tests/routers/resource_routers/test_router_contact.py
+++ b/src/tests/routers/resource_routers/test_router_contact.py
@@ -6,13 +6,11 @@ from unittest.mock import Mock
 
 from starlette.testclient import TestClient
 
-from authentication import keycloak_openid
 from database.model.agent.contact import Contact
 from database.model.agent.email import Email
 from database.model.platform.platform import Platform
 from database.session import DbSession
 from tests.testutils.default_instances import _create_class_with_body
-from tests.testutils.default_sqlalchemy import AI4EUROPE_CMS_TOKEN
 from tests.testutils.users import logged_in_user
 
 
@@ -204,6 +202,9 @@ def test_email_privacy_for_ai4europe_cms(
     endpoint: str,
     auto_publish: None,
 ):
+    """Test that ai4europe_cms contacts now follow the same privacy rules as other platforms:
+    emails are masked for guests but visible to authenticated users.
+    """
 
     with DbSession() as session:
         contact.platform = "ai4europe_cms"
@@ -218,7 +219,9 @@ def test_email_privacy_for_ai4europe_cms(
     headers = {"Authorization": "Fake token"}
 
     endpoint = endpoint.replace("/1", f"/{contact.identifier}")
-    response = client.get(endpoint, headers=headers)
+
+    # Guest users should see masked emails
+    response = client.get(endpoint)
     response_json = response.json()
     if isinstance(response_json, list):
         response_json = response_json[0]
@@ -227,8 +230,7 @@ def test_email_privacy_for_ai4europe_cms(
     assert len(response_json) > 0, response_json
     assert response_json["email"] == ["******"]
 
-    keycloak_openid.introspect = AI4EUROPE_CMS_TOKEN
-
+    # Authenticated users should see real emails
     response = client.get(endpoint, headers=headers)
     response_json = response.json()
     if isinstance(response_json, list):

--- a/src/tests/routers/resource_routers/test_router_person.py
+++ b/src/tests/routers/resource_routers/test_router_person.py
@@ -4,13 +4,11 @@ from unittest.mock import Mock
 import pytest
 from starlette.testclient import TestClient
 
-from authentication import keycloak_openid
 from database.model.agent.contact import Contact
 from database.model.agent.person import Person
 from database.model.agent.organisation import Organisation
 from database.model.platform.platform import Platform
 from database.session import DbSession
-from tests.testutils.default_sqlalchemy import AI4EUROPE_CMS_TOKEN
 
 
 def test_happy_path(
@@ -69,19 +67,17 @@ def test_happy_path(
         "/platforms/ai4europe_cms/persons/2",
     ]
 )
-def test_privacy_for_ai4europe_cms(
+def test_ai4europe_cms_person_data_visible(
     client: TestClient,
     mocked_privileged_token: Mock,
-    overwrites_keycloak_token: None,  # Technically already used by privileged token, but we also overwrite explicitly  # noqa: E501
     platform: Platform,
     person: Person,
     contact: Contact,
     endpoint: str,
     auto_publish: None,
 ):
-    """Test to ensure that only authenticated users with "full_view_ai4europe_cms_resources" role
-    can visualise fields such as name, given_name and surname of a person migrated from
-    the old ai4europe_cms platform.
+    """Test to ensure that person data from ai4europe_cms platform is now visible
+    without masking, since the ai4europe.eu portal has been replaced.
     """
 
     with DbSession() as session:
@@ -96,20 +92,8 @@ def test_privacy_for_ai4europe_cms(
         session.refresh(person)
         session.refresh(contact)
 
-    headers = {"Authorization": "Fake token"}
-
     endpoint = endpoint.replace("/1", f"/{person.identifier}")
-    response = client.get(endpoint, headers=headers)
-    response_json = response.json()
-    response_json = [response_json] if isinstance(response_json, dict) else response_json
-    assert response.status_code == 200, response_json
-    for person_dict in response_json:
-        assert person_dict["name"] == "******"
-        assert person_dict["given_name"] == "******"
-        assert person_dict["surname"] == "******"
-
-    keycloak_openid.introspect = AI4EUROPE_CMS_TOKEN
-    response = client.get(endpoint, headers=headers)
+    response = client.get(endpoint)
     response_json = response.json()
     response_json = [response_json] if isinstance(response_json, dict) else response_json
     assert response.status_code == 200, response_json


### PR DESCRIPTION

<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->

 This PR removes special privacy handling for the deprecated ai4europe_cms platform and fixes a date filtering bug that was
 causing test failures.


## Change(s)

Privacy Rule Simplification - 

  - Contact Router (contact_router.py):
    - Removed platform-specific check for ai4europe_cms
    - Removed role-based access control for viewing contact emails
    - All platforms now follow unified privacy rules: contact emails are masked for unauthenticated users
  - Person Router (person_router.py):
    - Removed entire _mask_or_filter method that handled ai4europe_cms special cases
    - Person information (name, given_name, surname) is now visible to all users regardless of platform
    - Removed unused imports: Sequence, Session, KeycloakUser, PlatformName

  Bug Fix: Date Filtering - 

  - Resource Router (resource_router.py):
    - Fixed date comparison bug where datetime objects were being compared directly with date objects
    - Now properly converts date filters to datetime using datetime.combine() before comparison
    - Ensures date_modified_after and date_modified_before filters work correctly


Test Updates

  - Contact Router Tests (test_router_contact.py):
    - Updated test_email_privacy_for_ai4europe_cms to reflect new behavior
    - Verified that guest users see masked emails and authenticated users see real emails
    - Removed dependency on AI4EUROPE_CMS_TOKEN fixture
  - Person Router Tests (test_router_person.py):
    - Renamed test_privacy_for_ai4europe_cms to test_ai4europe_cms_person_data_visible
    - Updated test to verify person data is now visible without masking
    - Removed role-based access testing
  - Resource Router Tests (test_resource_router.py):
    - Fixed timezone mismatch by using datetime.now(timezone.utc) instead of datetime.today()
    - Ensures date filter tests use UTC to match the backend implementation
    - All 180 date filtering tests now pass
   
## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues

Fixes #657 
