### PR TITLE
fix: offload blocking Keycloak introspect to thread pool

### DIFF
--- a/src/authentication.py
+++ b/src/authentication.py
@@ -18,6 +18,7 @@ performs a separate authorization request. The only downside is the overhead of 
 keycloak requests - if that becomes prohibitive in the future, we should reevaluate this design.
 """
 
+import asyncio
 import dataclasses
 import functools
 import logging
@@ -122,7 +123,10 @@ async def _get_user(token) -> KeycloakUser:
         token = token.replace("Bearer ", "")
         # query the authorization server to determine the active state of this token and to
         # determine meta-information.
-        userinfo = keycloak_openid.introspect(token)
+        # NOTE: python-keycloak's introspect() is synchronous (uses requests). Run it in the
+        # thread-pool executor so it does not block the asyncio event loop.
+        loop = asyncio.get_running_loop()
+        userinfo = await loop.run_in_executor(None, keycloak_openid.introspect, token)
         if not userinfo.get("active", False):
             logging.error("Invalid userinfo or inactive user.")
             raise InvalidUserError("Invalid userinfo or inactive user")  # caught below

--- a/src/middleware/access_log.py
+++ b/src/middleware/access_log.py
@@ -1,3 +1,4 @@
+from starlette.background import BackgroundTask
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -5,6 +6,17 @@ from starlette.responses import Response
 from database.session import DbSession
 from database.model.access.access_log import AssetAccessLog
 from middleware.path_parse import parse_asset_from_path
+
+
+def _write_access_log(resource_type: str, asset_id: str, status_code: int) -> None:
+    entry = AssetAccessLog(
+        asset_id=asset_id,
+        resource_type=resource_type,
+        status=status_code,
+    )
+    with DbSession() as sess:
+        sess.add(entry)
+        sess.commit()
 
 
 class AccessLogMiddleware(BaseHTTPMiddleware):
@@ -16,13 +28,8 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
         parsed = parse_asset_from_path(request.url.path)
         if parsed:
             resource_type, asset_id = parsed
-            entry = AssetAccessLog(
-                asset_id=asset_id,
-                resource_type=resource_type,
-                status=response.status_code,
+            response.background = BackgroundTask(
+                _write_access_log, resource_type, asset_id, response.status_code
             )
-            with DbSession() as sess:
-                sess.add(entry)
-                sess.commit()
 
         return response


### PR DESCRIPTION
**Summary**
Fixes a performance issue where blocking I/O was executed inside async code, causing the event loop to stall under load.

**Problem**

* In `src/authentication.py`, `_get_user()` called `keycloak_openid.introspect(token)`, which uses synchronous `requests`, blocking the asyncio event loop.
* In `src/middleware/access_log.py`, a synchronous DB `sess.commit()` ran inside async middleware, blocking request handling.

**Fix**

1. **Offload Keycloak introspection to a thread pool**

```python
loop = asyncio.get_running_loop()
userinfo = await loop.run_in_executor(None, keycloak_openid.introspect, token)
```

2. **Move access log DB write to a background task**

```python
response.background = BackgroundTask(
    _write_access_log, resource_type, asset_id, response.status_code
)
```

**Verification**

* Existing tests pass without modification
* Mocked `introspect()` works correctly with executor
* Concurrent requests no longer block each other
* Access logs are still written correctly
* Load testing shows reduced latency and improved throughput under concurrency
