### PR TITLE
[BUG] Fix es_logstash_setup permission error by explicit container user

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -202,6 +202,7 @@ services:
 
   es_logstash_setup:
     image: aiod_metadata_catalogue
+    user: "0:0"
     container_name:  es_logstash_setup
     environment:
       - MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD


### PR DESCRIPTION
## Change(s)
Change Type: Fixed  
Change Category: Internal  
Changelog Entry: Fix permission failure in `es_logstash_setup` by setting an explicit container user in compose.

## How to Test
1. Start from a clean checkout.
2. Run `docker compose up -d`.
3. Verify `es_logstash_setup` does not fail with permission denied on logstash config generation paths.

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it.
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

Explanation for tests/docs: this is a compose runtime permission fix; no Python logic changed. Reproduction/validation steps are provided above.

## Related Issues
Closes #224
