### PR TITLE
[BUG] Fix SQLite temp DB file on Windows

### DIFF
--- a/src/tests/testutils/default_sqlalchemy.py
+++ b/src/tests/testutils/default_sqlalchemy.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 import tempfile
 from typing import Iterator, Any
@@ -106,8 +107,11 @@ def engine() -> Iterator[Engine]:
     """
     Create a SqlAlchemy engine for tests, backed by a temporary sqlite file.
     """
-    temporary_file = tempfile.NamedTemporaryFile()
-    engine = create_engine(f"sqlite:///{temporary_file.name}?check_same_thread=False")
+    temporary_file = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    temp_path = temporary_file.name
+    temporary_file.close()
+
+    engine = create_engine(f"sqlite:///{temp_path}?check_same_thread=False")
     AIoDConcept.metadata.create_all(engine)
     with Session(engine) as session:
         for trigger in create_delete_triggers(AIoDConcept):
@@ -116,8 +120,11 @@ def engine() -> Iterator[Engine]:
             session.execute(trigger)
     EngineSingleton().patch(engine)
 
-    # Yielding is essential, the temporary file will be closed after the engine is used
     yield engine
+
+    engine.dispose()
+    if os.path.exists(temp_path):
+        os.unlink(temp_path)
 
 
 @pytest.fixture

--- a/src/tests/testutils/test_default_sqlalchemy.py
+++ b/src/tests/testutils/test_default_sqlalchemy.py
@@ -1,0 +1,32 @@
+import os
+import tempfile
+
+import pytest
+
+from tests.testutils import default_sqlalchemy
+
+
+def test_engine_fixture_uses_non_deleting_temp_file_and_cleans_up(monkeypatch):
+    captured: dict[str, object] = {}
+    original_named_temporary_file = tempfile.NamedTemporaryFile
+
+    def tracked_named_temporary_file(*args, **kwargs):
+        captured["kwargs"] = kwargs.copy()
+        temporary_file = original_named_temporary_file(*args, **kwargs)
+        captured["path"] = temporary_file.name
+        return temporary_file
+
+    monkeypatch.setattr(default_sqlalchemy.tempfile, "NamedTemporaryFile", tracked_named_temporary_file)
+
+    engine_generator = default_sqlalchemy.engine.__wrapped__()
+    _ = next(engine_generator)
+
+    temp_path = str(captured["path"])
+    assert captured["kwargs"]["delete"] is False
+    assert temp_path.endswith(".db")
+    assert os.path.exists(temp_path)
+
+    with pytest.raises(StopIteration):
+        next(engine_generator)
+
+    assert not os.path.exists(temp_path)


### PR DESCRIPTION
Summary:
- Make the test `engine` fixture create the sqlite file with `NamedTemporaryFile(delete=False, suffix=".db")`,
  close the handle before creating the SQLAlchemy engine, and explicitly dispose & unlink the file in teardown.
- Add a regression test that ensures the temp `.db` exists while the fixture is active and is removed after teardown.

Files changed:
- src/tests/testutils/default_sqlalchemy.py
- src/tests/testutils/test_default_sqlalchemy.py

Reason:
On Windows, `NamedTemporaryFile()` deletes the file on close by default, causing SQLAlchemy to fail to open the DB path. This change ensures the DB file remains accessible for the engine and is cleaned up after tests.

Tests:
- Added `test_engine_fixture_uses_non_deleting_temp_file_and_cleans_up` to validate behavior.

Fixes: #687