### PR TITLE
[BUG]: fixed docker container setup error

### DIFF
--- a/src/connectors/example/enum.py
+++ b/src/connectors/example/enum.py
@@ -1,0 +1,77 @@
+from typing import Iterator, TypeVar
+
+from sqlmodel import SQLModel
+
+from connectors.abstract.resource_connector_on_start_up import ResourceConnectorOnStartUp
+from connectors.record_error import RecordError
+from connectors.resource_with_relations import ResourceWithRelations
+from database.model.ai_resource.application_area import ApplicationArea
+from database.model.educational_resource.educational_resource_type import (
+    EducationalResourceType,
+)
+from database.model.event.event import EventMode, EventStatus
+from database.model.agent.language import Language
+from database.model.ai_asset.license import License
+from database.model.agent.organisation import OrganisationType
+from database.model.news.news_category import NewsCategory
+from database.model.platform.platform_names import PlatformName
+
+RESOURCE = TypeVar("RESOURCE", bound=SQLModel)
+
+class BaseEnum(ResourceConnectorOnStartUp[RESOURCE]):
+    @property
+    def platform_name(self) -> PlatformName:
+        return PlatformName.example
+
+    def fetch(
+        self, limit: int | None = None
+    ) -> Iterator[RESOURCE | ResourceWithRelations[RESOURCE] | RecordError]:
+        return iter([])
+
+
+class EnumConnectorApplicationArea(BaseEnum):
+    @property
+    def resource_class(self) -> type[ApplicationArea]:
+        return ApplicationArea
+
+
+class EnumConnectorEducationalResourceType(BaseEnum):
+    @property
+    def resource_class(self) -> type[EducationalResourceType]:
+        return EducationalResourceType
+
+
+class EnumConnectorEventMode(BaseEnum):
+    @property
+    def resource_class(self):
+        return EventMode
+
+
+class EnumConnectorEventStatus(BaseEnum):
+    @property
+    def resource_class(self):
+        return EventStatus
+
+
+class EnumConnectorLanguage(BaseEnum):
+    @property
+    def resource_class(self):
+        return Language
+
+
+class EnumConnectorLicense(BaseEnum):
+    @property
+    def resource_class(self):
+        return License
+
+
+class EnumConnectorOrganisationType(BaseEnum):
+    @property
+    def resource_class(self):
+        return OrganisationType
+
+
+class EnumConnectorNewsCategory(BaseEnum):
+    @property
+    def resource_class(self):
+        return NewsCategory

--- a/src/connectors/example/enum.py
+++ b/src/connectors/example/enum.py
@@ -18,6 +18,7 @@ from database.model.platform.platform_names import PlatformName
 
 RESOURCE = TypeVar("RESOURCE", bound=SQLModel)
 
+
 class BaseEnum(ResourceConnectorOnStartUp[RESOURCE]):
     @property
     def platform_name(self) -> PlatformName:

--- a/src/connectors/example/resources/resource/organisations.json
+++ b/src/connectors/example/resources/resource/organisations.json
@@ -47,9 +47,6 @@
           "name": "Name of this file."
       }
     ],
