### PR TITLE
[BUG] Silently reject empty enum values instead of storing them (#292)

### DIFF
--- a/src/database/model/serializers.py
+++ b/src/database/model/serializers.py
@@ -200,6 +200,9 @@ class FindByNameDeserializer(DeSerializer[NamedRelation]):
             raise ValueError(
                 "Expected a single value. Do you need to use FindByNameDeserializerList instead?"
             )
+        if not name.strip():
+            # Silently reject empty values instead of storing them as a term.
+            return None
         name = name.lower()
         query = select(self.clazz).where(self.clazz.name == name)
         item = session.scalars(query).first()
@@ -232,7 +235,8 @@ class FindByNameDeserializerList(DeSerializer[NamedRelation]):
             return []
         if not isinstance(name, list):
             raise ValueError("Expected a list. Do you need to use FindByNameDeserializer instead?")
-        names = {n if self.case_sensitive else n.casefold() for n in name}
+        # Empty values are silently rejected instead of being stored as a term.
+        names = {n if self.case_sensitive else n.casefold() for n in name if n.strip()}
         query = select(self.clazz).where(self.clazz.name.in_(names))  # type: ignore[attr-defined]
         existing = list(session.scalars(query).all())
         if self.case_sensitive:

--- a/src/tests/routers/generic/test_router_relations.py
+++ b/src/tests/routers/generic/test_router_relations.py
@@ -227,6 +227,26 @@ def test_post_happy_path(client_with_testobject: TestClient, auto_publish: None)
     assert related_objects[1]["field2"] == "val2.2"
 
 
+def test_post_empty_enum_values_are_rejected(
+    client_with_testobject: TestClient, auto_publish: None
+):
+    with logged_in_user():
+        response = client_with_testobject.post(
+            "/test_resources",
+            json={
+                "title": "title",
+                "named_string": "",
+                "named_string_list": ["", "1", "  ", ""],
+                "related_objects": [],
+            },
+            headers={"Authorization": "Fake token"},
+        )
+    assert response.status_code == 200, response.json()
+    obj = client_with_testobject.get("/test_resources?direction=asc").json()[-1]
+    assert "named_string" not in obj
+    assert obj["named_string_list"] == ["1"]
+
+
 def test_put_happy_path(test_objects: list[TestObject], client_with_testobject: TestClient, auto_publish: None):
     identifier = test_objects[3].identifier
     with logged_in_user(kc_user_with_roles("update_test_resources")):


### PR DESCRIPTION
<!--
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change(s)
<!-- Briefly describe the change of this PR, if there are multiple changes, please describe them separately. -->
Change Type: <!-- Added/Changed/Deprecated/Removed/Fixed/Security -->

Change Category: <!-- Documentation/Interface/Internal/Other -->

Changelog Entry: <!-- Brief description of the change, possibly followed by more details in a separate paragraph. For example: -->

<!--
Added the `contacts` field to the `AIResource` `GET` endpoints with full contact information.

This field contains the full contact information of the contacts whose identifiers are currently already provided through the `contact` field.
-->



## How to Test
<!-- Describe a way to test the change of this PR if it requires special steps beyond CI/CD. You're writing this for the reviewer. -->

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained. <!-- For code changes -->
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
- [ ] The PR title matches the changelog entry's one-line description.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
