### PR TITLE
[MNT] added pytest run command for github CI

### DIFF
--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -40,3 +40,8 @@ jobs:
       run: |
         source venv/bin/activate
         pre-commit run --all
+
+    - name: Run pytest
+      run: |
+        source venv/bin/activate
+        pytest src/tests


### PR DESCRIPTION
## Change(s)
in the `.github\workflows\pytest-tests.yml` file for `Run Unit Test via Pytest` does not contain any workflow to run the actual `pytests`. the jobs currently do:
- Setup Python virtual environment
- Install dependencies
- pre-commit check

added the job to run pytest at the end:
```yaml
    - name: Run pytest
      run: |
        source venv/bin/activate
        pytest src/tests
```

this should enable running the ctual pytests on github CI.

Solves #684

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [ ] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
