### PR TITLE
[DOC] Fix typo in README description

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # 🇪🇺 AI-on-Demand Metadata Catalogue
 
-The [AI-on-Demand](https://aiod.eu) Metadata Catalogue  provides a unified view of AI assets and resources stored across the AI landscape.
+The [AI-on-Demand](https://aiod.eu) Metadata Catalogue provides a unified view of AI assets and resources stored across the AI landscape.
 It collects metadata from platforms such as [_Hugging Face_](https://huggingface.co), [_OpenML_](https://openml.org), and [_Zenodo_](https://zenodo.org),
 and is connected to European projects like [Bonsapps](https://bonsapps.eu) and [AIDA](https://www.i-aida.org).
 Metadata of datasets, models, papers, news, and more from all of these sources is available through a REST API at [https://api.aiod.eu](https://api.aiod.eu/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # 🇪🇺 AI-on-Demand Metadata Catalogue
 
-The [AI-on-Demand](https://aiod.eu) Metadata Catalogue is part of the provides a unified view of AI assets and resources stored across the AI landscape.
+The [AI-on-Demand](https://aiod.eu) Metadata Catalogue  provides a unified view of AI assets and resources stored across the AI landscape.
 It collects metadata from platforms such as [_Hugging Face_](https://huggingface.co), [_OpenML_](https://openml.org), and [_Zenodo_](https://zenodo.org),
 and is connected to European projects like [Bonsapps](https://bonsapps.eu) and [AIDA](https://www.i-aida.org).
 Metadata of datasets, models, papers, news, and more from all of these sources is available through a REST API at [https://api.aiod.eu](https://api.aiod.eu/).


### PR DESCRIPTION
Change Type: Fixed
Change Category: Documentation
Changelog Entry: Fixed grammatical error in the introductory paragraph of the documentation.
Removed a sentence fragment ("is part of the") in the first paragraph of the README/Index to improve sentence structure and clarity.
How to Test
This is a pure documentation change. No code testing is required. I have verified the rendered Markdown to ensure the sentence flows correctly.
Checklist
[ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. - [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
[x] A self-review has been conducted.
[x] All CI checks pass.
[x] The PR title matches the changelog entry's one-line description.
Related Issues
None (found while reviewing the documentation).