-    "member": [
-      0
-    ],
     "note": [
       {
         "value": "A brief record of points or ideas about this AI resource."

--- a/src/routers/enum_routers/enum_router.py
+++ b/src/routers/enum_routers/enum_router.py
@@ -4,6 +4,7 @@ from typing import Type
 from fastapi import APIRouter
 from sqlmodel import select, Session
 
+from authentication import KeycloakUser
 from database.model.named_relation import NamedRelation
 from database.session import DbSession
 from versioning import Version
@@ -47,8 +48,14 @@ class EnumRouter(abc.ABC):
 
         return get_resources
 
-    def create_resource(self, session: Session, resource_create_instance: str):
+    def create_resource(
+        self,
+        session: Session,
+        resource_create_instance: str,
+        user: KeycloakUser | None = None,
+    ):
         # Used by synchronization.py: router.create_resource
+        # user parameter is ignored for enum/taxonomy types
         resource = self.resource_class(name=resource_create_instance)
         session.add(resource)
         session.commit()


### PR DESCRIPTION
Fixed #712 

added `src\connectors\example\enum.py` which was previously missing. all 8  enums added with a `BaseEnum` (reference from: src\connectors\example\example_connector.py)

now running `docker compose up fill-db-with-examples` results:

```sh
(venv) C:\Users\ASUS\Documents\work\opensource\AIOD-rest-api>docker compose up fill-db-with-examples
[+] Running 2/2
 ✔ Container sqlserver  Running                                                              0.0s 
 ✔ Container apiserver  Running                                                              0.0s 
Attaching to fill-db-with-examples
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:13.721 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:13.721 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:13.721 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:13.721 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:13.721 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:14.116 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:14.119 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:15.485 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:15.485 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:15.486 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:15.486 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:15.486 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:15.886 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:15.890 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:17.328 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:17.328 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:17.328 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:17.328 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:17.328 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:17.701 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:17.704 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:19.046 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:19.046 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:19.046 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:19.046 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:19.046 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:19.430 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:19.434 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:20.772 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:20.772 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:20.772 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:20.772 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:20.773 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:21.228 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:21.231 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:22.572 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:22.572 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:22.572 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:22.572 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:22.572 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:22.948 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:22.951 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:24.301 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:24.301 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:24.301 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:24.301 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:24.301 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:24.677 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:24.680 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:26.010 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:26.010 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:26.010 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:26.010 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:26.010 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:26.393 ERROR synchronization - main: Error on identifier None
fill-db-with-examples  | Traceback (most recent call last):
fill-db-with-examples  |   File "/app/connectors/synchronization.py", line 108, in save_to_database                                                                                                 
fill-db-with-examples  |     resource = router.create_resource(session, resource_create_instance, user)                                                                                             
fill-db-with-examples  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                             
fill-db-with-examples  |   File "/app/routers/resource_router.py", line 522, in create_resource
fill-db-with-examples  |     deserialize_resource_relationships(                                  
fill-db-with-examples  |   File "/app/database/model/serializers.py", line 327, in deserialize_resource_relationships                                                                               
fill-db-with-examples  |     new_value = relationship.deserializer.deserialize(session, new_value, user)                                                                                            
fill-db-with-examples  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                            
fill-db-with-examples  |   File "/app/database/model/serializers.py", line 132, in deserialize
fill-db-with-examples  |     existing = FindByIdentifierDeserializer.deserialize_ids(self.clazz, session, input_)                                                                                   
fill-db-with-examples  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   
fill-db-with-examples  |   File "/app/database/model/serializers.py", line 109, in deserialize_ids
fill-db-with-examples  |     raise HTTPException(                                                 
fill-db-with-examples  | fastapi.exceptions.HTTPException: 404: Could not find AgentTable with identifiers 0.                                                                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:26.400 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:27.715 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:27.715 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:27.715 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:27.715 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:27.715 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:28.070 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:28.075 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:29.469 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:29.469 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:29.469 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:29.469 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:29.469 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:29.840 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:29.844 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:31.180 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:31.180 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:31.180 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:31.180 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:31.180 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:31.555 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:31.558 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:32.909 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:32.909 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:32.909 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:32.909 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:32.910 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:33.266 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:33.270 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:34.671 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:34.671 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:34.671 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:34.671 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:34.671 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:35.187 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:35.193 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:36.552 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:36.552 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:36.552 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:36.552 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:36.552 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:36.927 WARNING resource_connector_on_start_up - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:36.931 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:38.279 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:38.279 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:38.279 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:38.279 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:38.279 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:38.639 WARNING enum - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:38.643 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:40.007 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:40.007 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:40.007 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:40.007 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:40.007 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:40.391 WARNING enum - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:40.395 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:41.771 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:41.771 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:41.771 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:41.771 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:41.771 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:42.142 WARNING enum - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:42.145 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:43.471 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:43.471 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:43.471 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:43.471 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:43.471 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:43.826 WARNING enum - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:43.830 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:45.223 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:45.223 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:45.223 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:45.223 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:45.223 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:45.602 WARNING enum - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:45.606 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:46.943 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:46.943 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:46.943 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:46.943 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:46.943 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:47.307 WARNING enum - run: This connector has run before. Exiting.
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:47.313 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:48.644 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:48.644 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:48.644 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:48.644 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:48.644 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:49.022 INFO synchronization - main: Done
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__tablename__"
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | /app/database/model/named_relation.py:65: RuntimeWarning: fields may not start with an underscore, ignoring "__plural__"                                                   
fill-db-with-examples  |   clazz = create_model(
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:50.353 INFO config - log_configuration: REVIEWER_ROLE_NAME=None
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:50.353 INFO config - log_configuration: ADMIN_ROLE_NAME=None                                                                                
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:50.353 INFO config - log_configuration: Loaded default configuration from /app/config.default.toml                                          
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:50.353 INFO config - log_configuration: Loaded configuration overrides from /app/config.override.toml                                       
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:50.353 INFO config - log_configuration: Starting with merged configuration: {'domain': 'https://api.aiod.eu/', 'configuration': {'versions': 'versions.toml'}, 'database': {'host': 'sqlserver', 'port': 3306, 'database': 'aiod', 'username': 'root', 'password': '****', 'build_database': 'if-absent'}, 'dev': {'reload': False, 'request_timeout': 10, 'log_level': 'INFO', 'disable_reviews': False, 'url_prefix': '', 'taxonomy': ''}, 'keycloak': {'server_url': 'http://keycloak:8080/aiod-auth/', 'realm': 'aiod', 'client_id': 'aiod-api', 'client_id_swagger': 'aiod-api-swagger', 'openid_connect_url': 'http://localhost/aiod-auth/realms/aiod/.well-known/openid-configuration', 'scopes': 'openid profile roles'}}
fill-db-with-examples  | v2.0.20251113 2026-03-03 21:43:50.713 INFO synchronization - main: Done
fill-db-with-examples exited with code 0
```



## How to Test
run these setup commands for the repo:
```sh
docker compose build app
docker compose build deletion

docker compose build

docker compose up fill-db-with-examples
```

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [ ] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
