### PR TITLE
[MNT] pin Python <3.14 due to pydantic v1 incompatibility with PEP 649

### DIFF
--- a/.github/workflows/pytest-tests.yml
+++ b/.github/workflows/pytest-tests.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +27,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Setup Python virtual environment
       run: |
-        python3.11 -m venv venv
+        python${{ matrix.python-version }} -m venv venv
         source venv/bin/activate
 
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aiod_metadata_catalogue"
 description = "A Metadata Catalogue for AI on Demand "
 version = "2.0.20251113"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 authors = [
     { name = "Adrián Alcolea" },
     { name = "Antonis Ganios" },


### PR DESCRIPTION
## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: Fixed

Change Category: Internal

Changelog Entry: Pin Python version to <3.14 and expand CI test matrix to cover Python 3.11–3.13.

<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->


## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [ ] The PR title matches the changelog entry's one-line description.

## Related Issues
* #682
* #681
