### PR TITLE
Align Project model with metadata schema (remove funder)

### DIFF
--- a/src/database/model/project/project.py
+++ b/src/database/model/project/project.py
@@ -63,15 +63,6 @@ class Project(ProjectBase, AIResource, table=True):  # type: ignore [call-arg]
     __abbreviation__ = "proj"
     __plural__ = "projects"
 
-    funder: list[Organisation] = Relationship(
-        link_model=many_to_many_link_factory(
-            "project",
-            Organisation.__tablename__,
-            table_prefix="funder",
-            from_identifier_type=str,
-            to_identifier_type=str,
-        ),
-    )
     participant: list[Organisation] = Relationship(
         link_model=many_to_many_link_factory(
             "project",
@@ -105,14 +96,6 @@ class Project(ProjectBase, AIResource, table=True):  # type: ignore [call-arg]
     )
 
     class RelationshipConfig(AIResource.RelationshipConfig):
-        funder: list[str] = ManyToMany(
-            description="Identifiers of organizations that support this project through some kind "
-            "of financial contribution. ",
-            _serializer=AttributeSerializer("identifier"),
-            deserializer=FindByIdentifierDeserializerList(Organisation),
-            default_factory_pydantic=list,
-            example=[],
-        )
         participant: list[str] = ManyToMany(
             description="Identifiers of members of this project. ",
             _serializer=AttributeSerializer("identifier"),

--- a/src/tests/routers/resource_routers/test_router_project.py
+++ b/src/tests/routers/resource_routers/test_router_project.py
@@ -35,7 +35,6 @@ def test_happy_path(
     body["start_date"] = "2021-02-02T15:15:00"
     body["end_date"] = "2021-02-03T15:15:00"
     body["total_cost_euros"] = 10000000.53
-    body["funder"] = [organisation.identifier]
     body["participant"] = [organisation.identifier]
     body["coordinator"] = organisation.identifier
     body["produced"] = [dataset.identifier]
@@ -56,7 +55,6 @@ def test_happy_path(
     assert response_json["start_date"] == "2021-02-02T15:15:00"
     assert response_json["end_date"] == "2021-02-03T15:15:00"
     assert response_json["total_cost_euros"] == 10000000.53
-    assert response_json["funder"] == [organisation.identifier]
     assert response_json["participant"] == [organisation.identifier]
     assert response_json["coordinator"] == organisation.identifier
     assert response_json["produced"] == [dataset.identifier]
@@ -65,7 +63,6 @@ def test_happy_path(
     assert response_json["subtitle"] == subtitle
 
     # Cleanup, so that all resources can be deleted in the teardown
-    body["funder"] = []
     body["participant"] = []
     body["coordinator"] = None
     body["produced"] = []


### PR DESCRIPTION
## Change(s)

Change Type: Removed / Updated  
Change Category: Internal  

Changelog Entry:  
Align the `Project` model with the metadata schema.

- Removed the 'funder' field from the 'Project' model and its 'RelationshipConfig', as it is not part of the metadata schema.
- Ensured consistent use of 'total_cost_euros' (instead of deprecated 'total_cost_euro').
- Updated project router tests to reflect the removal of the 'funder' field.

---

## How to Test

1. Navigate to the 'src' directory

2. Run project-specific tests:
pytest -q tests/routers/resource_routers/test_router_project.py

3. (Optional) Run broader router tests:
pytest -q tests/routers/resource_routers

All tests should pass successfully.

---

## Checklist

- [x] Tests have been added or updated to reflect the changes  
- [x] Documentation has not been updated (not required for this change)  
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed  
  - The changes in isolation seem reasonable  
- [x] All CI checks pass (or locally verified)  
- [x] The PR title matches the changelog entry's one-line description  

---

## Related Issues

Closes #492 