### PR TITLE
Fix: Added 'training_status' property to MLModel(#491)

### DIFF
--- a/src/database/model/models_and_experiments/ml_model.py
+++ b/src/database/model/models_and_experiments/ml_model.py
@@ -26,6 +26,12 @@ class MLModelBase(AIAssetBase):
         schema_extra={"example": "https://doi.org/10.1000/182"},
     )
 
+    training_status: str | None = Field(
+            description="The current training status of the machine learning model.",
+            max_length=SHORT,
+            default=None,
+            schema_extra={"example": "trained"},
+        )
 
 class MLModel(MLModelBase, AIAsset, table=True):  # type: ignore [call-arg]
     __tablename__ = "ml_model"


### PR DESCRIPTION
## Change(s)
Added a 'training_status' property to MLModel.
Change Type: Added

Change Category: Interface

Changelog Entry: 
Added the missing `training_status` property to the `MLModel` schema.

This ensures the API implementation is fully aligned with the latest conceptual model export.

## How to Test
You can verify this change by running the schema comparison script against the latest model export:
`python3 scripts/model_comparison/compare.py src scripts/model_comparison/model-export.json --class "MLModel"`
(This now correctly outputs zero differences).

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. *(Absence explained: Verified via the existing `compare.py` schema validation).*
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained. *(Absence explained: No manual documentation changes required; schema sync only).*
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it.
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [x] The PR title matches the changelog entry's one-line description.

## Related Issues
Closes #491