### PR TITLE
Fix sporadic test failures

### DIFF
--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -241,7 +241,7 @@ def test_get_submission_by_id(client, publication):
         submission_dict = submission.json()
         submission_date = submission_dict.pop("request_date")
         review_date = submission_dict["reviews"][0].pop("decision_date")
-        assert submission_date < review_date
+        assert submission_date <= review_date
         reviews = submission_dict.pop("reviews")
         assets = submission_dict.pop("assets")
         assert submission_dict == {

--- a/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
+++ b/src/tests/routers/resource_routers/test_router_dataset_generic_fields.py
@@ -70,8 +70,8 @@ def test_happy_path(
     assert response_json["aiod_entry"]["status"] == EntryStatus.PUBLISHED
     date_created = dateutil.parser.parse(response_json["aiod_entry"]["date_created"] + "Z")
     date_modified = dateutil.parser.parse(response_json["aiod_entry"]["date_modified"] + "Z")
-    assert 0 < (date_created - datetime_create_request).total_seconds() < 0.2
-    assert 0 < (date_modified - datetime_create_request).total_seconds() < 0.2
+    assert 0 <= (date_created - datetime_create_request).total_seconds() < 0.2
+    assert 0 <= (date_modified - datetime_create_request).total_seconds() < 0.2
 
     assert response_json["name"] == "The name"
     assert response_json["description"]["plain"] == description_plain
@@ -139,8 +139,8 @@ def test_happy_path(
 
     date_created = dateutil.parser.parse(response_json["aiod_entry"]["date_created"] + "Z")
     date_modified = dateutil.parser.parse(response_json["aiod_entry"]["date_modified"] + "Z")
-    assert 0 < (date_created - datetime_create_request).total_seconds() < 0.2
-    assert 0 < (date_modified - datetime_update_request).total_seconds() < 0.4
+    assert 0 <= (date_created - datetime_create_request).total_seconds() < 0.2
+    assert 0 <= (date_modified - datetime_update_request).total_seconds() < 0.4
 
     assert response_json["name"] == "new name"
 
@@ -283,8 +283,8 @@ def test_create_aiod_entry(client: TestClient, auto_publish):
     assert "aiod_entry" in resource_json
     date_created = dateutil.parser.parse(resource_json["aiod_entry"]["date_created"] + "Z")
     date_modified = dateutil.parser.parse(resource_json["aiod_entry"]["date_modified"] + "Z")
-    assert start < date_created < end
-    assert start < date_modified < end
+    assert start <= date_created <= end
+    assert start <= date_modified <= end
 
     assert resource_json["ai_resource_identifier"] == identifier
 
@@ -317,8 +317,8 @@ def test_update_aiod_entry(
     assert "aiod_entry" in resource_json
     date_created = dateutil.parser.parse(resource_json["aiod_entry"]["date_created"] + "Z")
     date_modified = dateutil.parser.parse(resource_json["aiod_entry"]["date_modified"] + "Z")
-    assert start < date_created < end
-    assert end < date_modified
+    assert start <= date_created <= end
+    assert end <= date_modified
 
     assert resource_json["aiod_entry"]["editor"] == [person.identifier]
     with DbSession() as session:

--- a/src/tests/testutils/users.py
+++ b/src/tests/testutils/users.py
@@ -59,8 +59,10 @@ def logged_in_user(user: KeycloakUser | None = None):
             "sub": user._subject_identifier,
         }
     )
-    yield
-    keycloak_openid.introspect = original
+    try:
+        yield
+    finally:
+        keycloak_openid.introspect = original
 
 
 def register_asset(asset: AIoDConcept, /, *, owner: KeycloakUser | None = None, status: EntryStatus = EntryStatus.PUBLISHED):


### PR DESCRIPTION
## Change(s)
Change Type: Fixed

Change Category: Internal

Changelog Entry: Fix sporadic test failures

tests were randomly failing (~2 out of 9 runs), found two issues:

- `logged_in_user()` was missing `try/finally` so if a test failed inside the
  `with` block, `keycloak_openid.introspect` never got restored and the mock
  leaked into the next tests (403 instead of 401, mocked requests not firing, etc.)

- some timestamp comparisons used `<` instead of `<=`, on a fast machine the
  timestamps can be equal so the assertion fails

## How to Test
run `pytest src/tests` a few times and check the failures from #688 don't show up

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment.
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one line description.

## Related Issues
Closes #688