### PR TITLE
Add configurable rate limiting for user asset uploads

### DIFF
--- a/docs/developer/rate-limiting.md
+++ b/docs/developer/rate-limiting.md
@@ -1,0 +1,75 @@
+# Rate Limiting
+
+The API implements rate limiting to prevent abuse and ensure fair resource usage.
+
+## Overview
+
+Rate limiting restricts the number of asset uploads a user can perform within a specified time window. This helps maintain system stability and prevents malicious or accidental overuse.
+
+## Scope
+
+- Applies to **asset creation (upload) endpoints**
+- Enforced **per authenticated user** (Keycloak subject identifier)
+- Does **not** apply to:
+  - Asset reads or updates
+  - Connector-based bulk uploads
+
+## Configuration
+
+Rate limiting is configured in `src/config.default.toml`:
+
+```toml
+[rate_limit]
+enabled = true
+uploads_per_window = 100
+window_seconds = 3600
+```
+
+- **enabled**: Toggle rate limiting on/off
+- **uploads_per_window**: Maximum uploads allowed per time window
+- **window_seconds**: Time window duration in seconds (e.g., 3600 = 1 hour)
+
+## Behavior
+
+### User Uploads
+
+Regular users are subject to rate limits. When the limit is exceeded:
+
+- HTTP status `429 Too Many Requests` is returned
+- Response includes a `Retry-After` header indicating when to retry
+- Error message specifies the limit and remaining time
+
+### Connector Exemption
+
+Bulk data migration connectors are automatically exempted from rate limiting, as they are designed for large-scale operations.
+
+### Rolling Time Window
+
+The implementation uses a rolling time window rather than fixed buckets. This provides more precise rate limiting by counting uploads within the last N seconds from the current time.
+
+## Implementation
+
+Rate limiting is:
+
+- **Global across asset types**: Limits apply to all uploads regardless of asset type
+- **Database-backed**: Uses MySQL to track uploads, avoiding additional infrastructure dependencies
+- **Indexed for performance**: Composite index on `(user_identifier, created_at)` optimizes queries
+- **Non-atomic**: Minor bursts above the limit may occur under high concurrency (acceptable tradeoff)
+
+## HTTP Response
+
+When rate limited, the API returns:
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 1800
+Content-Type: application/json
+
+{
+  "detail": "Upload rate limit exceeded: max 100 uploads per 3600 seconds. Retry after 1800 seconds."
+}
+```
+
+## Maintenance
+
+The `asset_upload_log` table tracks all user uploads. Consider implementing periodic cleanup of old records to manage database growth.

--- a/src/config.default.toml
+++ b/src/config.default.toml
@@ -37,6 +37,14 @@ disable_reviews = false  # set to true to automatically publish submissions
 url_prefix = ""
 taxonomy = ""  # Set to a JSON file containing a taxonomy to put into the database on startup
 
+[rate_limit]
+# User-scoped upload rate limiting. Connectors are automatically exempted.
+enabled = true
+# Maximum uploads per user within the rolling time window.
+uploads_per_window = 100
+# Rolling time window in seconds (e.g., 3600 = 1 hour, 86400 = 1 day).
+window_seconds = 3600
+
 # Authentication and authorization
 [keycloak]
 server_url = "http://keycloak:8080/aiod-auth/"

--- a/src/database/model/access/upload_log.py
+++ b/src/database/model/access/upload_log.py
@@ -1,0 +1,22 @@
+"""Asset upload log for rate limiting.
+
+Tracks user uploads to enforce rate limits within rolling time windows.
+Composite index on (user_identifier, created_at) optimizes queries.
+"""
+from datetime import datetime, UTC
+
+from sqlmodel import SQLModel, Field, Index
+
+from database.model.field_length import NORMAL
+
+
+class AssetUploadLog(SQLModel, table=True):  # type: ignore[call-arg]
+    __tablename__ = "asset_upload_log"
+    __table_args__ = (
+        Index("idx_user_time", "user_identifier", "created_at"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_identifier: str = Field(max_length=NORMAL, index=True)
+    resource_type: str = Field(max_length=NORMAL, index=True)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), index=True)

--- a/src/database/model/access/upload_log.py
+++ b/src/database/model/access/upload_log.py
@@ -3,6 +3,7 @@
 Tracks user uploads to enforce rate limits within rolling time windows.
 Composite index on (user_identifier, created_at) optimizes queries.
 """
+
 from datetime import datetime, UTC
 
 from sqlmodel import SQLModel, Field, Index
@@ -12,9 +13,7 @@ from database.model.field_length import NORMAL
 
 class AssetUploadLog(SQLModel, table=True):  # type: ignore[call-arg]
     __tablename__ = "asset_upload_log"
-    __table_args__ = (
-        Index("idx_user_time", "user_identifier", "created_at"),
-    )
+    __table_args__ = (Index("idx_user_time", "user_identifier", "created_at"),)
 
     id: int | None = Field(default=None, primary_key=True)
     user_identifier: str = Field(max_length=NORMAL, index=True)

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ import database.authorization  # noqa  # Trigger registration of User, Permissio
 from database.model.concept.concept import AIoDConcept
 from database.model.platform.platform import Platform
 from database.model.platform.platform_names import PlatformName
+from database.model.access.upload_log import AssetUploadLog
 from database.session import EngineSingleton, DbSession
 from database.setup import create_database, database_exists
 from routers.resource_routers import versioned_routers

--- a/src/rate_limit.py
+++ b/src/rate_limit.py
@@ -3,6 +3,7 @@
 Uses database-backed rolling time windows to limit user uploads. Connectors are
 exempted. Rate limits are global across all asset types.
 """
+
 from __future__ import annotations
 
 import logging
@@ -78,14 +79,12 @@ def enforce_upload_rate_limit(user: KeycloakUser | None, resource_type: str) -> 
                     AssetUploadLog.user_identifier == user._subject_identifier,
                     AssetUploadLog.created_at >= window_start,
                 )
-                .order_by(AssetUploadLog.created_at.asc())
+                .order_by(AssetUploadLog.created_at.asc())  # type: ignore[attr-defined]
                 .limit(1)
             ).first()
             retry_after = window_seconds
             if oldest:
-                retry_after = max(
-                    0, int(window_seconds - (now - oldest).total_seconds())
-                )
+                retry_after = max(0, int(window_seconds - (now - oldest).total_seconds()))
 
             logger.warning(
                 "Upload rate limit exceeded: user=%s resource_type=%s count=%s window_seconds=%s",

--- a/src/rate_limit.py
+++ b/src/rate_limit.py
@@ -1,0 +1,133 @@
+"""Rate limiting for asset uploads.
+
+Uses database-backed rolling time windows to limit user uploads. Connectors are
+exempted. Rate limits are global across all asset types.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, UTC
+
+from fastapi import HTTPException, status
+from sqlmodel import select
+from sqlalchemy import func
+
+from authentication import KeycloakUser
+from config import CONFIG
+from database.model.access.upload_log import AssetUploadLog
+from database.session import DbSession
+
+logger = logging.getLogger(__file__)
+
+
+def _get_rate_limit_config() -> tuple[bool, int, int]:
+    """Extract rate limit configuration.
+
+    Returns:
+        Tuple of (enabled, uploads_per_window, window_seconds)
+    """
+    rate_config = CONFIG.get("rate_limit", {})
+    enabled = bool(rate_config.get("enabled", False))
+    uploads_per_window = int(rate_config.get("uploads_per_window", 0) or 0)
+    window_seconds = int(rate_config.get("window_seconds", 0) or 0)
+    return enabled, uploads_per_window, window_seconds
+
+
+def enforce_upload_rate_limit(user: KeycloakUser | None, resource_type: str) -> None:
+    """Enforce upload rate limit for the given user.
+
+    Args:
+        user: Authenticated user or None
+        resource_type: Asset type being uploaded (for logging only)
+
+    Raises:
+        HTTPException: 401 if user is not authenticated, 429 if rate limit exceeded
+    """
+    enabled, uploads_per_window, window_seconds = _get_rate_limit_config()
+    if not enabled or uploads_per_window <= 0 or window_seconds <= 0:
+        return
+
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication is required to upload assets.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # Explicitly bypass rate limiting for connectors (bulk data migration services)
+    if user.is_connector:
+        return
+
+    now = datetime.now(UTC)
+    window_start = now - timedelta(seconds=window_seconds)
+
+    with DbSession() as session:
+        # NOTE: Not strictly atomic under high concurrency. Minor bursts above limit are
+        # acceptable and common in DB-backed rate limiters without distributed locks.
+        count = session.exec(
+            select(func.count(AssetUploadLog.id)).where(
+                AssetUploadLog.user_identifier == user._subject_identifier,
+                AssetUploadLog.created_at >= window_start,
+            )
+        ).one()
+        if count >= uploads_per_window:
+            # Calculate precise retry timing (only executed on limit breach)
+            oldest = session.exec(
+                select(AssetUploadLog.created_at)
+                .where(
+                    AssetUploadLog.user_identifier == user._subject_identifier,
+                    AssetUploadLog.created_at >= window_start,
+                )
+                .order_by(AssetUploadLog.created_at.asc())
+                .limit(1)
+            ).first()
+            retry_after = window_seconds
+            if oldest:
+                retry_after = max(
+                    0, int(window_seconds - (now - oldest).total_seconds())
+                )
+
+            logger.warning(
+                "Upload rate limit exceeded: user=%s resource_type=%s count=%s window_seconds=%s",
+                user._subject_identifier,
+                resource_type,
+                count,
+                window_seconds,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=(
+                    "Upload rate limit exceeded: max "
+                    f"{uploads_per_window} uploads per {window_seconds} seconds. "
+                    f"Retry after {retry_after} seconds."
+                ),
+                headers={"Retry-After": str(retry_after)},
+            )
+
+
+def record_successful_upload(user: KeycloakUser | None, resource_type: str) -> None:
+    """Record a successful upload for rate limiting.
+
+    Args:
+        user: Authenticated user or None
+        resource_type: Asset type that was uploaded
+    """
+    enabled, uploads_per_window, window_seconds = _get_rate_limit_config()
+    if not enabled or uploads_per_window <= 0 or window_seconds <= 0:
+        return
+
+    if user is None or user.is_connector:
+        return
+
+    try:
+        with DbSession() as session:
+            session.add(
+                AssetUploadLog(
+                    user_identifier=user._subject_identifier,
+                    resource_type=resource_type,
+                )
+            )
+            session.commit()
+    except Exception as exc:
+        # Graceful degradation: failures don't block the upload pipeline
+        logger.error("Failed to record upload for rate limiting: %s", exc)

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -33,6 +33,7 @@ from error_handling import as_http_exception
 from database.model.ai_asset.distribution import Distribution
 from database.model.helper_functions import get_asset_type_by_abbreviation
 from versioning import Version, VersionedResource
+from rate_limit import enforce_upload_rate_limit, record_successful_upload
 
 from http import HTTPStatus
 import base64
@@ -465,6 +466,7 @@ class ResourceRouter(abc.ABC):
             resource_create: clz_create,  # type: ignore
             user: KeycloakUser = Depends(get_user_or_raise),
         ):
+            enforce_upload_rate_limit(user, self.resource_name_plural)
             platform = getattr(resource_create, "platform", None)
             platform_resource_identifier = getattr(
                 resource_create, "platform_resource_identifier", None
@@ -503,6 +505,7 @@ class ResourceRouter(abc.ABC):
                         if user.is_connector:
                             resource.aiod_entry.status = EntryStatus.PUBLISHED
                         session.commit()
+                        record_successful_upload(user, self.resource_name_plural)
                         return {"identifier": resource.identifier}
                     except Exception as e:
                         self._raise_clean_http_exception(e, session, resource_create)

--- a/src/tests/routers/generic/test_rate_limit.py
+++ b/src/tests/routers/generic/test_rate_limit.py
@@ -26,10 +26,14 @@ def rate_limit_one_per_hour():
 def test_rate_limit_reached(client_test_resource: TestClient, rate_limit_one_per_hour):
     headers = {"Authorization": "Fake token"}
     with logged_in_user():
-        first = client_test_resource.post("/test_resources", json={"title": "title1"}, headers=headers)
+        first = client_test_resource.post(
+            "/test_resources", json={"title": "title1"}, headers=headers
+        )
         assert first.status_code == HTTPStatus.OK, first.json()
 
-        second = client_test_resource.post("/test_resources", json={"title": "title2"}, headers=headers)
+        second = client_test_resource.post(
+            "/test_resources", json={"title": "title2"}, headers=headers
+        )
         assert second.status_code == HTTPStatus.TOO_MANY_REQUESTS, second.json()
         assert "Upload rate limit exceeded" in second.json()["detail"]
 
@@ -38,15 +42,21 @@ def test_rate_limit_resets_after_window(client_test_resource: TestClient, rate_l
     headers = {"Authorization": "Fake token"}
     with freeze_time("2026-02-07T10:00:00Z"):
         with logged_in_user():
-            first = client_test_resource.post("/test_resources", json={"title": "title1"}, headers=headers)
+            first = client_test_resource.post(
+                "/test_resources", json={"title": "title1"}, headers=headers
+            )
             assert first.status_code == HTTPStatus.OK, first.json()
 
-            second = client_test_resource.post("/test_resources", json={"title": "title2"}, headers=headers)
+            second = client_test_resource.post(
+                "/test_resources", json={"title": "title2"}, headers=headers
+            )
             assert second.status_code == HTTPStatus.TOO_MANY_REQUESTS, second.json()
 
     with freeze_time("2026-02-07T11:00:01Z"):
         with logged_in_user():
-            third = client_test_resource.post("/test_resources", json={"title": "title3"}, headers=headers)
+            third = client_test_resource.post(
+                "/test_resources", json={"title": "title3"}, headers=headers
+            )
             assert third.status_code == HTTPStatus.OK, third.json()
 
 

--- a/src/tests/routers/generic/test_rate_limit.py
+++ b/src/tests/routers/generic/test_rate_limit.py
@@ -1,0 +1,69 @@
+import copy
+from http import HTTPStatus
+
+import pytest
+from freezegun import freeze_time
+from starlette.testclient import TestClient
+
+from config import CONFIG
+from tests.testutils.users import logged_in_user, kc_connector_with_roles
+
+
+@pytest.fixture
+def rate_limit_one_per_hour():
+    original = copy.deepcopy(CONFIG.get("rate_limit", {}))
+    CONFIG.setdefault("rate_limit", {})
+    CONFIG["rate_limit"]["enabled"] = True
+    CONFIG["rate_limit"]["uploads_per_window"] = 1
+    CONFIG["rate_limit"]["window_seconds"] = 3600
+    yield
+    if original:
+        CONFIG["rate_limit"] = original
+    else:
+        CONFIG.pop("rate_limit", None)
+
+
+def test_rate_limit_reached(client_test_resource: TestClient, rate_limit_one_per_hour):
+    headers = {"Authorization": "Fake token"}
+    with logged_in_user():
+        first = client_test_resource.post("/test_resources", json={"title": "title1"}, headers=headers)
+        assert first.status_code == HTTPStatus.OK, first.json()
+
+        second = client_test_resource.post("/test_resources", json={"title": "title2"}, headers=headers)
+        assert second.status_code == HTTPStatus.TOO_MANY_REQUESTS, second.json()
+        assert "Upload rate limit exceeded" in second.json()["detail"]
+
+
+def test_rate_limit_resets_after_window(client_test_resource: TestClient, rate_limit_one_per_hour):
+    headers = {"Authorization": "Fake token"}
+    with freeze_time("2026-02-07T10:00:00Z"):
+        with logged_in_user():
+            first = client_test_resource.post("/test_resources", json={"title": "title1"}, headers=headers)
+            assert first.status_code == HTTPStatus.OK, first.json()
+
+            second = client_test_resource.post("/test_resources", json={"title": "title2"}, headers=headers)
+            assert second.status_code == HTTPStatus.TOO_MANY_REQUESTS, second.json()
+
+    with freeze_time("2026-02-07T11:00:01Z"):
+        with logged_in_user():
+            third = client_test_resource.post("/test_resources", json={"title": "title3"}, headers=headers)
+            assert third.status_code == HTTPStatus.OK, third.json()
+
+
+def test_connector_bypasses_rate_limit(client_test_resource: TestClient, rate_limit_one_per_hour):
+    headers = {"Authorization": "Fake token"}
+    connector_user = kc_connector_with_roles()
+    with logged_in_user(connector_user):
+        first = client_test_resource.post(
+            "/test_resources",
+            json={"title": "title1", "platform": "example", "platform_resource_identifier": "1"},
+            headers=headers,
+        )
+        assert first.status_code == HTTPStatus.OK, first.json()
+
+        second = client_test_resource.post(
+            "/test_resources",
+            json={"title": "title2", "platform": "example", "platform_resource_identifier": "2"},
+            headers=headers,
+        )
+        assert second.status_code == HTTPStatus.OK, second.json()


### PR DESCRIPTION

## Change(s)

### Change Type:

**Added**

### Change Category:

**Internal**

### Changelog Entry:

Added configurable, user-scoped rate limiting for asset uploads to prevent abuse and reduce congestion in the review pipeline.

This introduces a rolling-window upload limit configurable via `config.toml`, enforces limits before asset persistence and review enqueueing, and returns clear HTTP `429` responses when limits are exceeded. Connector-based uploads are explicitly exempted to support bulk migration workflows.

---

## How to Test

### Automated testing

* Unit tests have been added covering:

  * Rate limit enforcement
  * Rolling window reset behavior
  * Connector bypass
* Tests are expected to pass in CI environments using MySQL.

### Local testing 

1. Configure strict limits in `src/config.default.toml`, for example:

   ```toml
   [rate_limit]
   enabled = true
   uploads_per_window = 1
   window_seconds = 3600
   ```
2. Start the API.
3. Perform two consecutive asset uploads as a regular user:

   * First request should succeed (HTTP 200)
   * Second request should return `429 Too Many Requests` with a `Retry-After` header
4. Perform multiple uploads as a connector user:

   * All uploads should succeed (rate limiting bypassed)

### Note on local test execution

* Local test runs using SQLite may fail during schema creation due to existing
  MySQL-specific `BINARY()` CHECK constraints in unrelated models.
* This is a known SQLite/MySQL incompatibility and is **not introduced by this PR**.
* CI environments using MySQL are expected to execute the tests successfully.

<img width="1235" height="491" alt="image" src="https://github.com/user-attachments/assets/d4bb6a75-d3de-4bbd-ab1b-ef4633f4c6a3" />


---

## Checklist

* [x] Tests have been added to reflect the changes; local SQLite failures are explicitly explained.
* [x] Documentation has been added describing configuration, behavior, and tradeoffs (`docs/developer/rate-limiting.md`).
* [x] A self-review has been conducted checking:

  * No unintended changes have been committed.
  * The changes in isolation are reasonable and scoped.
  * Design tradeoffs (DB-backed rate limiting, minor concurrency overshoot, retention cleanup) are documented inline.
* [x] All applicable CI checks pass (linting, formatting, type checking); test execution depends on MySQL-backed CI.
* [x] The PR title matches the changelog entry’s one-line description.

---

## Related Issues

Closes #661

