### PR TITLE
Fix: enforce Content-Type header via middleware with tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -46,6 +46,7 @@ from routers import (
 )
 from prometheus_fastapi_instrumentator import Instrumentator
 from middleware.access_log import AccessLogMiddleware
+from middleware.json_content_type import JsonContentTypeMiddleware
 from routers.access_stats_router import create as create_access_stats_router
 from versioning import (
     versions,
@@ -182,6 +183,7 @@ def build_app(*, url_prefix: str = "", version: str = "dev"):
     )
     # Since all traffic goes through the main app, this middleware only
     # needs to be registered with the main app and not the mounted apps.
+    main_app.add_middleware(JsonContentTypeMiddleware)
     main_app.add_middleware(AccessLogMiddleware)
 
     for app, _ in versioned_apps:

--- a/src/middleware/json_content_type.py
+++ b/src/middleware/json_content_type.py
@@ -1,0 +1,52 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+
+class JsonContentTypeMiddleware(BaseHTTPMiddleware):
+    """Enforce JSON Content-Type for write requests with request bodies."""
+
+    _METHODS_TO_VALIDATE = {"POST", "PUT", "PATCH"}
+
+    @staticmethod
+    def _is_docs_path(path: str) -> bool:
+        return any(
+            path.startswith(p) or path.endswith(p)
+            for p in ("/docs", "/redoc", "/openapi.json")
+        )
+
+    @staticmethod
+    def _is_multipart_image_upload(path: str) -> bool:
+        segments = [segment for segment in path.strip("/").split("/") if segment]
+        return len(segments) >= 3 and segments[-3] == "organisations" and segments[-1] == "image"
+
+    @staticmethod
+    def _has_request_body(request: Request) -> bool:
+        content_length = request.headers.get("content-length")
+        if content_length is not None:
+            try:
+                return int(content_length) > 0
+            except ValueError:
+                return True
+        return "transfer-encoding" in request.headers
+
+    async def dispatch(self, request: Request, call_next):
+        if request.method not in self._METHODS_TO_VALIDATE:
+            return await call_next(request)
+
+        path = request.url.path
+        if self._is_docs_path(path) or self._is_multipart_image_upload(path):
+            return await call_next(request)
+
+        if not self._has_request_body(request):
+            return await call_next(request)
+
+        content_type = request.headers.get("content-type", "")
+        if not content_type.lower().startswith("application/json"):
+            return JSONResponse(
+                status_code=415,
+                content={"detail": "Content-Type must include 'application/json'."},
+            )
+
+        response: Response = await call_next(request)
+        return response

