### PR TITLE
[BUG] correct path to example data fill script for database

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
     volumes:
       - ${DATA_PATH}/connectors:/opt/connectors/data
       - ./src/config.override.toml:/app/config.override.toml:ro
+      - ./connectors:/opt/connectors/script:ro
     command: >
       /bin/bash -c "/opt/connectors/script/fill-examples.sh"
     depends_on:


### PR DESCRIPTION
updated the `fill-db-with-examples` container to add the proper path of the example data filling script `connectors\fill-examples.sh` for mysql database

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [ ] The PR title matches the changelog entry's one-line description.

## Related Issues
Fixes #677 
