### PR TITLE
fix: Deleting an asset is very slow

### DIFF
--- a/src/database/deletion/triggers.py
+++ b/src/database/deletion/triggers.py
@@ -198,14 +198,13 @@ def create_deletion_trigger_many_to_many(
     )
     return DDL(
         f"""
-        CREATE TRIGGER IF NOT EXISTS delete_{link_name}
-        AFTER DELETE ON {trigger_name}
+        CREATE TRIGGER IF NOT EXISTS delete_orphan_{link_name}
+        AFTER DELETE ON {link_name}
         FOR EACH ROW
         BEGIN
-            DELETE FROM {link_name}
-            WHERE {link_name}.{link_from_identifier} = OLD.{trigger_identifier};
             DELETE FROM {delete_name}
-            WHERE {links_clause};
+            WHERE {delete_name}.{to_delete_identifier} = OLD.{link_to_identifier}
+            AND {links_clause};
         END;
         """  # noqa: S608  # never user input
     )

--- a/src/database/model/helper_functions.py
+++ b/src/database/model/helper_functions.py
@@ -58,6 +58,7 @@ def many_to_many_link_factory(
                         onupdate="CASCADE",
                     ),
                     primary_key=True,
+                    index=True,
                 )
             ),
         ),

--- a/verify_triggers.py
+++ b/verify_triggers.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.append(str(Path.cwd() / "src"))
+
+from database.deletion.triggers import create_deletion_trigger_many_to_many
+from database.model.dataset.dataset import Dataset
+from database.model.ai_resource.keyword import Keyword
+from database.model.helper_functions import many_to_many_link_factory
+
+# Mock many-to-many relationship details
+link_model = many_to_many_link_factory("dataset", "keyword", from_identifier_type=str)
+other_links = ["model_keyword_link", "publication_keyword_link"]
+
+ddl = create_deletion_trigger_many_to_many(
+    trigger=Dataset,
+    link=link_model,
+    to_delete=Keyword,
+    other_links=other_links
+)
+
+print("-" * 20)
+print("Generated DDL:")
+print(ddl.statement)
+print("-" * 20)


### PR DESCRIPTION
Summary
Optimized the performance of resource deletion (e.g., datasets) by refactoring many-to-many orphan deletion triggers and adding missing database indexes.

The Problem
Previously, deleting a resource triggered a full-table scan on all related tables (like keyword, publication, etc.) to check for orphans. This caused significant latency (measured in seconds) that would have become a major bottleneck as the database scaled.

The Solution
1. Targeted Triggers: Moved orphan deletion logic from the main resource tables to the many-to-many link tables. Triggers now only verify the specific items that were just unlinked.
2. Database Indexing: Added index=True to the linked_identifier column in all dynamically generated many-to-many link tables.
3. Efficiency: Reduced the orphan check complexity from O(N) (whole table scan) to O(1) (indexed lookup).