### PR TITLE
Fix REST API URL in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 The [AI-on-Demand](https://aiod.eu) Metadata Catalogue is part of the provides a unified view of AI assets and resources stored across the AI landscape.
 It collects metadata from platforms such as [_Hugging Face_](https://huggingface.co), [_OpenML_](https://openml.org), and [_Zenodo_](https://zenodo.org),
 and is connected to European projects like [Bonsapps](https://bonsapps.eu) and [AIDA](https://www.i-aida.org).
-Metadata of datasets, models, papers, news, and more from all of these sources is available through a REST API at [https://api.aiod.eu](https://api.aiod.eu/).
+Metadata of datasets, models, papers, news, and more from all of these sources is available through a REST API at [https://api.aiodp.eu](https://api.aiodp.eu/).
 
 **🧑‍🔬 For most users:**
 Many users will only use the REST API indirectly, for example;


### PR DESCRIPTION
Updated the REST API URL from 'api.aiod.eu' to 'api.aiodp.eu'.