### PR TITLE
Show OpenAPI last-modified timestamp in /docs

### DIFF
--- a/src/versioning.py
+++ b/src/versioning.py
@@ -111,6 +111,15 @@ def add_version_to_openapi(versioned_api: FastAPI):
         if versioned_api.openapi_schema:
             return versioned_api.openapi_schema
         schema = versioned_api._openapi()
+        info = schema.setdefault("info", {})
+        last_modified = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        info["x-lastModified"] = last_modified
+        info["description"] = (
+        f'{info.get("description","")}'
+        f'<br/><b>Last modified:</b> {last_modified}'
+)
+        # optional, if you want both fields:
+        info["x-releaseDate"] = info["x-lastModified"]
 
         if root_path:
             schema["servers"] = [{"url": root_path}]


### PR DESCRIPTION
## Changes
Change Type: Added

Change Category: Documentation
Changelog Entry:
Added `info.x-lastModified` (ISO-8601 UTC timestamp) to the generated OpenAPI schema and exposed it in Swagger UI `/docs` by appending it to `info.description`.

## How to Test
1. Run the stack (docker compose).
2. Open http://localhost:8000/openapi.json and verify `info.x-lastModified` exists.
3. Open http://localhost:8000/docs and verify "Last modified: <timestamp>" appears in the API description block.
4. Restart/recreate the `apiserver` container and confirm the timestamp updates.

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained. (Shown in `/docs` UI.)
- [ ] A self-review has been conducted.
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
Closes #572
