### PR TITLE
Fix silent failure on missing Content-Type header (#622)

### DIFF
--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -3,7 +3,7 @@ import datetime
 import traceback
 from functools import partial
 from typing import Annotated, Any, Literal, Sequence, Type, TypeVar, Union, Callable, cast
-from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
+from fastapi import APIRouter, Depends, HTTPException, status, Query, Path, Request
 from sqlalchemy import and_, func
 from sqlalchemy.sql.operators import is_
 from sqlmodel import SQLModel, Session, select
@@ -463,8 +463,16 @@ class ResourceRouter(abc.ABC):
 
         def register_resource(
             resource_create: clz_create,  # type: ignore
+            request: Request,
             user: KeycloakUser = Depends(get_user_or_raise),
         ):
+            content_type = request.headers.get("content-type", "")
+            if not content_type.startswith("application/json"):
+                raise HTTPException(
+                    status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                    detail="Content-Type header must be application/json",
+                )
+
             platform = getattr(resource_create, "platform", None)
             platform_resource_identifier = getattr(
                 resource_create, "platform_resource_identifier", None
@@ -544,8 +552,16 @@ class ResourceRouter(abc.ABC):
         def put_resource(
             identifier: str,
             resource_create_instance: clz_create,  # type: ignore
+            request: Request,
             user: KeycloakUser = Depends(get_user_or_raise),
         ):
+            content_type = request.headers.get("content-type", "")
+            if not content_type.startswith("application/json"):
+                raise HTTPException(
+                    status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                    detail="Content-Type header must be application/json",
+                )
+
             self._raise_if_identifier_is_wrong_type(identifier)
             with DbSession() as session:
                 try:


### PR DESCRIPTION
## Change(s)
Change Type: Fixed

Change Category: Interface

Changelog Entry: Fixed an issue where `POST` and `PUT` requests missing the `Content-Type: application/json` header would silently succeed (returning `200 OK`) with an empty body instead of failing. These requests now correctly return `415 Unsupported Media Type`.

## How to Test
The fix can be verified by sending a request to any resource endpoint (e.g., `/datasets`) with a body but without the `Content-Type` header.

**Verification Steps:**
1. Spin up the application stack: `docker compose up --build`
2. Run a python script (using `TestClient` with dependency overrides to bypass authentication) that sends a `PUT` or `POST` request with a valid body string but **no** content-type header.
3. Assert that the response status code is `415` (previously it was `200` with no action taken).

I verified this locally using a standalone script inside the Docker container that mocked the user authentication dependency to isolate the header check logic.

## Checklist
- [] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained. (Error handling fix; no documentation changes required).
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it.
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
Closes #622