### PR TITLE
[BUG] explicit encoding for file open to avoid failures on windows

### DIFF
--- a/src/tests/connectors/zenodo/mock_zenodo.py
+++ b/src/tests/connectors/zenodo/mock_zenodo.py
@@ -5,10 +5,10 @@ from tests.testutils.paths import path_test_resources
 
 TOKEN_EXPIRATION_DATETIME = "2024-02-08T17:40:07Z"
 
-with open(path_test_resources() / "connectors" / "zenodo" / "list_records_1.xml", "r") as f:
+with open(path_test_resources() / "connectors" / "zenodo" / "list_records_1.xml", "r", encoding="utf-8") as f:
     records_list_1 = f.read()
 
-with open(path_test_resources() / "connectors" / "zenodo" / "list_records_2.xml", "r") as f:
+with open(path_test_resources() / "connectors" / "zenodo" / "list_records_2.xml", "r", encoding="utf-8") as f:
     records_list_2 = f.read()
 
 
@@ -77,7 +77,7 @@ def response_with_no_records(mocked_requests: responses.RequestsMock):
 
 
 def record_response(mocked_requests: responses.RequestsMock, id_: int):
-    with open(path_test_resources() / "connectors" / "zenodo" / f"{id_}.json", "r") as f:
+    with open(path_test_resources() / "connectors" / "zenodo" / f"{id_}.json", "r", encoding="utf-8") as f:
         body = f.read()
     mocked_requests.add(
         responses.GET, f"https://zenodo.org/api/records/{id_}/files", body=body, status=200


### PR DESCRIPTION
## Change(s)
modified tests in `src\tests\connectors\zenodo\mock_zenodo.py` to explicitly sprcify the encoding `encoding="utf-8"` for file open.

Change Type: Fixed

## How to Test
run this command:
```bash
pytest src/tests/
```
before this fix, there would be a encoding error thrown (in windows only. linux does not have this issue)

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [ ] The PR title matches the changelog entry's one-line description.

## Related Issues
#683 