--- a/src/tests/middleware/test_json_content_type_middleware.py
+++ b/src/tests/middleware/test_json_content_type_middleware.py
@@ -1,0 +1,125 @@
+from fastapi import FastAPI, File, UploadFile
+from fastapi.testclient import TestClient
+
+from middleware.json_content_type import JsonContentTypeMiddleware
+
+import sys
+import os
+sys.path.append(os.path.abspath("src"))
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(JsonContentTypeMiddleware)
+
+    @app.post("/json")
+    async def post_json(payload: dict):
+        return payload
+
+    @app.put("/json")
+    async def put_json(payload: dict):
+        return payload
+
+    @app.patch("/json")
+    async def patch_json(payload: dict):
+        return payload
+
+    @app.post("/query-only")
+    async def query_only(value: str):
+        return {"value": value}
+
+    @app.post("/organisations/{identifier}/image")
+    async def upload_image(identifier: str, file: UploadFile = File(...)):
+        return {"identifier": identifier, "filename": file.filename}
+
+    return app
+
+
+def test_post_with_json_content_type_passes():
+    client = TestClient(_build_app())
+    response = client.post("/json", json={"x": 1})
+    assert response.status_code == 200
+    assert response.json() == {"x": 1}
+
+
+def test_put_with_invalid_content_type_returns_415():
+    client = TestClient(_build_app())
+    response = client.put(
+        "/json",
+        data='{"x": 1}',
+        headers={"Content-Type": "text/plain"},
+    )
+    assert response.status_code == 415
+    assert "application/json" in response.json()["detail"]
+
+
+def test_patch_without_content_type_returns_415_when_body_present():
+    client = TestClient(_build_app())
+    response = client.patch("/json", content=b'{"x": 1}')
+    assert response.status_code == 415
+    assert "application/json" in response.json()["detail"]
+
+
+def test_post_without_body_does_not_require_json_content_type():
+    client = TestClient(_build_app())
+    response = client.post("/query-only", params={"value": "ok"})
+    assert response.status_code == 200
+    assert response.json() == {"value": "ok"}
+
+
+def test_docs_endpoints_are_not_blocked():
+    client = TestClient(_build_app())
+    assert client.get("/docs").status_code == 200
+    assert client.get("/openapi.json").status_code == 200
+    assert client.get("/redoc").status_code == 200
+
+
+def test_multipart_upload_endpoint_is_not_blocked():
+    client = TestClient(_build_app())
+    files = {"file": ("logo.png", b"image-bytes", "image/png")}
+    response = client.post("/organisations/org_foo/image", files=files)
+    assert response.status_code == 200
+    assert response.json()["filename"] == "logo.png"
+
+
+def test_json_with_charset_header_passes():
+    client = TestClient(_build_app())
+    response = client.post(
+        "/json",
+        data='{"x": 1}',
+        headers={"Content-Type": "application/json; charset=utf-8"},
+    )
+    assert response.status_code == 200
+
+
+def test_content_type_case_insensitive():
+    client = TestClient(_build_app())
+    response = client.post(
+        "/json",
+        data='{"x": 1}',
+        headers={"Content-Type": "Application/JSON"},
+    )
+    assert response.status_code == 200
+
+
+def test_invalid_json_like_content_type_rejected():
+    client = TestClient(_build_app())
+    response = client.post(
+        "/json",
+        data='{"x": 1}',
+        headers={"Content-Type": "text/application-json"},
+    )
+    assert response.status_code == 415
+
+
+
+if __name__ == "__main__":
+    test_post_with_json_content_type_passes()
+    test_put_with_invalid_content_type_returns_415()
+    test_patch_without_content_type_returns_415_when_body_present()
+    test_post_without_body_does_not_require_json_content_type()
+    test_docs_endpoints_are_not_blocked()
+    test_multipart_upload_endpoint_is_not_blocked()
+    test_json_with_charset_header_passes()
+    test_content_type_case_insensitive()
+    test_invalid_json_like_content_type_rejected()
+    print("All tests passed!")


### PR DESCRIPTION
## Change(s)

Change Type: Fixed

Change Category: Internal

Changelog Entry:
Fix silent failure when 'Content-Type' header is missing for JSON requests.

Added a global middleware that validates the 'Content-Type' header for POST, PUT, and PATCH requests with a request body. If the header is missing or does not include 'application/json', the API now returns a '415 Unsupported Media Type' response instead of silently accepting the request.

The implementation ensures compatibility by:
- Skipping validation for documentation endpoints ('/docs', '/openapi.json', '/redoc')
- Allowing multipart/form-data endpoints (e.g. organisation image uploads)
- Only enforcing validation when a request body is present


## How to Test

- Send a POST/PUT/PATCH request with a JSON body but without the 'Content-Type: application/json' header → should return '415'
- Send the same request with a valid 'Content-Type' → should succeed
- Verify that:
  - '/docs', '/openapi.json', '/redoc' still work
  - Multipart upload endpoint ('/organisations/{identifier}/image') is not blocked

Automated tests have been added to cover these scenarios.


## Checklist
- [x] Tests have been added or updated to reflect the changes
- [ ] Documentation has been added or updated to reflect the changes (not required for this change)
- [x] A self-review has been conducted
- [ ] All CI checks pass before pinging a reviewer (will monitor CI after submission)
- [x] The PR title matches the changelog entry's one-line description


## Related Issues

Closes #622 