### PR TITLE
Fix quirky pagination and sorting behavior in /user/resources endpoint

### DIFF
--- a/src/routers/user_router.py
+++ b/src/routers/user_router.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import List
 
 from fastapi import APIRouter, Depends
@@ -76,16 +75,9 @@ def create(url_prefix: str, version: Version) -> APIRouter:
             for r in versioned_routers.get(version, [])
         }
 
-        def sort_function(asset):
-            value = getattr(asset.aiod_entry, sorting.sort)
-            direction = -1 if sorting.direction == SortDirection.DESC else 1
-            return direction * datetime.datetime.timestamp(value)
-
+        # Assets are already sorted by _get_resources_for_user, just transform them
         return {
-            asset_name: sorted(
-                (orm_to_read[asset_name](asset) for asset in assets),
-                key=sort_function,
-            )
+            asset_name: [orm_to_read[asset_name](asset) for asset in assets]
             for asset_name, assets in resources.items()
         }
 
@@ -117,12 +109,17 @@ def _get_resources_for_user(
     if limit:
         stmt = stmt.limit(limit)
     entries = session.scalars(stmt).all()
-    assets_to_fetch = [entry.identifier for entry in entries]
+
+    # Create a mapping of entry_identifier -> sort_order to preserve database ordering
+    entry_order = {entry.identifier: idx for idx, entry in enumerate(entries)}
+    assets_to_fetch = list(entry_order.keys())
+
     # We have AIoD entries, but want their respective asset information (e.g. publication).
     # We lack the information about what the type of the asset is, so unfortunately we
     # have to check all tables:
     asset_types = list(non_abstract_subclasses(AIoDConcept))
     found_assets: dict[str, list[AIoDConcept]] = {type_.__tablename__: [] for type_ in asset_types}
+
     for asset_type in asset_types:
         query = (
             select(asset_type)
@@ -130,7 +127,14 @@ def _get_resources_for_user(
             .where(asset_type.date_deleted.is_(None))
         )
         assets = session.scalars(query).all()
-        found_assets[asset_type.__tablename__] = list(assets)
+
+        # Sort assets by the original database order before adding to results
+        sorted_assets = sorted(
+            assets, key=lambda asset: entry_order.get(asset.aiod_entry_identifier, float("inf"))
+        )
+        found_assets[asset_type.__tablename__] = sorted_assets
+
         if sum(map(len, found_assets.values())) == len(assets_to_fetch):
             break
-    return found_assets  # minor optimization since queries may be expensive
+
+    return found_assets


### PR DESCRIPTION
## Change(s)

Change Type: Fixed

Change Category: Internal

Changelog Entry: Fixed quirky pagination and sorting behavior in `/user/resources` endpoint.

The `/user/resources` endpoint previously had unintuitive behavior where it would paginate at the `AIoDEntry` level, then re-query individual asset tables (potentially reordering results), and finally re-sort in Python. This fix preserves the database sort order throughout the query process by creating an `entry_order` mapping and applying it when fetching assets from individual tables, eliminating the need for Python-level re-sorting.

## How to Test

1. Create multiple resources (publications, datasets, etc.) with different `date_modified` timestamps
2. Query `/user/resources` with pagination and sorting parameters:
   - `GET /user/resources?limit=5&sort=date_modified&direction=desc`
   - `GET /user/resources?limit=5&offset=5&sort=date_modified&direction=desc`
3. Verify that:
   - Results are sorted correctly by `date_modified`
   - Pagination maintains the sort order across pages
   - Multiple asset types are each sorted correctly

Existing tests in [test_user_endpoints.py](cci:7://file:///c:/Users/HP/Desktop/aiod-rest-api/AIOD-rest-api/src/tests/test_user_endpoints.py:0:0-0:0) should pass (note: local Windows environment has unrelated test infrastructure issues with SQLite temp files, but CI/CD should pass).

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- Existing tests in test_user_endpoints.py verify pagination behavior -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained. <!-- No documentation changes needed - this is an internal fix with no API changes -->
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not. <!-- Local Windows environment has unrelated test failures (SQLite temp file issues and Zenodo connector Unicode errors). These are environmental issues, not related to the code changes. All code quality checks (ruff, mypy) pass. -->
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues

Closes #654