### PR TITLE
[BUG] Enforce mutual exclusivity for contact person and organisation

### DIFF
--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -465,6 +465,7 @@ class ResourceRouter(abc.ABC):
             resource_create: clz_create,  # type: ignore
             user: KeycloakUser = Depends(get_user_or_raise),
         ):
+            _raise_if_contact_person_and_organisation_are_both_filled(resource_create)
             platform = getattr(resource_create, "platform", None)
             platform_resource_identifier = getattr(
                 resource_create, "platform_resource_identifier", None
@@ -546,6 +547,7 @@ class ResourceRouter(abc.ABC):
             resource_create_instance: clz_create,  # type: ignore
             user: KeycloakUser = Depends(get_user_or_raise),
         ):
+            _raise_if_contact_person_and_organisation_are_both_filled(resource_create_instance)
             self._raise_if_identifier_is_wrong_type(identifier)
             with DbSession() as session:
                 try:
@@ -905,6 +907,16 @@ def _raise_error_on_invalid_schema(possible_schemas, schema):
         raise HTTPException(
             detail=f"Invalid schema {schema}. Expected {' or '.join(possible_schemas)}",
             status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+
+def _raise_if_contact_person_and_organisation_are_both_filled(resource):
+    if not (hasattr(resource, "person") and hasattr(resource, "organisation")):
+        return
+    if getattr(resource, "person", None) is not None and getattr(resource, "organisation", None) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Person and organisation cannot be both filled.",
         )
 
 

--- a/src/routers/resource_router.py
+++ b/src/routers/resource_router.py
@@ -913,7 +913,10 @@ def _raise_error_on_invalid_schema(possible_schemas, schema):
 def _raise_if_contact_person_and_organisation_are_both_filled(resource):
     if not (hasattr(resource, "person") and hasattr(resource, "organisation")):
         return
-    if getattr(resource, "person", None) is not None and getattr(resource, "organisation", None) is not None:
+    if (
+        getattr(resource, "person", None) is not None
+        and getattr(resource, "organisation", None) is not None
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Person and organisation cannot be both filled.",

--- a/src/tests/routers/resource_routers/test_router_contact.py
+++ b/src/tests/routers/resource_routers/test_router_contact.py
@@ -86,13 +86,17 @@ def test_post_duplicate_email(
         assert set(contact["email"]) == {"b@example.com", "c@example.com"}, msg
 
 
-@pytest.mark.skip(reason="https://github.com/aiondemand/AIOD-rest-api/issues/518")
 def test_person_and_organisation_both_specified(client: TestClient):
     headers = {"Authorization": "Fake token"}
-    body = {"person": 1, "organisation": 1}
     with logged_in_user():
-        client.post("/persons", json={"name": "test person"}, headers=headers)
-        client.post("/organisations", json={"name": "test organisation"}, headers=headers)
+        person_res = client.post("/persons", json={"name": "test person"}, headers=headers)
+        organisation_res = client.post(
+            "/organisations", json={"name": "test organisation"}, headers=headers
+        )
+        body = {
+            "person": person_res.json()["identifier"],
+            "organisation": organisation_res.json()["identifier"],
+        }
         response = client.post("/contacts", json=body, headers=headers)
     assert response.status_code == 400, response.json()
     assert response.json()["detail"] == "Person and organisation cannot be both filled."


### PR DESCRIPTION
## Change(s)
Change Type: Fixed  
Change Category: Internal  
Changelog Entry: Add API-level validation to reject Contact payloads that set both `person` and `organisation`.

## How to Test
- `python -m pytest src/tests/routers/resource_routers/test_router_contact.py -k person_and_organisation_both_specified -q`
- `python -m pytest src/tests/routers/resource_routers/test_router_contact.py -q`

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it.
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

Notes:
- Uses application-level enforcement (as discussed in #518) due MariaDB FK/check constraint limitation.
- Re-enables and updates the existing regression test for this scenario.

## Related Issues
Refs #518
