### PR TITLE
Add sort_by_date_modified parameter to all search endpoints

### DIFF
--- a/src/routers/search_router.py
+++ b/src/routers/search_router.py
@@ -142,7 +142,14 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
                 bool,
                 Query(
                     description="If true, the results are sorted by id."
-                    "By default they are sorted by best score.",
+                    " By default they are sorted by best score.",
+                ),
+            ] = False,
+            sort_by_date_modified: Annotated[
+                bool,
+                Query(
+                    description="If true, the results are sorted by date_modified (newest first)."
+                    " By default they are sorted by best score.",
                 ),
             ] = False,
             limit: Annotated[int, Query(ge=1, le=LIMIT_MAX)] = 10,
@@ -196,6 +203,8 @@ class SearchRouter(Generic[RESOURCE], abc.ABC):
             sort: dict[str, str | dict[str, str]] = {}
             if sort_by_id:
                 sort = {"identifier": "asc"}
+            elif sort_by_date_modified:
+                sort = {"date_modified": "desc"}
             else:
                 sort = {"_score": {"order": "desc"}}
 

--- a/src/tests/routers/search_routers/test_search_routers.py
+++ b/src/tests/routers/search_routers/test_search_routers.py
@@ -1,6 +1,5 @@
 import json
 from http import HTTPStatus
-from typing import Sequence
 from unittest.mock import Mock
 
 import pytest
@@ -44,7 +43,7 @@ def test_search_happy_path_get_all(client: TestClient, mocked_privileged_token: 
 
     response = client.post("/events", json=body, headers={"Authorization": "Fake token"})
     response.raise_for_status()
-    identifier = response.json()['identifier']
+    identifier = response.json()["identifier"]
     mock_elasticsearch(filename_mock="event_search.json", identifier=identifier)
 
     search_service = "/search/events"
@@ -143,6 +142,19 @@ def test_search_bad_offset(client: TestClient, search_router):
             "type": "value_error.number.not_ge",
         }
     ]
+
+
+@pytest.mark.parametrize("search_router", sr.router_list)
+def test_search_sort_by_date_modified(client: TestClient, search_router):
+    mock_elasticsearch(filename_mock=f"{search_router.es_index}_search.json")
+
+    search_service = f"/search/{search_router.resource_name_plural}"
+    params = {"search_query": "description", "sort_by_date_modified": True}
+    response = client.get(search_service, params=params)
+
+    assert response.status_code == 200, response.json()
+    _, kwargs = ElasticsearchSingleton().client.search.call_args
+    assert kwargs["sort"] == {"date_modified": "desc"}
 
 
 def mock_elasticsearch(filename_mock: str, identifier: str = ""):


### PR DESCRIPTION
<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
**Change Type:** Added 

**Change Category**: Interface 

**Changelog Entry:** Added `sort_by_date_modified` boolean parameter to all search endpoints. 
When set to `true`, results are sorted by `date modified` descending ( newest first ). By default, results are sorted based on relevance score.


<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->


## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Closes #521 