### PR TITLE
Fix: Deleting an asset doesn't remove its submission

### DIFF
--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -623,6 +623,17 @@ class ResourceRouter(abc.ABC):
                             status_code=status.HTTP_403_FORBIDDEN,
                             detail=f"You do not have permission to delete {self.resource_name_plural}.",
                         )
+                    if resource.aiod_entry.status == EntryStatus.SUBMITTED:
+                        query = select(AssetReview.review_identifier).where(
+                            AssetReview.aiod_entry_identifier == resource.aiod_entry.identifier
+                        )
+                        submission_id = session.scalars(query).first()
+                        msg = "This asset is part of an active review submission"
+                        if submission_id:
+                            msg += f" (submission_id: {submission_id})"
+                        msg += ". Please retract the submission before deleting the asset."
+                        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=msg)
+
                     if (
                         hasattr(self.resource_class, "__deletion_config__")
                         and not self.resource_class.__deletion_config__["soft_delete"]

--- a/src/tests/authorization/test_authorization.py
+++ b/src/tests/authorization/test_authorization.py
@@ -411,7 +411,7 @@ def test_user_needs_only_one_asset_to_retract(client, publication_factory):
 
 
 @pytest.mark.parametrize("status", EntryStatus)
-def test_user_can_always_delete_asset(status: EntryStatus, publication, client):
+def test_user_cannot_delete_submitted_asset(status: EntryStatus, publication, client):
     identifier = register_asset(publication, owner=ALICE, status=status)
 
     with logged_in_user(ALICE):
@@ -419,7 +419,13 @@ def test_user_can_always_delete_asset(status: EntryStatus, publication, client):
             f"/publications/{identifier}",
             headers={"Authorization": "Fake token"},
         )
-        assert response.status_code == HTTPStatus.OK, response.json()
+        if status == EntryStatus.SUBMITTED:
+            assert response.status_code == HTTPStatus.FORBIDDEN, response.json()
+            assert "submission" in response.json()["detail"].lower(), (
+                "Error message should mention the submission."
+            )
+        else:
+            assert response.status_code == HTTPStatus.OK, response.json()
 
 
 def test_user_can_edit_asset_in_draft(publication, client):


### PR DESCRIPTION
<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Fixed #652 

Change Category: Internal

Changelog Entry: Prevent deletion of assets that are currently submitted for review.
Assets that are part of an active review submission can no longer be deleted until the submission is retracted, preserving the integrity of the review process and avoiding orphaned or ambiguous submissions.

<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->
-Create or identify an asset in DRAFT state and submit it for review (status becomes SUBMITTED).
-Attempt to delete the asset while it is under review.
-The request should be rejected with a 403 Forbidden response.
-The error message should instruct the user to retract the submission first and include the submission identifier.
-Retract the submission.
-Attempt to delete the asset again.
-The deletion should now succeed.
-Verify that deleting assets in DRAFT or PUBLISHED state continues to work as before.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
 #652 